### PR TITLE
Improve tests, adding glob support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Unpublished
 
-- `vtc!` macro now supports `VARNISHTEST_DURATION` env var, defaulting to "5s"
-- `vtc!` macro now supported debug mode, e.g. `vtc!(file, true)` - keeps the temporary files and always prints the output.
+- `vtc!` macro has been replaced with `run_vtc_tests!("tests/*.vtc")`:
+  - supports glob patterns
+  - supports `VARNISHTEST_DURATION` env var, defaulting to "5s"
+  - supports debug mode - keeps the temporary files and always prints the output: `run_vtc_tests!!("tests/*.vtc", true)`
 
 # 0.0.19 (2024-03-24)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ varnish-sys = { path = "./varnish-sys", version = "=0.0.19" }
 #
 # These dependencies are used by one or more crates, and easier to maintain in one place.
 bindgen = "0.70.1"
+glob = "0.3.1"
 pkg-config = "0.3.30"
 serde = { version = "1", features = ["derive"] }
 

--- a/examples/vmod_be/src/lib.rs
+++ b/examples/vmod_be/src/lib.rs
@@ -6,7 +6,7 @@ use std::error::Error;
 
 use varnish::vcl::{Backend, Ctx, Serve, Transfer, VCLBackendPtr};
 
-varnish::vtc!(test01);
+varnish::run_vtc_tests!("tests/*.vtc");
 
 // parrot is our VCL object, which just holds a rust Backend,
 // it only needs two functions:

--- a/examples/vmod_error/src/lib.rs
+++ b/examples/vmod_error/src/lib.rs
@@ -4,7 +4,7 @@ use std::fs::read_to_string;
 
 use varnish::vcl::Ctx;
 
-varnish::vtc!(test01);
+varnish::run_vtc_tests!("tests/*.vtc");
 
 // no error, just return 0 if anything goes wrong
 pub fn cannot_fail(_: &Ctx, fp: &str) -> i64 {

--- a/examples/vmod_event/src/lib.rs
+++ b/examples/vmod_event/src/lib.rs
@@ -2,7 +2,7 @@ varnish::boilerplate!();
 
 use varnish::vcl::{Ctx, Event, LogTag, VPriv};
 
-varnish::vtc!(test01);
+varnish::run_vtc_tests!("tests/*.vtc");
 
 // number of times event() was run with Event::Load
 // event will increment it and store a VCL-local copy via VPriv, that loaded() will be able to

--- a/examples/vmod_example/src/lib.rs
+++ b/examples/vmod_example/src/lib.rs
@@ -56,5 +56,5 @@ mod tests {
     }
 
     // we also want to run test/test01.vtc
-    varnish::vtc!(test01);
+    varnish::run_vtc_tests!("tests/*.vtc");
 }

--- a/examples/vmod_infiniteloop/src/lib.rs
+++ b/examples/vmod_infiniteloop/src/lib.rs
@@ -3,7 +3,7 @@ varnish::boilerplate!();
 use varnish::ffi::{BUSYOBJ_MAGIC, REQ_MAGIC};
 use varnish::vcl::Ctx;
 
-varnish::vtc!(test01);
+varnish::run_vtc_tests!("tests/*.vtc");
 
 /// # Safety
 /// this function is unsafe from the varnish point of view, doing away with

--- a/examples/vmod_object/src/lib.rs
+++ b/examples/vmod_object/src/lib.rs
@@ -9,8 +9,7 @@ use std::sync::Mutex;
 use varnish::ffi::VCL_STRING;
 use varnish::vcl::{Ctx, IntoVCL};
 
-varnish::vtc!(test01);
-varnish::vtc!(test02);
+varnish::run_vtc_tests!("tests/*.vtc");
 
 const EMPTY_STRING: String = String::new();
 

--- a/examples/vmod_timestamp/src/lib.rs
+++ b/examples/vmod_timestamp/src/lib.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 
 use varnish::vcl::{Ctx, VPriv};
 
-varnish::vtc!(test01);
+varnish::run_vtc_tests!("tests/*.vtc");
 
 // VPriv can wrap any (possibly custom) struct, here we only need an Instant from std::time.
 // Storing and getting is up to the vmod writer but this removes the worry of NULL dereferencing

--- a/examples/vmod_vdp/src/lib.rs
+++ b/examples/vmod_vdp/src/lib.rs
@@ -5,7 +5,7 @@ use std::ffi::CStr;
 use varnish::ffi;
 use varnish::vcl::{new_vdp, Ctx, Event, InitResult, PushAction, PushResult, VDPCtx, VPriv, VDP};
 
-varnish::vtc!(test01);
+varnish::run_vtc_tests!("tests/*.vtc");
 
 // declare a new struct that will buffer the response body
 #[derive(Default)]

--- a/examples/vmod_vfp/src/lib.rs
+++ b/examples/vmod_vfp/src/lib.rs
@@ -5,7 +5,7 @@ use std::ffi::CStr;
 use varnish::ffi;
 use varnish::vcl::{new_vfp, Ctx, Event, InitResult, PullResult, VFPCtx, VPriv, VFP};
 
