### PR TITLE
Ctx should be mutable in the new method of VDPs and VFPs

### DIFF
--- a/examples/vmod_vdp/src/lib.rs
+++ b/examples/vmod_vdp/src/lib.rs
@@ -22,7 +22,7 @@ impl VDP for Flipper {
 
     // `new` is called when the VCL specifies "flipper" in `resp.filters`
     // just return an default struct, thanks to the derive macro
-    fn new(_: &Ctx, _: &mut VDPCtx, _oc: *mut varnish_sys::objcore) -> InitResult<Self> {
+    fn new(_: &mut Ctx, _: &mut VDPCtx, _oc: *mut varnish_sys::objcore) -> InitResult<Self> {
         InitResult::Ok(Default::default())
     }
 

--- a/examples/vmod_vfp/src/lib.rs
+++ b/examples/vmod_vfp/src/lib.rs
@@ -17,7 +17,7 @@ impl VFP for Lower {
         "lower\0"
     }
 
-    fn new(_: &Ctx, _: &mut VFPCtx) -> InitResult<Self> {
+    fn new(_: &mut Ctx, _: &mut VFPCtx) -> InitResult<Self> {
         InitResult::Ok(Lower {})
     }
 


### PR DESCRIPTION
This resolves issue #15

It changes the mutability of Ctx in the new method in both the VDP/VFP interfaces to allow modifications of things such as headers.
