### PR TITLE
Rename varnish-sys features (internal)

### DIFF
--- a/varnish-sys/Cargo.toml
+++ b/varnish-sys/Cargo.toml
@@ -11,7 +11,10 @@ license.workspace = true
 
 [features]
 default = []
-objcore_in_init = []  # <=7.5 passed *objcore in vdp_init_f as the 4th param
+#
+# These features are used to match the lib to the various Varnish API versions.
+# They are set in the build.rs file and should not be used directly by the user.
+_objcore_in_init = []  # <=7.5 passed *objcore in vdp_init_f as the 4th param
 
 [lib]
 name = "varnish_sys"

--- a/varnish-sys/build.rs
+++ b/varnish-sys/build.rs
@@ -29,7 +29,7 @@ fn main() {
                     .expect("varnishapi invalid version minor number");
                 println!("cargo::metadata=version_number={}", l.version);
                 if major == 7 && minor <= 5 {
-                    println!("cargo::rustc-cfg=feature=\"objcore_in_init\"");
+                    println!("cargo::rustc-cfg=feature=\"_objcore_in_init\"");
                 }
                 l.include_paths
             }

--- a/varnish-sys/src/vcl/processor.rs
+++ b/varnish-sys/src/vcl/processor.rs
@@ -70,7 +70,7 @@ pub unsafe extern "C" fn gen_vdp_init<T: VDP>(
     vrt_ctx: *const ffi::vrt_ctx,
     ctx_raw: *mut vdp_ctx,
     priv_: *mut *mut c_void,
-    #[cfg(feature = "objcore_in_init")] _oc: *mut ffi::objcore,
+    #[cfg(feature = "_objcore_in_init")] _oc: *mut ffi::objcore,
 ) -> c_int {
     assert_ne!(priv_, ptr::null_mut());
     assert_eq!(*priv_, ptr::null_mut());


### PR DESCRIPTION
Highlight that the build features should be set by build.rs only, not the user.