### PR TITLE
Efficient logging without extra allocations

### DIFF
--- a/examples/vmod_event/src/lib.rs
+++ b/examples/vmod_event/src/lib.rs
@@ -19,7 +19,7 @@ pub fn loaded(_: &Ctx, vp: &VPriv<i64>) -> i64 {
 // guarantees that event functions are called sequentially in the cli thread, so we'll be fine
 pub unsafe fn event(ctx: &mut Ctx, vp: &mut VPriv<i64>, event: Event) -> Result<(), &'static str> {
     // log the event, showing that it implements Debug
-    ctx.log(LogTag::Debug, &format!("event: {event:?}"));
+    ctx.log(LogTag::Debug, format!("event: {event:?}"));
 
     // we only care about load events, which is why we don't use `match`
     if matches!(event, Event::Load) {

--- a/src/vcl/backend.rs
+++ b/src/vcl/backend.rs
@@ -80,7 +80,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::ffi;
 use crate::vcl::convert::IntoVCL;
-use crate::vcl::ctx::{Ctx, Event, LogTag};
+use crate::vcl::ctx::{Ctx, Event, LogTag, Loggable};
 use crate::vcl::utils::{
     validate_director, validate_vdir, validate_vfp_ctx, validate_vfp_entry, validate_vrt_ctx,
 };
@@ -305,14 +305,11 @@ unsafe extern "C" fn vfp_pull<T: Transfer>(
     let reader = vfe.priv1.cast::<T>().as_mut().unwrap();
     match reader.read(buf) {
         Err(e) => {
-            let msg = e.to_string();
+            let msg = Loggable::from(e.to_string());
             // TODO: we should grow a VSL object
-            ffi::VSLbt(
-                ctx.req.as_ref().unwrap().vsl,
-                ffi::VSL_tag_e_SLT_Error,
-                // SAFETY: we assume ffi::VSLbt() will not store the pointer to the string's content
-                ffi::txt::from_str(msg.as_str()),
-            );
+            // SAFETY: we assume ffi::VSLbt() will not store the pointer to the string's content
+            let msg = ffi::txt::from_cstr(msg.as_cstr());
+            ffi::VSLbt(ctx.req.as_ref().unwrap().vsl, ffi::VSL_tag_e_SLT_Error, msg);
             ffi::vfp_status_VFP_ERROR
         }
         Ok(0) => {
@@ -385,7 +382,7 @@ unsafe extern "C" fn wrap_gethdrs<S: Serve<T>, T: Transfer>(
             }
             if beresp.proto().is_none() {
                 if let Err(e) = beresp.set_proto("HTTP/1.1") {
-                    ctx.fail(&format!("{}: {e}", backend.get_type()));
+                    ctx.fail(format!("{}: {e}", backend.get_type()));
                     return 1;
                 }
             }
@@ -394,7 +391,7 @@ unsafe extern "C" fn wrap_gethdrs<S: Serve<T>, T: Transfer>(
                 .cast::<ffi::http_conn>()
                 .as_mut()
             else {
-                ctx.fail(&format!("{}: insufficient workspace", backend.get_type()));
+                ctx.fail(format!("{}: insufficient workspace", backend.get_type()));
                 return -1;
             };
             htc.magic = ffi::HTTP_CONN_MAGIC;
@@ -426,13 +423,13 @@ unsafe extern "C" fn wrap_gethdrs<S: Serve<T>, T: Transfer>(
                                 .cast::<ffi::vfp>()
                                 .as_mut()
                         else {
-                            ctx.fail(&format!("{}: insufficient workspace", backend.get_type()));
+                            ctx.fail(format!("{}: insufficient workspace", backend.get_type()));
                             return -1;
                         };
                         let Ok(t) =
                             WS::new(bo.ws.as_mut_ptr()).copy_bytes_with_null(&backend.get_type())
                         else {
-                            ctx.fail(&format!("{}: insufficient workspace", backend.get_type()));
+                            ctx.fail(format!("{}: insufficient workspace", backend.get_type()));
                             return -1;
                         };
                         vfp.name = t.as_ptr();
@@ -442,7 +439,7 @@ unsafe extern "C" fn wrap_gethdrs<S: Serve<T>, T: Transfer>(
                         vfp.priv1 = null();
 
                         let Some(vfe) = ffi::VFP_Push(bo.vfc, vfp).as_mut() else {
-                            ctx.fail(&format!("{}: couldn't insert vfp", backend.get_type()));
+                            ctx.fail(format!("{}: couldn't insert vfp", backend.get_type()));
                             return -1;
                         };
                         // we don't need to clean vfe.priv1 at the vfp level, the backend will
@@ -456,10 +453,8 @@ unsafe extern "C" fn wrap_gethdrs<S: Serve<T>, T: Transfer>(
             0
         }
         Err(s) => {
-            ctx.log(
-                LogTag::FetchError,
-                &format!("{}: {}", backend.get_type(), &s.to_string()),
-            );
+            let typ = backend.get_type();
+            ctx.log(LogTag::FetchError, format!("{typ}: {s}"));
             1
         }
     }
@@ -498,7 +493,7 @@ unsafe extern "C" fn wrap_getip<T: Transfer>(
         .get_ip()
         .and_then(|ip| ip.into_vcl(&mut ctx.ws).map_err(|e| e.into()))
         .unwrap_or_else(|e| {
-            ctx.fail(&format!("{e}"));
+            ctx.fail(format!("{e}"));
             null()
         })
 }

--- a/src/vmodtool-rs.py
+++ b/src/vmodtool-rs.py
@@ -86,7 +86,7 @@ def rustfuncBody(self, vcc, t):
         rustFuncArgs(self, t)
         print('''\t) {
 \t\tOk(o) => { *objp = Box::into_raw(Box::new(o)); },
-\t\tErr(e) => { _ctx.fail(&e.to_string()); },
+\t\tErr(e) => { _ctx.fail(e.to_string()); },
 \t}''')
     elif t == "fini":
         print("\tdrop(Box::from_raw(*objp));")
@@ -96,7 +96,7 @@ def rustfuncBody(self, vcc, t):
         else:
             print("\tcrate::{name}(".format(name=self.cname()))
         rustFuncArgs(self, t)
-        print("\t).into_result().and_then(|v| v.into_vcl(&mut _ctx.ws)).unwrap_or_else(|e| {{ _ctx.fail(&e); <{0}>::vcl_default() }})".format(self.retval.ct if self.retval.vt != "VOID" else "()"))
+        print("\t).into_result().and_then(|v| v.into_vcl(&mut _ctx.ws)).unwrap_or_else(|e| {{ _ctx.fail(e); <{0}>::vcl_default() }})".format(self.retval.ct if self.retval.vt != "VOID" else "()"))
     print("}")
 
 


### PR DESCRIPTION
All logging functions now take a new `Loggable` object that contains a `Cow<CStr>` - making it possible to log without an extra re-allocation.