### PR TITLE
Document macro-based approach, bump to v0.1.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,8 +37,7 @@ jobs:
           curl -s https://packagecloud.io/install/repositories/varnishcache/${{ matrix.setup }}/script.deb.sh | sudo bash
           sudo apt-get install -y varnish-dev
       - run: just -v ci-test
-      - name: Check semver (disabled)
-        if: false  # FIXME: This should be enabled to ensure semver compliance
+      - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
 
   # Ensure that the docs can be built at docs.rs without varnish dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,21 @@
 # Unpublished
 
+- Introduce a new, vastly improved system of generating boilerplate code using a procedural macro `#[varnish(vmod)]` by @nyurik
+  - The macro will generate all the boilerplate code for a Varnish VMOD
+  - The macro attribute must be used on a `mod` block that contains the VMOD functions
+  - The macro can generate a markdown file, e.g. `#[varnish(docs = "README.md")]`
+  - All examples have been [updated](https://github.com/gquintard/varnish-rs/commit/f0f0120d3fddbdad491ff80fccbfdd1930d24dc6) to use the new system
+  - See [crate documentation](https://docs.rs/varnish/latest/varnish/) for more details 
 - `vtc!` macro has been replaced with `run_vtc_tests!("tests/*.vtc")`:
   - supports glob patterns
   - supports `VARNISHTEST_DURATION` env var, defaulting to "5s"
   - supports debug mode - keeps the temporary files and always prints the output: `run_vtc_tests!!("tests/*.vtc", true)`
+- Multi-version support for `libvarnish` headers now allows the same code to be used with Varnish v7.4, v7.5, and v7.6
 
 # 0.0.19 (2024-03-24)
 
-- vsc::Error implements std::Error
-- improve vtc!() debuggability
+- `vsc::Error` implements `std::Error`
+- improve `vtc!()` debuggability
 - use newer `bindgen`
 
 # 0.0.18 (2024-03-19)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,16 +6,16 @@ members = ["varnish", "varnish-macros", "varnish-sys", "vmod_test", "examples/vm
 [workspace.package]
 # These fields are used by multiple crates, so it's defined here.
 # Version must also be updated in the `varnish-macros` dependency below.
-version = "0.0.19"
+version = "0.1.0"
 repository = "https://github.com/gquintard/varnish-rs"
 edition = "2021"
 license = "BSD-3-Clause"
 
 [workspace.dependencies]
 # These versions must match the one in the [workspace.package] section above
-varnish = { path = "./varnish", version = "=0.0.19" }
-varnish-macros = { path = "./varnish-macros", version = "=0.0.19" }
-varnish-sys = { path = "./varnish-sys", version = "=0.0.19" }
+varnish = { path = "./varnish", version = "0.1.0" }
+varnish-macros = { path = "./varnish-macros", version = "0.1.0" }
+varnish-sys = { path = "./varnish-sys", version = "0.1.0" }
 #
 # These dependencies are used by one or more crates, and easier to maintain in one place.
 bindgen = "0.70.1"

--- a/README.md
+++ b/README.md
@@ -1,21 +1,14 @@
+# varnish-rs
+
 [![GitHub](https://img.shields.io/badge/github-varnish-8da0cb?logo=github)](https://github.com/gquintard/varnish-rs)
 [![crates.io version](https://img.shields.io/crates/v/varnish.svg)](https://crates.io/crates/varnish)
 [![docs.rs docs](https://docs.rs/varnish/badge.svg)](https://docs.rs/varnish)
 [![crates.io version](https://img.shields.io/crates/l/varnish.svg)](https://github.com/gquintard/varnish-rs/blob/main/LICENSE)
 [![CI build](https://github.com/gquintard/varnish-rs/actions/workflows/tests.yaml/badge.svg)](https://github.com/gquintard/varnish-rs/actions)
 
-[Documentation](https://docs.rs/varnish/)
+This library provides a safe and idiomatic interface to the [Varnish](https://varnish-cache.org/intro/index.html) C API, allowing you to write Varnish modules (VMODs) in Rust. See the [crate documentation](https://docs.rs/varnish) for more details.
 
-In your `Cargo.toml`:
-
-```
-[dependencies]
-varnish = "0.0.16"
-```
-
-# varnish-rs
-
-Varnish bindings, notably to build vmods, such as:
+Some VMODs that use this library:
 
 - [vmod-reqwest](https://github.com/gquintard/vmod_reqwest): issue HTTP calls from VCL, use dynamic, HTTPS backends (support HTTP2)
 - [vmod-rers](https://github.com/gquintard/vmod_rers): support for dynamic regex, including response body manipulation
@@ -25,15 +18,19 @@ Don't hesitate to open GitHub issues if something is unclear or impractical. You
 
 ## Requirements
 
-### Rust
+When compiling, this library generates bindings from the `libvarnish` headers. Depending on you Linux distribution, you may need to install the related package, which could be named `varnish-devel`, `varnish-dev` or maybe `libvarnish-dev`.
 
-`varnish-rs` works on stable Rust and should be fine with more recent versions too. If it doesn't, please open an issue.
+Before v0.1.0, this library relied on a specific version of `libvarnish`. Since v0.1.0, this is no longer the case, and it should work with multiple supported Varnish versions.
 
-### Varnish
-
-`varnish-rs` relies on `varnish-sys` (in this same repository) to generate bindings from the `libvarnish` headers which you will need to install, depending on you linux distribution, the related package can be named `varnish-devel`, `varnish-dev` or maybe `libvarnish-dev`.
-
-Right now, the only Varnish versions supported are `7.*`.
+| varnish-rs (Rust) | libvarnish (C) |
+|:-----------------:|:--------------:|
+|       0.1.0       |   7.4 - 7.6    |
+|  0.0.18 - 0.0.19  |      7.5       |
+|      0.0.17       |      7.4       |
+|  0.0.15 - 0.0.16  |      7.3       |
+|  0.0.12 - 0.0.14  |      7.2       |
+|  0.0.9 - 0.0.11   |      7.1       |
+|   0.0.0 - 0.0.8   |      7.0       |
 
 ## Development
 
@@ -42,33 +39,8 @@ Right now, the only Varnish versions supported are `7.*`.
 * To get a list of available commands, run `just`.
 * To run tests, use `just test`.
 
-``` bash
-git clone https://github.com/gquintard/varnish-rs.git
-cd varnish-rs
-cargo build
-```
-
-If your `varnish` headers are installed where `pkg-config` can find them, it's all there is to it. If not, you can set the `VARNISH_INCLUDE_PATHS` environment variable to a colon-separated list of paths to search:
+It is recommended if your `varnish` headers are installed where `pkg-config` can find them.  If not, you can set the `VARNISH_INCLUDE_PATHS` environment variable to a colon-separated list of paths to search, but note that `build.rs` script cannot detect `libvarnish` version, and assumes the latest.
 
 ```
 VARNISH_INCLUDE_PATHS=/my/custom/libpath:/my/other/custom/libpath cargo build
-```
-
-## Versions
-
-The `varnish-rs` and `varnish-sys` versions will work in tandem: to build version X of `varnish`, you need version X of `varnish-rs` and of `varnish-sys`, in turn `varnish-sys` will depend on a specific Varnish C library version:
-
-| varnish-rs/varnish-sys (rust) | libvarnish (C) |
-|:-----------------------------:|:--------------:|
-|       0.0.18 -> 0.0.19        |      7.5       |
-|            0.0.17             |      7.4       |
-|       0.0.15 -> 0.0.16        |      7.3       |
-|       0.0.12 -> 0.0.14        |      7.2       |
-|        0.0.9 -> 0.0.11        |      7.1       |
-|             0.0.*             |      7.0       |
-
-You can check which Varnish version is required using the `libvarnish` metadata field of `varnish-sys`:
-
-``` bash
-cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "varnish-sys") | .metadata.libvarnishapi.version '
 ```

--- a/varnish-sys/src/vcl/convert.rs
+++ b/varnish-sys/src/vcl/convert.rs
@@ -6,7 +6,8 @@
 //! the type conversions defined here. The values need to be converted from Varnish's internal types
 //! to Rust's types, and vice versa.
 //!
-//! The  `IntoVCL` trait take care of converting a Rust type into VCL. It requires a `&mut `[`WS`]
+//! Most conversions from VCL to Rust are straightforward, using either `From` or `TryFrom` traits.
+//! The `IntoVCL` trait take care of converting a Rust type into VCL. It requires a `&mut `[`WS`]
 //! to possibly store the returned value into the task request. This allows vmod writes to just return
 //! easy-to-work-with strings, and let the boilerplate handle the allocation, copy and error handling.
 //!

--- a/varnish-sys/src/vcl/convert.rs
+++ b/varnish-sys/src/vcl/convert.rs
@@ -2,14 +2,13 @@
 //!
 //! # Type conversion
 //!
-//! To allow for easier development the generated boilerplate will handle conversion between the
-//! lightly disguised C types used by `vmod.vcc` into regular Rust, and it will also do the
-//! opposite conversion when it is time to send the return value to Varnish.
+//! The proc macro will generate the wrappers for each user function, relying on
+//! the type conversions defined here. The values need to be converted from Varnish's internal types
+//! to Rust's types, and vice versa.
 //!
-//! The two traits `IntoVCL` and `IntoRust` take care of this, with `IntoVCL` being notable in
-//! that it requires a `&mut `[`WS`] to possibly store the returned value into the task
-//! request. This allows vmod writes to just return easy-to-work-with `Strings` and let the
-//! boilerplate handle the allocation, copy and error handling.
+//! The  `IntoVCL` trait take care of converting a Rust type into VCL. It requires a `&mut `[`WS`]
+//! to possibly store the returned value into the task request. This allows vmod writes to just return
+//! easy-to-work-with strings, and let the boilerplate handle the allocation, copy and error handling.
 //!
 //! If one wants to handle things manually, all `VCL_*` types implement [`IntoVCL`] as a no-op. It
 //! can be useful to avoid extra memory allocations by the boilerplate, if that is a worry.
@@ -18,12 +17,11 @@
 //!
 //! | Rust | direction | VCL |
 //! | :--: | :-------: | :-:
+//! | `()` | -> | `VCL_VOID` |
 //! | `f64`  | <-> | `VCL_REAL` |
 //! | `i64`  | <-> | `VCL_INT` |
-//! | `i64`  | <-> | `VCL_BYTES` |
 //! | `bool` | <-> | `VCL_BOOL` |
 //! | `std::time::Duration` | <-> | `VCL_DURATION` |
-//! | `()` | <-> | `VOID` |
 //! | `&str` | <-> | `VCL_STRING` |
 //! | `String` | -> | `VCL_STRING` |
 //! | `Option<COWProbe>` | <-> | `VCL_PROBE` |

--- a/varnish/src/lib.rs
+++ b/varnish/src/lib.rs
@@ -32,10 +32,10 @@
 //!
 //! ``` toml
 //! [build-dependencies]
-//! varnish = "0.0.19"
+//! varnish = "0.1.0"
 //!
 //! [dependencies]
-//! varnish = "0.0.19"
+//! varnish = "0.1.0"
 //! ```
 //!
 //! ## vmod.vcc


### PR DESCRIPTION
* Add lots of documentation on how to use the new macro-based approach
* This ensures the main branch is always conforming with the semver rules - if the API is breaking, it must increment minor (for 0.*.*), and major (for 1+.*.*).  See https://github.com/obi1kenobi/cargo-semver-checks