### PR TITLE
Wrap `VCL_BOOL` in a struct to ensure type safety

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -38,6 +38,32 @@ fn main() {
         .derive_debug(true)
         .derive_default(true)
         .generate_cstr(true)
+        //
+        // VCL_ACL = *const vrt_acl
+        // VCL_BACKEND = *const director
+        // VCL_BLOB = *const vrt_blob
+        // VCL_BODY = *const ::std::os::raw::c_void
+        // VCL_BOOL = ::std::os::raw::c_uint
+        .new_type_alias_deref("VCL_BOOL")
+        // VCL_BYTES = i64
+        // VCL_DURATION = vtim_dur
+        // VCL_ENUM = *const ::std::os::raw::c_char
+        // VCL_HEADER = *const gethdr_s
+        // VCL_HTTP = *mut http
+        // VCL_INSTANCE = ::std::os::raw::c_void
+        // VCL_INT = i64
+        // VCL_IP = *const suckaddr
+        // VCL_PROBE = *const vrt_backend_probe
+        // VCL_REAL = f64
+        // VCL_REGEX = *const vre
+        // VCL_STEVEDORE = *const stevedore
+        // VCL_STRANDS = *const strands
+        // VCL_STRING = *const ::std::os::raw::c_char
+        // VCL_SUB = *const vcl_sub
+        // VCL_TIME = vtim_real
+        // VCL_VCL = *mut vcl
+        // VCL_VOID = ::std::os::raw::c_void
+        //
         .generate()
         .expect("Unable to generate bindings");
 

--- a/src/bindings.rs.saved
+++ b/src/bindings.rs.saved
@@ -4295,7 +4295,22 @@ pub type VCL_ACL = *const vrt_acl;
 pub type VCL_BACKEND = *const director;
 pub type VCL_BLOB = *const vrt_blob;
 pub type VCL_BODY = *const ::std::ffi::c_void;
-pub type VCL_BOOL = ::std::ffi::c_uint;
+#[repr(transparent)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct VCL_BOOL(pub ::std::ffi::c_uint);
+impl ::std::ops::Deref for VCL_BOOL {
+    type Target = ::std::ffi::c_uint;
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl ::std::ops::DerefMut for VCL_BOOL {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
 pub type VCL_BYTES = i64;
 pub type VCL_DURATION = vtim_dur;
 pub type VCL_ENUM = *const ::std::ffi::c_char;


### PR DESCRIPTION
Introduce a wrapper for `VCL_BOOL` type, per #51

## Open Questions
* [ ] Do we actually need `Deref` and `DerefMut` implementations for it?  It can be simplified to `struct VCL_BOOL(pub c_uint);`
* [ ] `probe.exp_status = self.exp_status.into_vcl(ws)?` and 2 more no longer work because it seem they were silently using int to bool conversion?
* [ ] Seems like it is no longer needs to use `vcl_types!`?