### PR TITLE
Clean up tests

### DIFF
--- a/examples/vmod_example/src/lib.rs
+++ b/examples/vmod_example/src/lib.rs
@@ -3,9 +3,6 @@ varnish::boilerplate!();
 
 // even though we won't use it here, we still need to know what the context type is
 use varnish::vcl::ctx::Ctx;
-// this import is only needed for tests
-#[cfg(test)]
-use varnish::vcl::ctx::TestCtx;
 
 // we now implement both functions from vmod.vcc, but with rust types.
 // Don't forget to make the function public with "pub" in front of them
@@ -26,33 +23,38 @@ pub fn captain_obvious(_: &Ctx, opt: Option<i64>) -> String {
     }
 }
 
-// Write some more unit tests
-#[test]
-fn obviousness() {
-    let mut test_ctx = TestCtx::new(100);
-    let ctx = test_ctx.ctx();
+#[cfg(test)]
+mod tests {
+    use varnish::vcl::ctx::TestCtx;
 
-    assert_eq!(
-        "I was called without an argument",
-        captain_obvious(&ctx, None)
-    );
-    assert_eq!(
-        "I was given 975322 as argument",
-        captain_obvious(&ctx, Some(975_322))
-    );
+    use super::*;
+
+    #[test]
+    fn obviousness() {
+        let mut test_ctx = TestCtx::new(100);
+        let ctx = test_ctx.ctx();
+
+        assert_eq!(
+            "I was called without an argument",
+            captain_obvious(&ctx, None)
+        );
+        assert_eq!(
+            "I was given 975322 as argument",
+            captain_obvious(&ctx, Some(975_322))
+        );
+    }
+
+    #[test]
+    fn even_test() {
+        // we don't use it, but we still need one
+        let mut test_ctx = TestCtx::new(100);
+        let ctx = test_ctx.ctx();
+
+        assert!(is_even(&ctx, 0));
+        assert!(is_even(&ctx, 1024));
+        assert!(!is_even(&ctx, 421_321));
+    }
+
+    // we also want to run test/test01.vtc
+    varnish::vtc!(test01);
 }
-
-// Write some more unit tests
-#[test]
-fn even_test() {
-    // we don't use it, but we still need one
-    let mut test_ctx = TestCtx::new(100);
-    let ctx = test_ctx.ctx();
-
-    assert!(is_even(&ctx, 0));
-    assert!(is_even(&ctx, 1024));
-    assert!(!is_even(&ctx, 421_321));
-}
-
-// we also want to run test/test01.vtc
-varnish::vtc!(test01);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,10 +170,11 @@ pub mod vcl {
 /// **Important note:** you need to first build your vmod (i.e. with `cargo build`) before the tests can be run,
 /// otherwise you'll get a panic.
 ///
-/// Tests will automatically timeout after 5s. To override, set `VARNISHTEST_DURATION` env var.
+/// Tests will automatically time out after 5s. To override, set `VARNISHTEST_DURATION` env var.
 #[macro_export]
 macro_rules! vtc {
     ( $name:ident ) => {
+        #[cfg(test)]
         #[test]
         fn $name() {
             use std::io::{self, Write};


### PR DESCRIPTION
* Use dedicated `tests` module (recommended practice)
* Use `#[cfg(test)]` on both test module and `vtc!` macro to speed up compilation for non-test cases (and avoids including junk in the output)

| Use "hide whitespace" when reviewing |
|---|
| ![image](https://github.com/user-attachments/assets/db61ac20-4b87-4114-a9b8-d116db54b786) |