-varnish::vtc!(test01);
+varnish::run_vtc_tests!("tests/*.vtc");
 
 // here, we don't actually need a struct to hold data, just to implement some methods
 struct Lower {}

--- a/varnish/Cargo.toml
+++ b/varnish/Cargo.toml
@@ -14,6 +14,7 @@ license.workspace = true
 default = []
 
 [dependencies]
+glob.workspace = true
 pkg-config.workspace = true
 varnish-sys.workspace = true
 

--- a/varnish/src/varnishtest.rs
+++ b/varnish/src/varnishtest.rs
@@ -1,0 +1,99 @@
+use std::env;
+use std::env::consts::{DLL_PREFIX, DLL_SUFFIX};
+use std::ffi::OsString;
+use std::fmt::Write as _;
+use std::io::{stderr, stdout, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use glob::glob;
+
+/// Run all tests that match the glob pattern
+pub fn run_all_tests(
+    ld_library_paths: &str,
+    vmod_name: &str,
+    glob_path: &str,
+    timeout: &str,
+    debug: bool,
+) -> Result<(), String> {
+    let vmod_lib_name = format!("{DLL_PREFIX}{vmod_name}{DLL_SUFFIX}");
+    let vmod_path = find_vmod_lib(&vmod_lib_name, ld_library_paths)?;
+    let mut found = false;
+    let mut failed = Vec::new();
+    for test in
+        glob(glob_path).map_err(|e| format!("Failed to find any tests in '{glob_path}': {e}"))?
+    {
+        found = true;
+        let file = test.map_err(|e| format!("Failed to get test path: {e}"))?;
+        if let Err(err) = run_varnish_test(&vmod_path, &file, timeout, debug) {
+            failed.push(format!("{}: {err}", file.display()));
+            eprintln!("{err}");
+        }
+    }
+
+    if !found {
+        Err(format!("No tests found in '{glob_path}'"))
+    } else if failed.is_empty() {
+        Ok(())
+    } else {
+        let mut err = String::new();
+        if failed.len() > 1 {
+            // If we only had one failed test, we already printed the error
+            let _ = write!(err, "{} tests failed:", failed.len());
+            for f in failed {
+                let _ = write!(err, "{f}");
+            }
+        }
+        Err(err)
+    }
+}
+
+pub fn run_varnish_test(
+    vmod_path: &Path,
+    testfile: &Path,
+    timeout: &str,
+    debug: bool,
+) -> Result<(), String> {
+    eprintln!("Running varnishtest {}", testfile.display());
+    let mut cmd = Command::new("varnishtest");
+    if debug {
+        // Keep output, and run in verbose mode
+        cmd.arg("-L").arg("-v");
+    }
+
+    let mut vmod_arg = OsString::from("vmod=");
+    vmod_arg.push(vmod_path);
+
+    cmd.arg("-D")
+        .arg(vmod_arg)
+        .arg(testfile)
+        .env("VARNISHTEST_DURATION", timeout);
+
+    let output = cmd
+        .output()
+        .map_err(|e| format!("Failed to run varnishtest:\n{cmd:?}\n{e}"))?;
+
+    if debug || !output.status.success() {
+        stdout().write_all(&output.stdout).unwrap();
+        stderr().write_all(&output.stderr).unwrap();
+    }
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "varnishtest {} failed\n{cmd:?}",
+            testfile.display()
+        ))
+    }
+}
+
+/// Find the vmod so file
+pub fn find_vmod_lib(vmod_lib_name: &str, ld_library_paths: &str) -> Result<PathBuf, String> {
+    env::split_paths(ld_library_paths)
+        .map(|p| p.join(vmod_lib_name))
+        .find(|p| p.exists())
+        .ok_or_else(|| {
+            format!("Unable to find {vmod_lib_name} in {ld_library_paths}\nHave you built your vmod first?")
+        })
+}

--- a/vmod_test/src/lib.rs
+++ b/vmod_test/src/lib.rs
@@ -11,13 +11,7 @@ use varnish::vcl::{
     VPriv, VclResult, VFP,
 };
 
-varnish::vtc!(test01);
-varnish::vtc!(test02);
-varnish::vtc!(test03);
-varnish::vtc!(test04);
-varnish::vtc!(test05);
-varnish::vtc!(test06);
-varnish::vtc!(test07);
+varnish::run_vtc_tests!("tests/*.vtc");
 
 pub fn set_hdr(ctx: &mut Ctx, name: &str, value: &str) -> VclResult<()> {
     if let Some(ref mut req) = ctx.http_req {


### PR DESCRIPTION
Use proper strings and full paths to run unit tests. Ensures that all test files are executed, rather than forcing devs to remember to add a new .vtc file to the list. Fill fail if no files are found. Also allows users to do their own testing using function calls.

```rust
varnish::run_vtc_tests!("tests/*.vtc");
```