### PR TITLE
Minor `VPriv` improvements

### DIFF
--- a/src/vcl/convert.rs
+++ b/src/vcl/convert.rs
@@ -435,9 +435,11 @@ impl IntoRust<Duration> for VCL_DURATION {
     }
 }
 
-impl<T> IntoRust<VPriv<T>> for *mut vmod_priv {
-    fn into_rust(self) -> VPriv<T> {
-        VPriv::<T>::new(self)
+impl<'a, T> IntoRust<VPriv<'a, T>> for *mut vmod_priv {
+    fn into_rust(self) -> VPriv<'a, T> {
+        // FIXME: this is not a good pattern for sure,
+        // but we assume that vmod_priv will live longer than VPriv
+        unsafe { VPriv::from_ptr(self) }
     }
 }
 


### PR DESCRIPTION
* Make `Vpriv` store a reference instead of a pointer, with an attached lifetime.  Unfortunately we have to support `into_rust` which must fake it with `'static`.
* Do not double-wrap name string - first as a `CString` inside a `Box` because `CString` is already heap-allocated.
* Improve `store` fn