### PR TITLE
Add debug mode to the `vtc!` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unpublished
 
 - `vtc!` macro now supports `VARNISHTEST_DURATION` env var, defaulting to "5s"
+- `vtc!` macro now supported debug mode, e.g. `vtc!(file, true)` - keeps the temporary files and always prints the output.
 
 # 0.0.19 (2024-03-24)
 


### PR DESCRIPTION
`vtc!` macro now supported debug mode, e.g. `vtc!(file, true)` - keeps the temporary files and always prints the output.