### PR TITLE
fail() should not return anything

### DIFF
--- a/examples/vmod_error/src/lib.rs
+++ b/examples/vmod_error/src/lib.rs
@@ -24,26 +24,29 @@ pub fn cannot_fail(_: &Ctx, fp: &str) -> i64 {
 pub fn manual_fail(ctx: &mut Ctx, fp: &str) -> i64 {
     // try to read the path at fp into a string, but return if there was an error
     let Ok(content) = read_to_string(fp) else {
-        return ctx
-            .fail("manual_fail: couldn't read file into string")
-            .into();
+        ctx.fail("manual_fail: couldn't read file into string");
+        return 0;
     };
 
     // try to convert the string into an i64
     // no need to return as the last expression is automatically returned
-    content
-        .parse::<i64>()
-        .unwrap_or_else(|_| ctx.fail("manual_fail: conversion failed").into())
+    let Ok(result) = content.parse::<i64>() else {
+        ctx.fail("manual_fail: conversion failed");
+        return 0;
+    };
+
+    result
 }
 
 // more idiomatic, we return a Result, and the generated boilerplate will be in charge of
 // calling `ctx.fail() and return a dummy value
 pub fn result_fail(_: &mut Ctx, fp: &str) -> Result<i64, String> {
-    read_to_string(fp) // read the file
-        .map_err(|e| format!("result_fail: {e}"))? // convert the error (if any!), into a string
-        // the ? will automatically return in case
-        // of an error
-        .parse::<i64>() // convert
-        .map_err(|e| format!("result_fail: {e}")) // map the type, and we are good to
-                                                  // automatically return
+    // read the file
+    read_to_string(fp)
+        // convert the error (if any!), into a string and return right away with the `?` operator
+        .map_err(|e| format!("result_fail: {e}"))?
+        // try to parse content into i64
+        .parse::<i64>()
+        // map the error to a string message and return either the parsed integer or that error
+        .map_err(|e| format!("result_fail: {e}"))
 }

--- a/varnish-sys/src/vcl/ctx.rs
+++ b/varnish-sys/src/vcl/ctx.rs
@@ -104,12 +104,11 @@ impl<'a> Ctx<'a> {
     ///
     /// Once the control goes back to Varnish, it will see that the transaction was marked as fail
     /// and will return a synthetic error to the client.
-    pub fn fail(&mut self, msg: impl AsRef<str>) -> u8 {
+    pub fn fail(&mut self, msg: impl AsRef<str>) {
         let msg = msg.as_ref();
         unsafe {
             VRT_fail(self.raw, c"%.*s".as_ptr(), msg.len(), msg.as_ptr());
         }
-        0
     }
 
     /// Log a message, attached to the current context

--- a/vmod_test/src/lib.rs
+++ b/vmod_test/src/lib.rs
@@ -125,8 +125,8 @@ pub fn cowprobe_prop(_ctx: &mut Ctx, probe: Option<COWProbe<'_>>) -> String {
         Some(probe) => format!(
             "{}-{}-{}-{}-{}-{}",
             match probe.request {
-                COWRequest::URL(url) => format!("url:{}", &url),
-                COWRequest::Text(text) => format!("text:{}", &text),
+                COWRequest::URL(url) => format!("url:{url}"),
+                COWRequest::Text(text) => format!("text:{text}"),
             },
             probe.threshold,
             probe.timeout.as_secs(),
@@ -143,8 +143,8 @@ pub fn probe_prop(_ctx: &mut Ctx, probe: Option<Probe>) -> String {
         Some(probe) => format!(
             "{}-{}-{}-{}-{}-{}",
             match probe.request {
-                Request::URL(url) => format!("url:{}", &url),
-                Request::Text(text) => format!("text:{}", &text),
+                Request::URL(url) => format!("url:{url}"),
+                Request::Text(text) => format!("text:{text}"),
             },
             probe.threshold,
             probe.timeout.as_secs(),


### PR DESCRIPTION
it seems `fail() -> u8` was a hack to benefit the `vmod_error` example.  `fail()` should not have any results.

Also, a minor unrelated fix - inlined format args in the test.