### PR TITLE
Support varnish 7.4, 7.5, and 7.6 in one package

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,6 +12,13 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - setup: varnish74
+          - setup: varnish75
+          - setup: varnish76
     env:
       RUST_BACKTRACE: 1
       RUSTDOCFLAGS: -D warnings
@@ -27,7 +34,7 @@ jobs:
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
       - name: install varnish-dev
         run: |
-          curl -s https://packagecloud.io/install/repositories/varnishcache/varnish75/script.deb.sh | sudo bash
+          curl -s https://packagecloud.io/install/repositories/varnishcache/${{ matrix.setup }}/script.deb.sh | sudo bash
           sudo apt-get install -y varnish-dev
       - run: just -v ci-test
       - name: Check semver (disabled)

--- a/examples/vmod_vdp/src/lib.rs
+++ b/examples/vmod_vdp/src/lib.rs
@@ -22,7 +22,7 @@ impl VDP for Flipper {
 
     // `new` is called when the VCL specifies "flipper" in `resp.filters`
     // just return a default struct, thanks to the derive macro
-    fn new(_: &mut Ctx, _: &mut VDPCtx, _oc: *mut ffi::objcore) -> InitResult<Self> {
+    fn new(_: &mut Ctx, _: &mut VDPCtx) -> InitResult<Self> {
         InitResult::Ok(Flipper::default())
     }
 

--- a/justfile
+++ b/justfile
@@ -41,10 +41,6 @@ build:
 test: build
     cargo test --workspace --all-targets
 
-test-all-features: test
-    cargo build --workspace --all-targets --all-features
-    cargo test --workspace --all-targets --all-features
-
 # Test documentation
 test-doc:
     cargo test --doc
@@ -55,7 +51,7 @@ rust-info:
     cargo --version
 
 # Run all tests as expected by CI
-ci-test: rust-info test-fmt clippy test-all-features test-doc
+ci-test: rust-info test-fmt clippy test test-doc
 
 # Verify that the current version of the crate is not the same as the one published on crates.io
 check-if-published:

--- a/varnish-sys/Cargo.toml
+++ b/varnish-sys/Cargo.toml
@@ -9,6 +9,10 @@ repository.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+default = []
+objcore_in_init = []  # <=7.5 passed *objcore in vdp_init_f as the 4th param
+
 [lib]
 name = "varnish_sys"
 

--- a/varnish-sys/build.rs
+++ b/varnish-sys/build.rs
@@ -5,27 +5,45 @@ fn main() {
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
 
     println!("cargo:rerun-if-env-changed=VARNISH_INCLUDE_PATHS");
-    let varnish_paths: Vec<PathBuf> = match env::var("VARNISH_INCLUDE_PATHS") {
-        Ok(s) => s.split(':').map(PathBuf::from).collect(),
-        Err(_) => {
-            match pkg_config::Config::new()
-                .atleast_version("7.5")
-                .probe("varnishapi")
-            {
-                Ok(l) => l.include_paths,
-                Err(e) => {
-                    // See https://docs.rs/about/builds#detecting-docsrs
-                    if env::var("DOCS_RS").is_ok() {
-                        eprintln!("libvarnish not found, using saved bindings for the doc.rs: {e}");
-                        std::fs::copy("src/bindings.rs.saved", out_path).unwrap();
-                        return;
-                    }
-                    // FIXME: we should give a URL describing how to install varnishapi
-                    // I tried to find it, but failed to find a clear URL for this.
-                    panic!(
-                        "pkg_config failed to find varnishapi, make sure it is installed: {e:?}"
-                    );
+    let varnish_paths: Vec<PathBuf> = if let Ok(s) = env::var("VARNISH_INCLUDE_PATHS") {
+        // FIXME: If the user has set the VARNISH_INCLUDE_PATHS environment variable, use that.
+        //    At the moment we have no way to detect which version it is.
+        //    vmod_abi.h  seems to have this line, which can be used in the future.
+        //    #define VMOD_ABI_Version "Varnish 7.5.0 eef25264e5ca5f96a77129308edb83ccf84cb1b1"
+        s.split(':').map(PathBuf::from).collect()
+    } else {
+        let pkg = pkg_config::Config::new();
+        match pkg.probe("varnishapi") {
+            Ok(l) => {
+                // version is "7.5.0" and similar
+                let mut version = l.version.split('.');
+                let major = version
+                    .next()
+                    .expect("varnishapi invalid version major")
+                    .parse::<u32>()
+                    .expect("varnishapi invalid version major number");
+                let minor = version
+                    .next()
+                    .expect("varnishapi invalid version minor")
+                    .parse::<u32>()
+                    .expect("varnishapi invalid version minor number");
+                println!("cargo::metadata=version_number={}", l.version);
+                if major == 7 && minor <= 5 {
+                    println!("cargo::rustc-cfg=feature=\"objcore_in_init\"");
                 }
+                l.include_paths
+            }
+            Err(e) => {
+                // See https://docs.rs/about/builds#detecting-docsrs
+                if env::var("DOCS_RS").is_ok() {
+                    eprintln!("libvarnish not found, using saved bindings for the doc.rs: {e}");
+                    std::fs::copy("src/bindings.rs.saved", out_path).unwrap();
+                    println!("cargo::metadata=version_number=7.6.0");
+                    return;
+                }
+                // FIXME: we should give a URL describing how to install varnishapi
+                // I tried to find it, but failed to find a clear URL for this.
+                panic!("pkg_config failed to find varnishapi, make sure it is installed: {e:?}");
             }
         }
     };

--- a/varnish-sys/src/bindings.rs.saved
+++ b/varnish-sys/src/bindings.rs.saved
@@ -136,7 +136,6 @@ pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
-pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
 pub const _STDC_PREDEF_H: u32 = 1;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_60559_BFP__: u32 = 201404;
@@ -145,7 +144,7 @@ pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 39;
+pub const __GLIBC_MINOR__: u32 = 36;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
@@ -419,8 +418,6 @@ pub const SO_BUF_LOCK: u32 = 72;
 pub const SO_RESERVE_MEM: u32 = 73;
 pub const SO_TXREHASH: u32 = 74;
 pub const SO_RCVMARK: u32 = 75;
-pub const SO_PASSPIDFD: u32 = 76;
-pub const SO_PEERPIDFD: u32 = 77;
 pub const SO_TIMESTAMP: u32 = 29;
 pub const SO_TIMESTAMPNS: u32 = 35;
 pub const SO_TIMESTAMPING: u32 = 37;
@@ -509,14 +506,14 @@ pub const __jmp_buf_tag_defined: u32 = 1;
 pub const PTHREAD_STACK_MIN: u32 = 16384;
 pub const PTHREAD_ONCE_INIT: u32 = 0;
 pub const PTHREAD_BARRIER_SERIAL_THREAD: i32 = -1;
+pub const __GNUC_VA_LIST: u32 = 1;
 pub const VRT_INTEGER_MAX: u64 = 999999999999999;
 pub const VRT_INTEGER_MIN: i64 = -999999999999999;
-pub const VRT_MAJOR_VERSION: u32 = 19;
+pub const VRT_MAJOR_VERSION: u32 = 20;
 pub const VRT_MINOR_VERSION: u32 = 0;
 pub const _STDINT_H: u32 = 1;
 pub const _BITS_WCHAR_H: u32 = 1;
 pub const _BITS_STDINT_UINTN_H: u32 = 1;
-pub const _BITS_STDINT_LEAST_H: u32 = 1;
 pub const INT8_MIN: i32 = -128;
 pub const INT16_MIN: i32 = -32768;
 pub const INT32_MIN: i32 = -2147483648;
@@ -772,7 +769,7 @@ pub const VDP_CTX_MAGIC: u32 = 3998227959;
 #[allow(unsafe_code)]
 pub const VMOD_ABI_Version: &::std::ffi::CStr = unsafe {
     ::std::ffi::CStr::from_bytes_with_nul_unchecked(
-        b"Varnish 7.5.0 eef25264e5ca5f96a77129308edb83ccf84cb1b1\0",
+        b"Varnish 7.6.0 ed1243ca162a7b1d975bc0332f0d66d33f0bc78e\0",
     )
 };
 pub const VSB_MAGIC: u32 = 1250090378;
@@ -801,6 +798,8 @@ pub const VSM_MGT_RESTARTED: u32 = 8;
 pub const VSM_WRK_RUNNING: u32 = 512;
 pub const VSM_WRK_CHANGED: u32 = 1024;
 pub const VSM_WRK_RESTARTED: u32 = 2048;
+pub const VSM_MGT_MASK: u32 = 255;
+pub const VSM_WRK_MASK: u32 = 65280;
 pub const HTTP_CONN_MAGIC: u32 = 1041886673;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -4116,8 +4115,8 @@ extern "C" {
         __child: ::std::option::Option<unsafe extern "C" fn()>,
     ) -> ::std::ffi::c_int;
 }
-pub type __gnuc_va_list = __builtin_va_list;
 pub type va_list = __builtin_va_list;
+pub type __gnuc_va_list = __builtin_va_list;
 pub type wchar_t = ::std::ffi::c_int;
 #[repr(C)]
 #[repr(align(16))]
@@ -4633,13 +4632,15 @@ pub struct vrt_backend {
     pub connect_timeout: vtim_dur,
     pub first_byte_timeout: vtim_dur,
     pub between_bytes_timeout: vtim_dur,
+    pub backend_wait_timeout: vtim_dur,
     pub max_connections: ::std::ffi::c_uint,
     pub proxy_header: ::std::ffi::c_uint,
+    pub backend_wait_limit: ::std::ffi::c_uint,
     pub probe: VCL_PROBE,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of vrt_backend"][::std::mem::size_of::<vrt_backend>() - 80usize];
+    ["Size of vrt_backend"][::std::mem::size_of::<vrt_backend>() - 96usize];
     ["Alignment of vrt_backend"][::std::mem::align_of::<vrt_backend>() - 8usize];
     ["Offset of field: vrt_backend::magic"][::std::mem::offset_of!(vrt_backend, magic) - 0usize];
     ["Offset of field: vrt_backend::endpoint"]
@@ -4656,11 +4657,15 @@ const _: () = {
         [::std::mem::offset_of!(vrt_backend, first_byte_timeout) - 48usize];
     ["Offset of field: vrt_backend::between_bytes_timeout"]
         [::std::mem::offset_of!(vrt_backend, between_bytes_timeout) - 56usize];
+    ["Offset of field: vrt_backend::backend_wait_timeout"]
+        [::std::mem::offset_of!(vrt_backend, backend_wait_timeout) - 64usize];
     ["Offset of field: vrt_backend::max_connections"]
-        [::std::mem::offset_of!(vrt_backend, max_connections) - 64usize];
+        [::std::mem::offset_of!(vrt_backend, max_connections) - 72usize];
     ["Offset of field: vrt_backend::proxy_header"]
-        [::std::mem::offset_of!(vrt_backend, proxy_header) - 68usize];
-    ["Offset of field: vrt_backend::probe"][::std::mem::offset_of!(vrt_backend, probe) - 72usize];
+        [::std::mem::offset_of!(vrt_backend, proxy_header) - 76usize];
+    ["Offset of field: vrt_backend::backend_wait_limit"]
+        [::std::mem::offset_of!(vrt_backend, backend_wait_limit) - 80usize];
+    ["Offset of field: vrt_backend::probe"][::std::mem::offset_of!(vrt_backend, probe) - 88usize];
 };
 impl Default for vrt_backend {
     fn default() -> Self {
@@ -7774,7 +7779,6 @@ pub type vdp_init_f = ::std::option::Option<
         ctx: *const vrt_ctx,
         arg1: *mut vdp_ctx,
         priv_: *mut *mut ::std::ffi::c_void,
-        arg2: *mut objcore,
     ) -> ::std::ffi::c_int,
 >;
 pub type vdp_fini_f = ::std::option::Option<
@@ -7911,11 +7915,13 @@ pub struct vdp_ctx {
     pub nxt: *mut vdp_entry,
     pub wrk: *mut worker,
     pub vsl: *mut vsl_log,
-    pub req: *mut req,
+    pub oc: *mut objcore,
+    pub hp: *mut http,
+    pub clen: *mut intmax_t,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of vdp_ctx"][::std::mem::size_of::<vdp_ctx>() - 64usize];
+    ["Size of vdp_ctx"][::std::mem::size_of::<vdp_ctx>() - 80usize];
     ["Alignment of vdp_ctx"][::std::mem::align_of::<vdp_ctx>() - 8usize];
     ["Offset of field: vdp_ctx::magic"][::std::mem::offset_of!(vdp_ctx, magic) - 0usize];
     ["Offset of field: vdp_ctx::retval"][::std::mem::offset_of!(vdp_ctx, retval) - 4usize];
@@ -7924,7 +7930,9 @@ const _: () = {
     ["Offset of field: vdp_ctx::nxt"][::std::mem::offset_of!(vdp_ctx, nxt) - 32usize];
     ["Offset of field: vdp_ctx::wrk"][::std::mem::offset_of!(vdp_ctx, wrk) - 40usize];
     ["Offset of field: vdp_ctx::vsl"][::std::mem::offset_of!(vdp_ctx, vsl) - 48usize];
-    ["Offset of field: vdp_ctx::req"][::std::mem::offset_of!(vdp_ctx, req) - 56usize];
+    ["Offset of field: vdp_ctx::oc"][::std::mem::offset_of!(vdp_ctx, oc) - 56usize];
+    ["Offset of field: vdp_ctx::hp"][::std::mem::offset_of!(vdp_ctx, hp) - 64usize];
+    ["Offset of field: vdp_ctx::clen"][::std::mem::offset_of!(vdp_ctx, clen) - 72usize];
 };
 impl Default for vdp_ctx {
     fn default() -> Self {

--- a/varnish/Cargo.toml
+++ b/varnish/Cargo.toml
@@ -10,9 +10,6 @@ repository.workspace = true
 edition.workspace = true
 license.workspace = true
 
-[features]
-default = []
-
 [dependencies]
 glob.workspace = true
 pkg-config.workspace = true


### PR DESCRIPTION
Detect which varnish is installed, and generate appropriate code.

Adds CI tests for `7.[456]` versions

Note that this also updates the saved bindings to 7.6 - used only when generating docs.