### PR TITLE
`Event` cleanup

### DIFF
--- a/src/vcl/backend.rs
+++ b/src/vcl/backend.rs
@@ -320,7 +320,9 @@ unsafe extern "C" fn vfp_pull<T: Transfer>(
 
 unsafe extern "C" fn wrap_event<S: Serve<T>, T: Transfer>(be: VCLBackendPtr, ev: ffi::vcl_event_e) {
     let backend: &S = validate_director(be).get_backend();
-    backend.event(Event::new(ev));
+    backend.event(ev.try_into().unwrap_or_else(|e| {
+        panic!("{e}: value={ev} for backend {}", backend.get_type());
+    }));
 }
 
 unsafe extern "C" fn wrap_list<S: Serve<T>, T: Transfer>(

--- a/src/vcl/ws.rs
+++ b/src/vcl/ws.rs
@@ -270,15 +270,20 @@ impl TestWS {
     }
 }
 
-#[test]
-fn ws_test() {
-    let mut test_ws = TestWS::new(160);
-    let mut ws = test_ws.ws();
-    for _ in 0..10 {
-        let r = ws.alloc(16);
-        assert!(r.is_ok());
-        let buf = r.unwrap();
-        assert_eq!(buf.len(), 16);
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ws_test() {
+        let mut test_ws = TestWS::new(160);
+        let mut ws = test_ws.ws();
+        for _ in 0..10 {
+            let r = ws.alloc(16);
+            assert!(r.is_ok());
+            let buf = r.unwrap();
+            assert_eq!(buf.len(), 16);
+        }
+        assert!(ws.alloc(1).is_err());
     }
-    assert!(ws.alloc(1).is_err());
 }

--- a/src/vmodtool-rs.py
+++ b/src/vmodtool-rs.py
@@ -104,7 +104,7 @@ def rustEventFunc():
     print('''
 unsafe extern "C" fn vmod_c__event(vrt_ctx: *mut varnish::vcl::boilerplate::vrt_ctx, vp: *mut varnish::vcl::boilerplate::vmod_priv, ev: varnish::vcl::boilerplate::vcl_event_e) -> varnish::vcl::boilerplate::VCL_INT {
     let mut ctx = Ctx::from_ptr(vrt_ctx);
-    let event = Event::new(ev);
+    let event = Event::from_raw(ev);
     match crate::event(
         &mut ctx,
         &mut vp.into_rust(),


### PR DESCRIPTION
* Add `try_into` to parse `ffi::vcl_event_e` value without panicking
* In backend `wrap_event` callback, panic with a better message including the backend type (is this ok?)
* move all remaining tests to the separate `#[cfg(test)]` mods