### PR TITLE
Remove warning as error flags for dev

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,0 @@
-[build]
-rustflags = "-D warnings"
-rustdocflags = "-D warnings"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUST_BACKTRACE: 1
+      RUSTDOCFLAGS: -D warnings
+      RUSTFLAGS: -D warnings
     steps:
       - uses: taiki-e/install-action@v2
         with: { tool: just }

--- a/varnish-sys/src/vcl/convert.rs
+++ b/varnish-sys/src/vcl/convert.rs
@@ -131,6 +131,8 @@ impl IntoVCL<VCL_STRING> for &[u8] {
     fn into_vcl(self, ws: &mut WS) -> Result<VCL_STRING, String> {
         // try to save some work if the buffer is already in the workspace
         // and if it ends in a null byte
+        // FIXME: UB here - we check if the value AFTER the slice is a null byte
+        //        in other words we access memory that is not ours. This is a bug.
         if unsafe { ws.is_slice_allocated(self) && *self.as_ptr().add(self.len()) == b'\0' } {
             Ok(self.as_ptr().cast::<c_char>())
         } else {


### PR DESCRIPTION
* It is better to allow warnings to stay as warnings while development, but fail warnings in CI
* Also, discovered a bug that I flagged without fixing, just so it won't be forgotten