### PR TITLE
Fix trait order and type

### DIFF
--- a/examples/vmod_vdp/src/lib.rs
+++ b/examples/vmod_vdp/src/lib.rs
@@ -1,5 +1,7 @@
 varnish::boilerplate!();
 
+use std::ffi::CStr;
+
 use varnish::ffi;
 use varnish::vcl::ctx::{Ctx, Event};
 use varnish::vcl::processor::{new_vdp, InitResult, PushAction, PushResult, VDPCtx, VDP};
@@ -15,11 +17,6 @@ struct Flipper {
 
 // implement the actual behavior of the VDP
 impl VDP for Flipper {
-    // return our id, adding the NULL character to avoid confusing the C layer
-    fn name() -> &'static str {
-        "flipper\0"
-    }
-
     // `new` is called when the VCL specifies "flipper" in `resp.filters`
     // just return an default struct, thanks to the derive macro
     fn new(_: &mut Ctx, _: &mut VDPCtx, _oc: *mut ffi::objcore) -> InitResult<Self> {
@@ -40,6 +37,11 @@ impl VDP for Flipper {
         self.body.reverse();
         // send
         ctx.push(act, &self.body)
+    }
+
+    // return our id
+    fn name() -> &'static CStr {
+        c"flipper"
     }
 }
 

--- a/examples/vmod_vfp/src/lib.rs
+++ b/examples/vmod_vfp/src/lib.rs
@@ -1,5 +1,7 @@
 varnish::boilerplate!();
 
+use std::ffi::CStr;
+
 use varnish::ffi;
 use varnish::vcl::ctx::{Ctx, Event};
 use varnish::vcl::processor::{new_vfp, InitResult, PullResult, VFPCtx, VFP};
@@ -12,11 +14,6 @@ struct Lower {}
 
 // implement the actual behavior of the VFP
 impl VFP for Lower {
-    // return our id, adding the NULL character to avoid confusing the C layer
-    fn name() -> &'static str {
-        "lower\0"
-    }
-
     // `new` is called when the VCL specifies "lower" in `beresp.filters`
     fn new(_: &mut Ctx, _: &mut VFPCtx) -> InitResult<Self> {
         InitResult::Ok(Lower {})
@@ -35,6 +32,11 @@ impl VFP for Lower {
             e.make_ascii_lowercase();
         }
         pull_res
+    }
+
+    // return our id, adding the NULL character to avoid confusing the C layer
+    fn name() -> &'static CStr {
+        c"lower"
     }
 }
 

--- a/src/vcl/processor.rs
+++ b/src/vcl/processor.rs
@@ -5,7 +5,7 @@
 //! *Note:* The rust wrapper here is pretty thin and the vmod writer will most probably need to have to
 //! deal with the raw Varnish internals.
 
-use std::ffi::{c_char, c_int, c_void};
+use std::ffi::{c_char, c_int, c_void, CStr};
 use std::ptr;
 
 use crate::ffi;
@@ -68,7 +68,7 @@ where
     /// The name of the processor.
     ///
     /// **Note:** it must be NULL-terminated as it will be used directly as a C string.
-    fn name() -> &'static str;
+    fn name() -> &'static CStr;
 }
 
 pub unsafe extern "C" fn gen_vdp_init<T: VDP>(
@@ -196,9 +196,7 @@ where
     /// The name of the processor.
     ///
     /// **Note:** it must be NULL-terminated as it will be used directly as a C string.
-    fn name() -> &'static str {
-        unimplemented!()
-    }
+    fn name() -> &'static CStr;
 }
 
 unsafe extern "C" fn wrap_vfp_init<T: VFP>(

--- a/vmod_test/src/lib.rs
+++ b/vmod_test/src/lib.rs
@@ -1,5 +1,6 @@
 varnish::boilerplate!();
 
+use std::ffi::CStr;
 use std::io::Write;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::time::Duration;
@@ -162,16 +163,16 @@ struct VFPTest {
 
 // Force a pass here to test to make sure that fini does not panic due to a null priv1 member
 impl VFP for VFPTest {
-    fn name() -> &'static str {
-        "vfptest\0"
-    }
-
     fn new(_: &mut Ctx, _: &mut VFPCtx) -> InitResult<Self> {
         InitResult::Pass
     }
 
     fn pull(&mut self, _: &mut VFPCtx, _: &mut [u8]) -> PullResult {
         PullResult::Err
+    }
+
+    fn name() -> &'static CStr {
+        c"vfptest"
     }
 }
 


### PR DESCRIPTION
Make ordering of the trait impl the same as in definition, and modify return to prevent accidental mismatches.