### PR TITLE
Consolidate `Error` and `Result`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,43 @@
+/// custom vcl `Error` type
+///
+/// The C errors aren't typed and are just C strings, so we just wrap them into a proper rust
+/// `Error`
+pub struct Error {
+    s: String,
+}
+
+impl Error {
+    /// Create a new `Error` from a string
+    pub(crate) fn new(s: String) -> Self {
+        Error { s }
+    }
+}
+
+impl std::fmt::Debug for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.s, f)
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.s, f)
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<String> for Error {
+    fn from(s: String) -> Self {
+        Error { s }
+    }
+}
+
+impl From<&str> for Error {
+    fn from(s: &str) -> Self {
+        Error { s: s.into() }
+    }
+}
+
+/// Shorthand to `std::result::Result<T, Error>`
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,8 @@ pub mod ffi {
 
 pub mod vsc;
 
+mod error;
+
 pub mod vcl {
     pub mod backend;
     pub mod convert;
@@ -120,45 +122,9 @@ pub mod vcl {
     pub mod vpriv;
     pub mod vsb;
     pub mod ws;
+    pub use super::error::{Error, Result};
 
     pub mod boilerplate;
-
-    /// custom vcl `Error` type
-    ///
-    /// The C errors aren't typed and are just C strings, so we just wrap them into a proper rust
-    /// `Error`
-    pub struct Error {
-        s: String,
-    }
-
-    impl std::fmt::Debug for Error {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            std::fmt::Debug::fmt(&self.s, f)
-        }
-    }
-
-    impl std::fmt::Display for Error {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            std::fmt::Display::fmt(&self.s, f)
-        }
-    }
-
-    impl std::error::Error for Error {}
-
-    impl From<String> for Error {
-        fn from(s: String) -> Self {
-            Error { s }
-        }
-    }
-
-    impl From<&str> for Error {
-        fn from(s: &str) -> Self {
-            Error { s: s.into() }
-        }
-    }
-
-    /// Shorthand to `std::result::Result<T, Error>`
-    pub type Result<T> = std::result::Result<T, Error>;
 }
 
 /// Automate VTC testing

--- a/src/vsc.rs
+++ b/src/vsc.rs
@@ -9,29 +9,8 @@ use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::ptr;
 
+pub use crate::error::{Error, Result};
 use crate::ffi;
-
-/// Error wrapping the VSM/VSC error reported by the C api
-pub struct Error {
-    s: String,
-}
-
-impl std::fmt::Debug for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Debug::fmt(&self.s, f)
-    }
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self.s, f)
-    }
-}
-
-impl std::error::Error for Error {}
-
-/// Shorthand to `std::result::Result<T, Error>`
-pub type Result<T> = std::result::Result<T, Error>;
 
 /// A statistics set, created using a [`VSCBuilder`]
 #[derive(Debug)]
@@ -170,12 +149,12 @@ impl<'a> VSCBuilder<'a> {
 
 fn vsm_error(p: *const ffi::vsm) -> Error {
     unsafe {
-        Error {
-            s: CStr::from_ptr(ffi::VSM_Error(p))
+        Error::new(
+            CStr::from_ptr(ffi::VSM_Error(p))
                 .to_str()
                 .unwrap()
                 .to_string(),
-        }
+        )
     }
 }
 


### PR DESCRIPTION
There does not seem to be any reason to keep `Error` and `Result` in both `vcl` and `vsc` modules.

Also, note that `vcl::Error` is actually never instantiated.

In the future, I think it would be better to rename them, e.g. to `VarnishError` and `VarnishResult`.  This is a common practice now to distinguish them from the built-in ones (lots of people have been complaining that `std::io::Result` and others didn't follow that convention, but it is too late for that now).