### PR TITLE
A few small lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+lints.workspace = true
+
 [package]
 name = "varnish"
 version = "0.0.19"
@@ -9,7 +11,42 @@ homepage = "https://github.com/gquintard/varnish-rs"
 repository = "https://github.com/gquintard/varnish-rs"
 readme = "README.md"
 keywords = ["varnish", "vmod", "cache", "http", "reverse-proxy"]
-categories = [ "api-bindings"]
+categories = ["api-bindings"]
+
+[workspace.lints.rust]
+unused_qualifications = "warn"
+
+[workspace.lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+derive_partial_eq_without_eq = "allow"
+implicit_hasher = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+module_name_repetitions = "allow"
+# FIX
+bool_to_int_with_if = "allow"
+cast_lossless = "allow"
+cast_possible_truncation = "allow"
+cast_possible_wrap = "allow"
+cast_ptr_alignment = "allow"  # this one is really suspicious
+cast_sign_loss = "allow"
+checked_conversions = "allow"
+doc_markdown = "allow"
+extra_unused_lifetimes = "allow"  # this one seems pretty bad
+into_iter_without_iter = "allow"
+len_without_is_empty = "allow"
+missing_safety_doc = "allow"
+must_use_candidate = "allow"
+needless_pass_by_value = "allow"
+new_without_default = "allow"
+not_unsafe_ptr_arg_deref = "allow"  # this one seems pretty bad
+ptr_as_ptr = "allow"
+ptr_cast_constness = "allow"
+redundant_closure_for_method_calls = "allow"
+ref_as_ptr = "allow"
+result_unit_err = "allow"
+similar_names = "allow"
+wildcard_imports = "allow"
 
 [dependencies]
 varnish-sys = { path = "varnish-sys", version = "0.0.19" }
@@ -18,4 +55,4 @@ serde = { version = "1", features = ["derive"] }
 
 [workspace]
 
-members = [ "examples/vmod_*", "vmod_test" ]
+members = ["examples/vmod_*", "vmod_test"]

--- a/examples/vmod_be/src/lib.rs
+++ b/examples/vmod_be/src/lib.rs
@@ -3,6 +3,7 @@
 varnish::boilerplate!();
 
 use std::error::Error;
+
 use varnish::vcl::backend::{Backend, Serve, Transfer, VCLBackendPtr};
 use varnish::vcl::ctx::Ctx;
 

--- a/examples/vmod_error/src/lib.rs
+++ b/examples/vmod_error/src/lib.rs
@@ -1,6 +1,7 @@
 varnish::boilerplate!();
 
 use std::fs::read_to_string;
+
 use varnish::vcl::ctx::Ctx;
 
 varnish::vtc!(test01);

--- a/examples/vmod_event/src/lib.rs
+++ b/examples/vmod_event/src/lib.rs
@@ -1,8 +1,6 @@
 varnish::boilerplate!();
 
-use varnish::vcl::ctx::Ctx;
-use varnish::vcl::ctx::Event;
-use varnish::vcl::ctx::LogTag;
+use varnish::vcl::ctx::{Ctx, Event, LogTag};
 use varnish::vcl::vpriv::VPriv;
 
 varnish::vtc!(test01);

--- a/examples/vmod_example/src/lib.rs
+++ b/examples/vmod_example/src/lib.rs
@@ -3,7 +3,6 @@ varnish::boilerplate!();
 
 // even though we won't use it here, we still need to know what the context type is
 use varnish::vcl::ctx::Ctx;
-
 // this import is only needed for tests
 #[cfg(test)]
 use varnish::vcl::ctx::TestCtx;

--- a/examples/vmod_object/src/lib.rs
+++ b/examples/vmod_object/src/lib.rs
@@ -5,6 +5,7 @@ varnish::boilerplate!();
 
 use std::collections::HashMap;
 use std::sync::Mutex;
+
 use varnish::vcl::convert::IntoVCL;
 use varnish::vcl::ctx::Ctx;
 use varnish_sys::VCL_STRING;

--- a/examples/vmod_vdp/src/lib.rs
+++ b/examples/vmod_vdp/src/lib.rs
@@ -1,7 +1,6 @@
 varnish::boilerplate!();
 
-use varnish::vcl::ctx::Ctx;
-use varnish::vcl::ctx::Event;
+use varnish::vcl::ctx::{Ctx, Event};
 use varnish::vcl::processor::{new_vdp, InitResult, PushAction, PushResult, VDPCtx, VDP};
 use varnish::vcl::vpriv::VPriv;
 

--- a/examples/vmod_vfp/src/lib.rs
+++ b/examples/vmod_vfp/src/lib.rs
@@ -1,7 +1,6 @@
 varnish::boilerplate!();
 
-use varnish::vcl::ctx::Ctx;
-use varnish::vcl::ctx::Event;
+use varnish::vcl::ctx::{Ctx, Event};
 use varnish::vcl::processor::{new_vfp, InitResult, PullResult, VFPCtx, VFP};
 use varnish::vcl::vpriv::VPriv;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,12 +89,11 @@
 //!
 //! The various type translations are described in detail in [`crate::vcl::convert`].
 
-use std::env;
 use std::env::join_paths;
-use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::{env, fs};
 
 pub mod vsc;
 
@@ -133,13 +132,13 @@ pub mod vcl {
 
     impl std::error::Error for Error {}
 
-    impl std::convert::From<String> for Error {
+    impl From<String> for Error {
         fn from(s: String) -> Self {
             Error { s }
         }
     }
 
-    impl std::convert::From<&str> for Error {
+    impl From<&str> for Error {
         fn from(s: &str) -> Self {
             Error { s: s.into() }
         }

--- a/src/vcl/probe.rs
+++ b/src/vcl/probe.rs
@@ -1,7 +1,8 @@
-use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::os::raw::c_uint;
 use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum COWRequest<'a> {

--- a/src/vcl/processor.rs
+++ b/src/vcl/processor.rs
@@ -8,8 +8,9 @@
 use std::ffi::{c_char, c_int, c_void};
 use std::ptr;
 
-use crate::vcl::ctx::Ctx;
 use varnish_sys::{objcore, vdp_ctx, vfp_ctx, vfp_entry};
+
+use crate::vcl::ctx::Ctx;
 
 /// passed to [`VDP::push`] to describe special conditions occuring in the pipeline.
 #[derive(Debug, Copy, Clone)]
@@ -60,11 +61,7 @@ where
 {
     /// Create a new processor, possibly using knowledge from the pipeline, or from the current
     /// request.
-    fn new(
-        vrt_ctx: &mut Ctx,
-        vdp_ctx: &mut VDPCtx,
-        oc: *mut varnish_sys::objcore,
-    ) -> InitResult<Self>;
+    fn new(vrt_ctx: &mut Ctx, vdp_ctx: &mut VDPCtx, oc: *mut objcore) -> InitResult<Self>;
     /// Handle the data buffer from the previous processor. This function generally uses
     /// [`VDPCtx::push`] to push data to the next processor.
     fn push(&mut self, ctx: &mut VDPCtx, act: PushAction, buf: &[u8]) -> PushResult;
@@ -145,7 +142,7 @@ pub fn new_vdp<T: VDP>() -> varnish_sys::vdp {
 
 /// A thin wrapper around a `*mut varnish_sys::vdp_ctx`
 pub struct VDPCtx<'a> {
-    pub raw: &'a mut varnish_sys::vdp_ctx,
+    pub raw: &'a mut vdp_ctx,
 }
 
 impl<'a> VDPCtx<'a> {
@@ -154,7 +151,7 @@ impl<'a> VDPCtx<'a> {
     /// # Safety
     ///
     /// The caller is in charge of making sure the structure doesn't outlive the pointer.
-    pub unsafe fn new(raw: *mut varnish_sys::vdp_ctx) -> Self {
+    pub unsafe fn new(raw: *mut vdp_ctx) -> Self {
         let raw = raw.as_mut().unwrap();
         assert_eq!(raw.magic, varnish_sys::VDP_CTX_MAGIC);
         VDPCtx { raw }
@@ -199,7 +196,7 @@ where
 
 unsafe extern "C" fn wrap_vfp_init<T: VFP>(
     vrt_ctx: *const varnish_sys::vrt_ctx,
-    ctxp: *mut varnish_sys::vfp_ctx,
+    ctxp: *mut vfp_ctx,
     vfep: *mut vfp_entry,
 ) -> varnish_sys::vfp_status {
     let ctx = ctxp.as_mut().unwrap();
@@ -222,8 +219,8 @@ unsafe extern "C" fn wrap_vfp_init<T: VFP>(
 }
 
 pub unsafe extern "C" fn wrap_vfp_pull<T: VFP>(
-    ctxp: *mut varnish_sys::vfp_ctx,
-    vfep: *mut varnish_sys::vfp_entry,
+    ctxp: *mut vfp_ctx,
+    vfep: *mut vfp_entry,
     ptr: *mut c_void,
     len: *mut isize,
 ) -> varnish_sys::vfp_status {
@@ -274,7 +271,7 @@ pub fn new_vfp<T: VFP>() -> varnish_sys::vfp {
 
 /// A thin wrapper around a `*mut varnish_sys::vfp_ctx`
 pub struct VFPCtx<'a> {
-    pub raw: &'a mut varnish_sys::vfp_ctx,
+    pub raw: &'a mut vfp_ctx,
 }
 
 impl<'a> VFPCtx<'a> {
@@ -283,7 +280,7 @@ impl<'a> VFPCtx<'a> {
     /// # Safety
     ///
     /// The caller is in charge of making sure the structure doesn't outlive the pointer.
-    pub unsafe fn new(raw: *mut varnish_sys::vfp_ctx) -> Self {
+    pub unsafe fn new(raw: *mut vfp_ctx) -> Self {
         let raw = raw.as_mut().unwrap();
         assert_eq!(raw.magic, varnish_sys::VFP_CTX_MAGIC);
         VFPCtx { raw }
@@ -306,7 +303,7 @@ impl<'a> VFPCtx<'a> {
                 PullResult::End(len as usize)
             }
             varnish_sys::vfp_status_VFP_ERROR => PullResult::Err,
-            n => panic!("unknown vfp_status: {}", n),
+            n => panic!("unknown vfp_status: {n}"),
         }
     }
 }

--- a/src/vcl/ws.rs
+++ b/src/vcl/ws.rs
@@ -30,9 +30,7 @@ pub struct WS<'a> {
 impl<'a> WS<'a> {
     /// Wrap a raw pointer into an object we can use.
     pub fn new(raw: *mut varnish_sys::ws) -> Self {
-        if raw.is_null() {
-            panic!("raw pointer was null");
-        }
+        assert!(!raw.is_null(), "raw pointer was null");
         WS {
             raw,
             phantom_a: std::marker::PhantomData,
@@ -47,7 +45,7 @@ impl<'a> WS<'a> {
 
         let p = unsafe { varnish_sys::WS_Alloc(wsp, sz as u32).cast::<u8>() };
         if p.is_null() {
-            Err(format!("workspace allocation ({} bytes) failed", sz))
+            Err(format!("workspace allocation ({sz} bytes) failed"))
         } else {
             unsafe { Ok(from_raw_parts_mut(p, sz)) }
         }
@@ -224,7 +222,7 @@ pub struct TestWS {
 impl TestWS {
     /// Instantiate a `C` ws struct and the required space of size `sz`.
     pub fn new(sz: usize) -> Self {
-        let al = std::mem::align_of::<*const c_void>();
+        let al = align_of::<*const c_void>();
         let aligned_sz = (sz / al) * al;
 
         let mut v: Vec<c_char> = vec![0; sz];

--- a/src/vsc.rs
+++ b/src/vsc.rs
@@ -62,7 +62,7 @@ impl<'a> VSCBuilder<'a> {
             let vsc = varnish_sys::VSC_New();
             assert!(!vsc.is_null());
             // get raw value, we can always clamp them later
-            varnish_sys::VSC_Arg(vsc, 'r' as core::ffi::c_char, std::ptr::null());
+            varnish_sys::VSC_Arg(vsc, 'r' as core::ffi::c_char, ptr::null());
             VSCBuilder {
                 vsm,
                 vsc,
@@ -106,7 +106,7 @@ impl<'a> VSCBuilder<'a> {
     }
 
     fn vsc_arg(self, o: char, s: &str) -> std::result::Result<Self, std::ffi::NulError> {
-        let c_s = std::ffi::CString::new(s)?;
+        let c_s = CString::new(s)?;
         unsafe {
             let ret = varnish_sys::VSC_Arg(
                 self.vsc,
@@ -293,7 +293,7 @@ unsafe extern "C" fn add_point(
     };
     assert_eq!((*internal).points.insert(k, stat), None);
     (*internal).added.push(k);
-    std::ptr::null_mut()
+    ptr::null_mut()
 }
 
 unsafe extern "C" fn del_point(ptr: *mut std::ffi::c_void, point: *const varnish_sys::VSC_point) {
@@ -367,7 +367,7 @@ impl<'a> VSC<'a> {
     /// (if a key appears in both `Vec`s, the statistic got replaced).
     pub fn update(&mut self) -> (Vec<usize>, Vec<usize>) {
         unsafe {
-            varnish_sys::VSC_Iter(self.vsc, self.vsm, None, std::ptr::null_mut());
+            varnish_sys::VSC_Iter(self.vsc, self.vsm, None, ptr::null_mut());
         }
         let added = std::mem::take(&mut self.internal.added);
         let deleted = std::mem::take(&mut self.internal.deleted);

--- a/varnish-sys/src/lib.rs
+++ b/varnish-sys/src/lib.rs
@@ -3,5 +3,8 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(clippy::approx_constant)]
+#![allow(clippy::missing_safety_doc)]
+#![allow(clippy::useless_transmute)]
+#![allow(clippy::too_many_arguments)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/vmod_test/src/lib.rs
+++ b/vmod_test/src/lib.rs
@@ -5,10 +5,9 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::time::Duration;
 
 use varnish::vcl::ctx::{Ctx, Event};
-use varnish::vcl::probe;
 use varnish::vcl::processor::{new_vfp, InitResult, PullResult, VFPCtx, VFP};
 use varnish::vcl::vpriv::VPriv;
-use varnish::vcl::Result;
+use varnish::vcl::{probe, Result};
 
 varnish::vtc!(test01);
 varnish::vtc!(test02);


### PR DESCRIPTION
* reformat with `cargo +nightly fmt --all -- --config imports_granularity=Module,group_imports=StdExternalCrate`
* add clippy lint configuration to Cargo.toml

This seems like a bug, but I didn't change the logic:

```rust
        self.raw.protover = match value {
            "HTTP/0.9" => 9,
            // FIXME: Is this a bug?
            "HTTP/1.0" | "HTTP/1.1" => 10,
            "HTTP/2.0" => 20,
            _ => 0,
        };
```