### PR TITLE
Improve github action workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,10 +26,8 @@ jobs:
           sudo apt-get install -y varnish-dev
       - name: test-fmt
         run: cargo fmt --all -- --check
-      - name: check
-        run: RUSTFLAGS='-D warnings' cargo check --workspace --all-targets
-      - name: build vmod
-        run: cargo build --all-targets
+      - name: build
+        run: RUSTFLAGS='-D warnings' cargo build --workspace --all-targets
       - name: test
         run: cargo test --workspace --all-targets
       - name: test-doc

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,36 +1,50 @@
 name: Build
-on: [push]
-jobs:
-  no-libvarnish:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - run: |
-          cargo doc
-  with-libvarnish:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - run: |
-          set -x
-          sudo apt-get install -y curl
-          curl -s https://packagecloud.io/install/repositories/varnishcache/varnish75/script.deb.sh | sudo bash
-          sudo apt-get install varnish-dev
-      - run: |
-          set -x
-          cargo doc
-          export RUST_BACKTRACE=1
-          for dir in vmod_test $(ls -d examples/vmod_*); do
-            (
-              cd $dir
-              cargo build --all-targets
-              cargo test
-            )
-          done
 
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      RUST_BACKTRACE: 1
+    steps:
+      - uses: actions/checkout@v4
+      - name: rust-info
+        run: rustc --version && cargo --version
+      - uses: Swatinem/rust-cache@v2
+        if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
+      - name: install varnish-dev
+        run: |
+          curl -s https://packagecloud.io/install/repositories/varnishcache/varnish75/script.deb.sh | sudo bash
+          sudo apt-get install -y varnish-dev
+      - name: test-fmt
+        run: cargo fmt --all -- --check
+      - name: check
+        run: RUSTFLAGS='-D warnings' cargo check --workspace --all-targets
+      - name: build vmod
+        run: cargo build --all-targets
+      - name: test
+        run: cargo test --workspace --all-targets
+      - name: test-doc
+        run: |
+          cargo test --doc
+          RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
+
+  # Ensure that the docs can be built at docs.rs without varnish dependencies
+  test-docs-rs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: rust-info
+        run: rustc --version && cargo --version
+      - uses: Swatinem/rust-cache@v2
+        if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
+      - name: Ensure docs can be built at docs.rs without varnish dependencies
+        run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,5 +54,4 @@ pkg-config = "0.3.22"
 serde = { version = "1", features = ["derive"] }
 
 [workspace]
-
-members = ["examples/vmod_*", "vmod_test"]
+members = ["varnish-sys", "vmod_test", "examples/vmod_*"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-[![crates.io](https://img.shields.io/crates/v/varnish.svg)](https://crates.io/crates/varnish)
-[![tests](https://github.com/gquintard/varnish-rs/actions/workflows/tests.yaml/badge.svg)](https://github.com/gquintard/varnish-rs/actions)
-[![docs.rs](https://img.shields.io/badge/docs.rs-v0.0.8-brightgreen)](https://docs.rs/varnish/latest/varnish/)
+[![GitHub](https://img.shields.io/badge/github-varnish-8da0cb?logo=github)](https://github.com/gquintard/varnish-rs)
+[![crates.io version](https://img.shields.io/crates/v/varnish.svg)](https://crates.io/crates/varnish)
+[![docs.rs docs](https://docs.rs/varnish/badge.svg)](https://docs.rs/varnish)
+[![crates.io version](https://img.shields.io/crates/l/varnish.svg)](https://github.com/gquintard/varnish-rs/blob/main/LICENSE)
+[![CI build](https://github.com/gquintard/varnish-rs/actions/workflows/tests.yaml/badge.svg)](https://github.com/gquintard/varnish-rs/actions)
 
 [Documentation](https://docs.rs/varnish/)
 
@@ -10,6 +12,7 @@ In your `Cargo.toml`:
 [dependencies]
 varnish = "0.0.16"
 ```
+
 # varnish-rs
 
 Varnish bindings, notably to build vmods, such as:


### PR DESCRIPTION
P.S. Note that CI currently fails - not certain why yet

I copied some of these from many of my crates like https://github.com/nyurik/sqlite-hashes (eventually I think it is better to use `just` to simplify the process, and make it identical for the developer and CI)

* removed the `no-libvarnish` job -- not used
* remove rust installation - it is always pre-installed unless you want an older version, e.g. for msrv test
* use build cache
* add all sorts of tests
* no need to do a loop over vmod - enough to just say `cargo ... --workspace`
* not much value in `RUST_BACKTRACE=1` I think - if it fails, longer backtrace won't tell you much in CI
* add doc testing