### PR TITLE
Wrap `VCL_INT` and `VCL_REAL`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -39,30 +39,29 @@ fn main() {
         .derive_default(true)
         .generate_cstr(true)
         //
-        // VCL_ACL = *const vrt_acl
-        // VCL_BACKEND = *const director
-        // VCL_BLOB = *const vrt_blob
-        // VCL_BODY = *const ::std::os::raw::c_void
-        // VCL_BOOL = ::std::os::raw::c_uint
-        .new_type_alias_deref("VCL_BOOL")
-        // VCL_BYTES = i64
-        // VCL_DURATION = vtim_dur
-        // VCL_ENUM = *const ::std::os::raw::c_char
-        // VCL_HEADER = *const gethdr_s
-        // VCL_HTTP = *mut http
-        // VCL_INSTANCE = ::std::os::raw::c_void
-        // VCL_INT = i64
-        // VCL_IP = *const suckaddr
-        // VCL_PROBE = *const vrt_backend_probe
-        // VCL_REAL = f64
-        // VCL_REGEX = *const vre
-        // VCL_STEVEDORE = *const stevedore
-        // VCL_STRANDS = *const strands
-        // VCL_STRING = *const ::std::os::raw::c_char
-        // VCL_SUB = *const vcl_sub
-        // VCL_TIME = vtim_real
-        // VCL_VCL = *mut vcl
-        // VCL_VOID = ::std::os::raw::c_void
+        // .new_type_alias("VCL_ACL") // *const vrt_acl
+        // .new_type_alias("VCL_BACKEND") // *const director
+        // .new_type_alias("VCL_BLOB") // *const vrt_blob
+        // .new_type_alias("VCL_BODY") // *const ::std::os::raw::c_void
+        .new_type_alias("VCL_BOOL") // ::std::os::raw::c_uint
+        // .new_type_alias("VCL_BYTES") // i64
+        // .new_type_alias("VCL_DURATION") // vtim_dur
+        // .new_type_alias("VCL_ENUM") // *const ::std::os::raw::c_char
+        // .new_type_alias("VCL_HEADER") // *const gethdr_s
+        // .new_type_alias("VCL_HTTP") // *mut http
+        // .new_type_alias("VCL_INSTANCE") // ::std::os::raw::c_void
+        .new_type_alias("VCL_INT") // i64
+        // .new_type_alias("VCL_IP") // *const suckaddr
+        // .new_type_alias("VCL_PROBE") // *const vrt_backend_probe
+        .new_type_alias("VCL_REAL") // f64
+        // .new_type_alias("VCL_REGEX") // *const vre
+        // .new_type_alias("VCL_STEVEDORE") // *const stevedore
+        // .new_type_alias("VCL_STRANDS") // *const strands
+        // .new_type_alias("VCL_STRING") // *const ::std::os::raw::c_char
+        // .new_type_alias("VCL_SUB") // *const vcl_sub
+        // .new_type_alias("VCL_TIME") // vtim_real
+        // .new_type_alias("VCL_VCL") // *mut vcl
+        // .new_type_alias("VCL_VOID") // ::std::os::raw::c_void
         //
         .generate()
         .expect("Unable to generate bindings");

--- a/src/bindings.rs.saved
+++ b/src/bindings.rs.saved
@@ -4298,29 +4298,20 @@ pub type VCL_BODY = *const ::std::ffi::c_void;
 #[repr(transparent)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct VCL_BOOL(pub ::std::ffi::c_uint);
-impl ::std::ops::Deref for VCL_BOOL {
-    type Target = ::std::ffi::c_uint;
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl ::std::ops::DerefMut for VCL_BOOL {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
 pub type VCL_BYTES = i64;
 pub type VCL_DURATION = vtim_dur;
 pub type VCL_ENUM = *const ::std::ffi::c_char;
 pub type VCL_HEADER = *const gethdr_s;
 pub type VCL_HTTP = *mut http;
 pub type VCL_INSTANCE = ::std::ffi::c_void;
-pub type VCL_INT = i64;
+#[repr(transparent)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct VCL_INT(pub i64);
 pub type VCL_IP = *const suckaddr;
 pub type VCL_PROBE = *const vrt_backend_probe;
-pub type VCL_REAL = f64;
+#[repr(transparent)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct VCL_REAL(pub f64);
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct vre {

--- a/src/vcl/convert.rs
+++ b/src/vcl/convert.rs
@@ -97,25 +97,25 @@ vcl_types! {
     VCL_BACKEND,
     VCL_BLOB,
     VCL_BODY,
-    // VCL_BOOL,  // need?
+//  VCL_BOOL,  // need?
     VCL_BYTES,
     VCL_DURATION,
-//    VCL_ENUM, // same as VCL_BODY
+//  VCL_ENUM, // same as VCL_BODY
     VCL_HEADER,
     VCL_HTTP,
     VCL_INSTANCE,
-//    VCL_INT, // same as VCL_BYTES
+//  VCL_INT, // same as VCL_BYTES
     VCL_IP,
     VCL_PROBE,
-//    VCL_REAL, // same as VCL_DURATION
+//  VCL_REAL, // same as VCL_DURATION
     VCL_REGEX,
     VCL_STEVEDORE,
     VCL_STRANDS,
     VCL_STRING,
     VCL_SUB,
-//    VCL_TIME, // same as VCL_DURATION
+//  VCL_TIME, // same as VCL_DURATION
     VCL_VCL,
-//    VCL_VOID, // same as VCL_INSTANCE
+//  VCL_VOID, // same as VCL_INSTANCE
 }
 
 impl IntoVCL<()> for () {
@@ -410,18 +410,6 @@ pub trait IntoRust<T> {
     fn into_rust(self) -> T;
 }
 
-impl IntoRust<f64> for VCL_REAL {
-    fn into_rust(self) -> f64 {
-        self
-    }
-}
-
-impl IntoRust<i64> for VCL_INT {
-    fn into_rust(self) -> i64 {
-        self
-    }
-}
-
 impl<'a> IntoRust<Cow<'a, str>> for VCL_STRING {
     fn into_rust(self) -> Cow<'a, str> {
         let s = if self.is_null() { EMPTY_STRING } else { self };
@@ -554,3 +542,19 @@ impl From<VCL_BOOL> for bool {
         b.0 != 0
     }
 }
+
+macro_rules! impl_type_cast_from {
+    ($ident:ident, $typ:ty) => {
+        impl From<$ident> for $typ {
+            fn from(b: $ident) -> Self {
+                <Self>::from(b.0)
+            }
+        }
+    };
+}
+
+impl_type_cast!(VCL_REAL, f64);
+impl_type_cast_from!(VCL_REAL, f64);
+
+impl_type_cast!(VCL_INT, i64);
+impl_type_cast_from!(VCL_INT, i64);

--- a/src/vmodtool-rs.py
+++ b/src/vmodtool-rs.py
@@ -109,8 +109,8 @@ unsafe extern "C" fn vmod_c__event(vrt_ctx: * mut varnish::vcl::boilerplate::vrt
         &mut ctx,
         &mut vp.into_rust(),
         event).into_result() {
-            Ok(()) => 0,
-            Err(ref e) => {{ ctx.fail(e); 1 }},
+            Ok(()) => 0.into(),
+            Err(ref e) => {{ ctx.fail(e); 1.into() }},
     }
 }
 ''')


### PR DESCRIPTION
This removes the deref (not needed). I tried to add `VCL_BYTES`, but hit a snag (into_result() conflicts because of multiple i64->Result). I might have to finish the proc macro before doing the rest of them.