### PR TITLE
Add `Debug` trait to all structs and enums

### DIFF
--- a/src/vcl/backend.rs
+++ b/src/vcl/backend.rs
@@ -96,6 +96,7 @@ pub type VCLBackendPtr = ffi::VCL_BACKEND;
 /// result, you don't want to drop it until after all the transfers are done. The most common way
 /// is just to have the backend be part of a vmod object because the object won't be dropped until
 /// the VCL is discarded and that can only happen once all the backend fetches are done.
+#[derive(Debug)]
 pub struct Backend<S: Serve<T>, T: Transfer> {
     bep: *const ffi::director,
     #[allow(dead_code)]
@@ -574,6 +575,7 @@ impl<S: Serve<T>, T: Transfer> Drop for Backend<S, T> {
 ///
 /// When piping a response, the backend is in charge of closing the file descriptor (which is done
 /// automatically by the rust layer), but also to provide how/why it got closed.
+#[derive(Debug)]
 pub enum StreamClose {
     RemClose,
     ReqClose,

--- a/src/vcl/ctx.rs
+++ b/src/vcl/ctx.rs
@@ -1,4 +1,5 @@
-//! Expose the Varnish context (`struct vrt_ctx`) as a Rust object
+//! Expose the Varnish context [`vrt_ctx`] as a Rust object
+//!
 use std::ffi::{c_char, c_int, c_uint, c_void, CString};
 use std::ptr;
 
@@ -16,6 +17,7 @@ use crate::vcl::ws::{TestWS, WS};
 /// An `enum` wrapper around [VSL tags](https://varnish-cache.org/docs/trunk/reference/vsl.html#vsl-tags).
 /// Only the most current tags (for vmod writers) are mapped, and [`LogTag::Any`] will allow to
 /// directly pass a native tag code (`ffi::VSL_tag_e_SLT_*`).
+#[derive(Debug)]
 pub enum LogTag {
     Debug,
     Error,
@@ -62,6 +64,7 @@ impl LogTag {
 ///     }
 /// }
 /// ```
+#[derive(Debug)]
 pub struct Ctx<'a> {
     pub raw: &'a mut vrt_ctx,
     pub http_req: Option<HTTP<'a>>,
@@ -162,17 +165,18 @@ impl<'a> Ctx<'a> {
     }
 }
 
-/// A struct holding both a native vrt_ctx struct and the space it points to.
+/// A struct holding both a native [`vrt_ctx`] struct and the space it points to.
 ///
 /// As the name implies, this struct mainly exist to facilitate testing and should probably not be
 /// used elsewhere.
+#[derive(Debug)]
 pub struct TestCtx {
     vrt_ctx: vrt_ctx,
     test_ws: TestWS,
 }
 
 impl TestCtx {
-    /// Instantiate a vrt_ctx, as well as the workspace (of size `sz`) it links to.
+    /// Instantiate a [`vrt_ctx`], as well as the workspace (of size `sz`) it links to.
     pub fn new(sz: usize) -> Self {
         let mut test_ctx = TestCtx {
             vrt_ctx: vrt_ctx {
@@ -180,12 +184,12 @@ impl TestCtx {
                 syntax: 0,
                 method: 0,
                 vclver: 0,
-                msg: ptr::null::<vsb>() as *mut vsb,
-                vsl: ptr::null::<vsl_log>() as *mut vsl_log,
+                msg: ptr::null_mut::<vsb>(),
+                vsl: ptr::null_mut::<vsl_log>(),
                 vcl: ptr::null::<VCL_VCL>() as VCL_VCL,
                 ws: ptr::null_mut::<ws>(),
-                sp: ptr::null::<sess>() as *mut sess,
-                req: ptr::null::<req>() as *mut req,
+                sp: ptr::null_mut::<sess>(),
+                req: ptr::null_mut::<req>(),
                 http_req: ptr::null::<VCL_HTTP>() as VCL_HTTP,
                 http_req_top: ptr::null::<VCL_HTTP>() as VCL_HTTP,
                 http_resp: ptr::null::<VCL_HTTP>() as VCL_HTTP,

--- a/src/vcl/http.rs
+++ b/src/vcl/http.rs
@@ -31,6 +31,7 @@ const HDR_UNSET: u16 = ffi::HTTP_HDR_UNSET as u16;
 const HDR_URL: u16 = ffi::HTTP_HDR_URL as u16;
 
 /// HTTP headers of an object
+#[derive(Debug)]
 pub struct HTTP<'a> {
     pub raw: &'a mut ffi::http,
 }
@@ -224,6 +225,7 @@ impl<'a> IntoIterator for &'a mut HTTP<'a> {
     }
 }
 
+#[derive(Debug)]
 pub struct HTTPIter<'a> {
     http: &'a HTTP<'a>,
     cursor: isize,

--- a/src/vcl/processor.rs
+++ b/src/vcl/processor.rs
@@ -143,6 +143,7 @@ pub fn new_vdp<T: VDP>() -> ffi::vdp {
 }
 
 /// A thin wrapper around a `*mut ffi::vdp_ctx`
+#[derive(Debug)]
 pub struct VDPCtx<'a> {
     pub raw: &'a mut vdp_ctx,
 }
@@ -273,6 +274,7 @@ pub fn new_vfp<T: VFP>() -> ffi::vfp {
 }
 
 /// A thin wrapper around a `*mut ffi::vfp_ctx`
+#[derive(Debug)]
 pub struct VFPCtx<'a> {
     pub raw: &'a mut vfp_ctx,
 }

--- a/src/vcl/vpriv.rs
+++ b/src/vcl/vpriv.rs
@@ -12,6 +12,7 @@ use crate::ffi;
 // Ideally:
 // - vmod_priv_methods would have a method to free itself
 // - we would be able to create vmod_priv_methods from a const fn
+#[derive(Debug)]
 pub struct VPriv<T> {
     ptr: *mut ffi::vmod_priv,
     phantom: PhantomData<T>,

--- a/src/vcl/vsb.rs
+++ b/src/vcl/vsb.rs
@@ -4,6 +4,7 @@ use std::ffi::c_void;
 
 use crate::ffi;
 
+#[derive(Debug)]
 pub struct Vsb<'a> {
     /// Raw pointer to the C struct
     pub raw: &'a mut ffi::vsb,

--- a/src/vcl/ws.rs
+++ b/src/vcl/ws.rs
@@ -25,6 +25,7 @@ use crate::ffi;
 ///
 /// The workspace is usually a few tens of kilobytes large, don't be greedy. If you need more
 /// space, consider storing your data in a [`VPriv`](crate::vcl::vpriv::VPriv).
+#[derive(Debug)]
 pub struct WS<'a> {
     /// Raw pointer to the C struct
     pub raw: *mut ffi::ws,
@@ -171,6 +172,7 @@ impl<'a> WS<'a> {
 /// let r3 = ws.reserve();
 /// assert_eq!(r3.buf.len(), 150);
 /// ```
+#[derive(Debug)]
 pub struct ReservedBuf<'a> {
     /// The reserved buffer
     pub buf: &'a mut [u8],
@@ -221,6 +223,7 @@ impl<'a> Drop for ReservedBuf<'a> {
 ///
 /// As the name implies, this struct mainly exist to facilitate testing and should probably not be
 /// used elsewhere.
+#[derive(Debug)]
 pub struct TestWS {
     c_ws: ffi::ws,
     #[allow(dead_code)]


### PR DESCRIPTION
Makes debugging far easier. Includes a few tiny lints.