### PR TITLE
use c-consts `c"..."` instead of the `b"...\\0"`

### DIFF
--- a/src/vcl/backend.rs
+++ b/src/vcl/backend.rs
@@ -146,7 +146,7 @@ impl<S: Serve<T>, T: Transfer> Backend<S, T> {
                 ctx.raw,
                 &*methods,
                 &mut *inner as *mut S as *mut std::ffi::c_void,
-                "%s\0".as_ptr() as *const c_char,
+                c"%s".as_ptr(),
                 cstring_name.as_ptr() as *const c_char,
             )
         };

--- a/src/vcl/convert.rs
+++ b/src/vcl/convert.rs
@@ -388,7 +388,7 @@ impl VCLDefault for () {
     fn vcl_default() -> Self::Item {}
 }
 
-const EMPTY_STRING: *const c_char = b"\0".as_ptr() as *const c_char;
+const EMPTY_STRING: *const c_char = c"".as_ptr();
 
 /// Convert a VCL type into a Rust one.
 ///

--- a/src/vcl/ctx.rs
+++ b/src/vcl/ctx.rs
@@ -106,7 +106,7 @@ impl<'a> Ctx<'a> {
         // not great, we have to copy the string to add a null character
         let c_cstring = CString::new(msg).unwrap();
         unsafe {
-            VRT_fail(self.raw, "%s\0".as_ptr() as *const c_char, c_cstring.as_ptr());
+            VRT_fail(self.raw, c"%s".as_ptr(), c_cstring.as_ptr());
         }
         0
     }
@@ -248,6 +248,6 @@ impl Event {
 pub fn log(logtag: LogTag, msg: &str) {
     unsafe {
         let c_cstring = CString::new(msg).unwrap();
-        varnish_sys::VSL(logtag.into_u32(), varnish_sys::vxids { vxid: 0 }, b"%s\0".as_ptr() as *const c_char, c_cstring.as_ptr() as *const u8);
+        varnish_sys::VSL(logtag.into_u32(), varnish_sys::vxids { vxid: 0 }, c"%s".as_ptr(), c_cstring.as_ptr() as *const u8);
     }
 }

--- a/src/vmodtool-rs.py
+++ b/src/vmodtool-rs.py
@@ -234,9 +234,9 @@ unsafe impl Sync for vmod_data {{}}
 pub static Vmod_{name}_Data: vmod_data = vmod_data {{
 	vrt_major: {major},
 	vrt_minor: {minor},
-	file_id: "{file_id}\\0".as_ptr() as *const c_char,
-	name: "{name}\\0".as_ptr() as *const c_char,
-	func_name: "{csn}\\0".as_ptr() as *const c_char,
+	file_id: c"{file_id}".as_ptr(),
+	name: c"{name}".as_ptr(),
+	func_name: c"{csn}".as_ptr(),
 	func_len: ::std::mem::size_of::<{csn}>() as c_int,
 	func: &{csn} as *const _ as *const c_void,
 	abi: varnish::vcl::boilerplate::VMOD_ABI_Version.as_ptr() as *const c_char,
@@ -245,7 +245,7 @@ pub static Vmod_{name}_Data: vmod_data = vmod_data {{
 }};
 
 const JSON: *const c_char =
-    b"VMOD_JSON_SPEC\x02\\n{json}\\n\x03\\0".as_ptr() as *const c_char;
+    c"VMOD_JSON_SPEC\x02\\n{json}\\n\x03".as_ptr();
 """.format(
         file_id = v.file_id,
         name = v.modname,


### PR DESCRIPTION
See https://rust-lang.github.io/rust-clippy/master/index.html#/manual_c_str_literals