### PR TITLE
Remove `unimplementd!` from the `VFP` trait

### DIFF
--- a/examples/vmod_vdp/src/lib.rs
+++ b/examples/vmod_vdp/src/lib.rs
@@ -17,6 +17,11 @@ struct Flipper {
 
 // implement the actual behavior of the VDP
 impl VDP for Flipper {
+    // return our id
+    fn name() -> &'static CStr {
+        c"flipper"
+    }
+
     // `new` is called when the VCL specifies "flipper" in `resp.filters`
     // just return a default struct, thanks to the derive macro
     fn new(_: &mut Ctx, _: &mut VDPCtx, _oc: *mut ffi::objcore) -> InitResult<Self> {
@@ -37,11 +42,6 @@ impl VDP for Flipper {
         self.body.reverse();
         // send
         ctx.push(act, &self.body)
-    }
-
-    // return our id
-    fn name() -> &'static CStr {
-        c"flipper"
     }
 }
 

--- a/examples/vmod_vfp/src/lib.rs
+++ b/examples/vmod_vfp/src/lib.rs
@@ -14,6 +14,11 @@ struct Lower {}
 
 // implement the actual behavior of the VFP
 impl VFP for Lower {
+    // return our id
+    fn name() -> &'static CStr {
+        c"lower"
+    }
+
     // `new` is called when the VCL specifies "lower" in `beresp.filters`
     fn new(_: &mut Ctx, _: &mut VFPCtx) -> InitResult<Self> {
         InitResult::Ok(Lower {})
@@ -30,11 +35,6 @@ impl VFP for Lower {
             e.make_ascii_lowercase();
         }
         pull_res
-    }
-
-    // return our id
-    fn name() -> &'static CStr {
-        c"lower"
     }
 }
 

--- a/src/vcl/processor.rs
+++ b/src/vcl/processor.rs
@@ -57,18 +57,15 @@ pub enum InitResult<T> {
 }
 
 /// Describes a VDP
-pub trait VDP
-where
-    Self: Sized,
-{
+pub trait VDP: Sized {
+    /// The name of the processor.
+    fn name() -> &'static CStr;
     /// Create a new processor, possibly using knowledge from the pipeline, or from the current
     /// request.
     fn new(vrt_ctx: &mut Ctx, vdp_ctx: &mut VDPCtx, oc: *mut objcore) -> InitResult<Self>;
     /// Handle the data buffer from the previous processor. This function generally uses
     /// [`VDPCtx::push`] to push data to the next processor.
     fn push(&mut self, ctx: &mut VDPCtx, act: PushAction, buf: &[u8]) -> PushResult;
-    /// The name of the processor.
-    fn name() -> &'static CStr;
 }
 
 pub unsafe extern "C" fn gen_vdp_init<T: VDP>(
@@ -176,19 +173,14 @@ impl<'a> VDPCtx<'a> {
 }
 
 /// Describes a VFP
-pub trait VFP
-where
-    Self: Sized,
-{
+pub trait VFP: Sized {
+    /// The name of the processor.
+    fn name() -> &'static CStr;
     /// Create a new processor, possibly using knowledge from the pipeline
-    fn new(_vrt_ctx: &mut Ctx, _vfp_ctx: &mut VFPCtx) -> InitResult<Self> {
-        unimplemented!()
-    }
+    fn new(vrt_ctx: &mut Ctx, vfp_ctx: &mut VFPCtx) -> InitResult<Self>;
     /// Write data into `buf`, generally using `VFP_Suck` to collect data from the previous
     /// processor.
     fn pull(&mut self, ctx: &mut VFPCtx, buf: &mut [u8]) -> PullResult;
-    /// The name of the processor.
-    fn name() -> &'static CStr;
 }
 
 unsafe extern "C" fn wrap_vfp_init<T: VFP>(

--- a/vmod_test/src/lib.rs
+++ b/vmod_test/src/lib.rs
@@ -163,16 +163,16 @@ struct VFPTest {
 
 // Force a pass here to test to make sure that fini does not panic due to a null priv1 member
 impl VFP for VFPTest {
+    fn name() -> &'static CStr {
+        c"vfptest"
+    }
+
     fn new(_: &mut Ctx, _: &mut VFPCtx) -> InitResult<Self> {
         InitResult::Pass
     }
 
     fn pull(&mut self, _: &mut VFPCtx, _: &mut [u8]) -> PullResult {
         PullResult::Err
-    }
-
-    fn name() -> &'static CStr {
-        c"vfptest"
     }
 }
 


### PR DESCRIPTION
There is no reason to have a crashing code, when we can have compiler refuse to compile.

Also do a few tiny styling cleanups. Static `name` should probably be first, and `Sized` can use shorter notation