### PR TITLE
Make Serde into an optional dependency

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,6 +30,10 @@ jobs:
         run: cargo build --workspace --all-targets
       - name: test
         run: cargo test --workspace --all-targets
+      - name: build-all
+        run: cargo build --workspace --all-targets --all-features
+      - name: test-all
+        run: cargo test --workspace --all-targets --all-features
       - name: test-doc
         run: |
           cargo test --doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,47 @@
-lints.workspace = true
-
 [package]
 name = "varnish"
-version = "0.0.19"
 authors = ["Guillaume Quintard <guillaume.quintard@gmail.com>"]
-edition = "2021"
-license = "BSD-3-Clause"
 description = "Access to the Varnish modules API"
-homepage = "https://github.com/gquintard/varnish-rs"
-repository = "https://github.com/gquintard/varnish-rs"
-readme = "README.md"
 keywords = ["varnish", "vmod", "cache", "http", "reverse-proxy"]
 categories = ["api-bindings"]
+version.workspace = true
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[features]
+default = []
+serde = ["dep:serde"]
+
+[dependencies]
+pkg-config.workspace = true
+serde = { workspace = true, optional = true }
+
+[build-dependencies]
+pkg-config.workspace = true
+bindgen.workspace = true
+
+[lints]
+workspace = true
+
+#
+# Keep all dependencies, lints, and other values in one place where possible
+#
+
+[workspace]
+members = ["vmod_test", "examples/vmod_*"]
+
+[workspace.package]
+# These fields could be used by multiple crates
+version = "0.0.19"
+repository = "https://github.com/gquintard/varnish-rs"
+edition = "2021"
+license = "BSD-3-Clause"
+
+[workspace.dependencies]
+bindgen = "0.70.1"
+pkg-config = "0.3.30"
+serde = { version = "1", features = ["derive"] }
 
 [workspace.lints.rust]
 unused_qualifications = "warn"
@@ -49,14 +79,3 @@ ref_as_ptr = "allow"
 similar_names = "allow"
 struct_field_names = "allow"
 wildcard_imports = "allow"
-
-[dependencies]
-pkg-config = "0.3.22"
-serde = { version = "1", features = ["derive"] }
-
-[build-dependencies]
-pkg-config = "0.3.30"
-bindgen = "0.70.1"
-
-[workspace]
-members = ["vmod_test", "examples/vmod_*"]

--- a/src/vcl/probe.rs
+++ b/src/vcl/probe.rs
@@ -2,15 +2,18 @@ use std::borrow::Cow;
 use std::ffi::c_uint;
 use std::time::Duration;
 
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum COWRequest<'a> {
     URL(Cow<'a, str>),
     Text(Cow<'a, str>),
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct COWProbe<'a> {
     pub request: COWRequest<'a>,
     pub timeout: Duration,
@@ -21,13 +24,15 @@ pub struct COWProbe<'a> {
     pub initial: c_uint,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Request {
     URL(String),
     Text(String),
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Probe {
     pub request: Request,
     pub timeout: Duration,

--- a/vmod_test/Cargo.toml
+++ b/vmod_test/Cargo.toml
@@ -1,9 +1,7 @@
-lints.workspace = true
-
 [package]
 name = "vmod_test"
 version = "0.0.1"
-edition = "2021"
+edition.workspace = true
 
 [build-dependencies]
 varnish = { path = ".." }
@@ -13,3 +11,6 @@ varnish = { path = ".." }
 
 [lib]
 crate-type = ["cdylib"]
+
+[lints]
+workspace = true


### PR DESCRIPTION
* Now `serde` requires `serde` feature to be manually enabled
* Add build/testing of both "default" and "all features" modes
* Refactored Cargo.toml a bit -- now some shared values are in one place, moved all lints to the bottom (as least important)
* Removed some Cargo.toml values because their values are the same as used by default (per doc, only recommended when different)