### PR TITLE
Cleanup generated enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ varnish-sys = { path = "./varnish-sys", version = "=0.0.19" }
 #
 # These dependencies are used by one or more crates, and easier to maintain in one place.
 bindgen = "0.70.1"
+convert_case = "0.6.0"
 darling = "0.20.10"
 glob = "0.3.1"
 insta = "1"

--- a/examples/vmod_vdp/src/lib.rs
+++ b/examples/vmod_vdp/src/lib.rs
@@ -1,6 +1,7 @@
 use std::ffi::CStr;
 
-use varnish::vcl::{Ctx, InitResult, PushAction, PushResult, VDPCtx, VDP};
+use varnish::ffi::VdpAction;
+use varnish::vcl::{Ctx, InitResult, PushResult, VDPCtx, VDP};
 
 varnish::run_vtc_tests!("tests/*.vtc");
 
@@ -65,12 +66,12 @@ impl VDP for Flipper {
     }
 
     // buffer everything, then reverse the buffer, and send it, easy
-    fn push(&mut self, ctx: &mut VDPCtx, act: PushAction, buf: &[u8]) -> PushResult {
+    fn push(&mut self, ctx: &mut VDPCtx, act: VdpAction, buf: &[u8]) -> PushResult {
         // ingest everything we're given
         self.body.extend_from_slice(buf);
 
         // nod along if it isn't the last call
-        if !matches!(act, PushAction::End) {
+        if !matches!(act, VdpAction::End) {
             return PushResult::Ok;
         }
 

--- a/varnish-macros/snapshots/event1_event@code.snap
+++ b/varnish-macros/snapshots/event1_event@code.snap
@@ -9,7 +9,7 @@ mod event {
         use std::ptr::null;
         use varnish::ffi::{
             VCL_BACKEND, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL,
-            VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, vcl_event_e,
+            VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, VclEvent,
             vmod_priv, vmod_priv_methods, vrt_ctx,
         };
         use varnish::vcl::{Ctx, IntoVCL};
@@ -17,11 +17,10 @@ mod event {
         unsafe extern "C" fn vmod_c_on_event(
             __ctx: *mut vrt_ctx,
             __vp: *mut vmod_priv,
-            __ev: vcl_event_e,
+            __ev: VclEvent,
         ) -> VCL_INT {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0 = Event::from_raw(__ev);
-            let __result = super::on_event(__var0);
+            let __result = super::on_event(__ev);
             VCL_INT(0)
         }
         #[repr(C)]
@@ -30,7 +29,7 @@ mod event {
                 unsafe extern "C" fn(
                     __ctx: *mut vrt_ctx,
                     __vp: *mut vmod_priv,
-                    __ev: vcl_event_e,
+                    __ev: VclEvent,
                 ) -> VCL_INT,
             >,
         }

--- a/varnish-macros/snapshots/event2_event2@code.snap
+++ b/varnish-macros/snapshots/event2_event2@code.snap
@@ -9,7 +9,7 @@ mod event2 {
         use std::ptr::null;
         use varnish::ffi::{
             VCL_BACKEND, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL,
-            VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, vcl_event_e,
+            VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, VclEvent,
             vmod_priv, vmod_priv_methods, vrt_ctx,
         };
         use varnish::vcl::{Ctx, IntoVCL};
@@ -17,11 +17,10 @@ mod event2 {
         unsafe extern "C" fn vmod_c_on_event(
             __ctx: *mut vrt_ctx,
             __vp: *mut vmod_priv,
-            __ev: vcl_event_e,
+            __ev: VclEvent,
         ) -> VCL_INT {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var1 = Event::from_raw(__ev);
-            let __result = super::on_event(&__ctx, __var1);
+            let __result = super::on_event(&__ctx, __ev);
             match __result {
                 Ok(_) => VCL_INT(0),
                 Err(err) => {
@@ -36,7 +35,7 @@ mod event2 {
                 unsafe extern "C" fn(
                     __ctx: *mut vrt_ctx,
                     __vp: *mut vmod_priv,
-                    __ev: vcl_event_e,
+                    __ev: VclEvent,
                 ) -> VCL_INT,
             >,
         }

--- a/varnish-macros/snapshots/function_types@code.snap
+++ b/varnish-macros/snapshots/function_types@code.snap
@@ -9,7 +9,7 @@ mod types {
         use std::ptr::null;
         use varnish::ffi::{
             VCL_BACKEND, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL,
-            VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, vcl_event_e,
+            VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, VclEvent,
             vmod_priv, vmod_priv_methods, vrt_ctx,
         };
         use varnish::vcl::{Ctx, IntoVCL};

--- a/varnish-macros/snapshots/object_obj@code.snap
+++ b/varnish-macros/snapshots/object_obj@code.snap
@@ -9,7 +9,7 @@ mod obj {
         use std::ptr::null;
         use varnish::ffi::{
             VCL_BACKEND, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL,
-            VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, vcl_event_e,
+            VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, VclEvent,
             vmod_priv, vmod_priv_methods, vrt_ctx,
         };
         use varnish::vcl::{Ctx, IntoVCL};

--- a/varnish-macros/snapshots/shared2_tuple@code.snap
+++ b/varnish-macros/snapshots/shared2_tuple@code.snap
@@ -9,7 +9,7 @@ mod tuple {
         use std::ptr::null;
         use varnish::ffi::{
             VCL_BACKEND, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL,
-            VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, vcl_event_e,
+            VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, VclEvent,
             vmod_priv, vmod_priv_methods, vrt_ctx,
         };
         use varnish::vcl::{Ctx, IntoVCL};
@@ -27,7 +27,7 @@ mod tuple {
         unsafe extern "C" fn vmod_c_on_event(
             __ctx: *mut vrt_ctx,
             __vp: *mut vmod_priv,
-            __ev: vcl_event_e,
+            __ev: VclEvent,
         ) -> VCL_INT {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let mut __var0 = (*__vp).take();
@@ -56,7 +56,7 @@ mod tuple {
                 unsafe extern "C" fn(
                     __ctx: *mut vrt_ctx,
                     __vp: *mut vmod_priv,
-                    __ev: vcl_event_e,
+                    __ev: VclEvent,
                 ) -> VCL_INT,
             >,
             vmod_c_per_tsk_val: Option<

--- a/varnish-macros/snapshots/shared3_tuple@code.snap
+++ b/varnish-macros/snapshots/shared3_tuple@code.snap
@@ -9,7 +9,7 @@ mod tuple {
         use std::ptr::null;
         use varnish::ffi::{
             VCL_BACKEND, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL,
-            VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, vcl_event_e,
+            VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, VclEvent,
             vmod_priv, vmod_priv_methods, vrt_ctx,
         };
         use varnish::vcl::{Ctx, IntoVCL};

--- a/varnish-macros/snapshots/shared_task@code.snap
+++ b/varnish-macros/snapshots/shared_task@code.snap
@@ -9,7 +9,7 @@ mod task {
         use std::ptr::null;
         use varnish::ffi::{
             VCL_BACKEND, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL,
-            VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, vcl_event_e,
+            VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, VclEvent,
             vmod_priv, vmod_priv_methods, vrt_ctx,
         };
         use varnish::vcl::{Ctx, IntoVCL};
@@ -27,12 +27,11 @@ mod task {
         unsafe extern "C" fn vmod_c_on_event(
             __ctx: *mut vrt_ctx,
             __vp: *mut vmod_priv,
-            __ev: vcl_event_e,
+            __ev: VclEvent,
         ) -> VCL_INT {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0 = Event::from_raw(__ev);
             let mut __var2 = (*__vp).take();
-            let __result = super::on_event(__var0, &mut __ctx, &mut __var2);
+            let __result = super::on_event(__ev, &mut __ctx, &mut __var2);
             if let Some(obj) = __var2 {
                 (*__vp).put(obj, &PRIV_VCL_METHODS);
             }
@@ -184,7 +183,7 @@ mod task {
                 unsafe extern "C" fn(
                     __ctx: *mut vrt_ctx,
                     __vp: *mut vmod_priv,
-                    __ev: vcl_event_e,
+                    __ev: VclEvent,
                 ) -> VCL_INT,
             >,
             vmod_c_per_vcl_val: Option<

--- a/varnish-macros/src/gen_func.rs
+++ b/varnish-macros/src/gen_func.rs
@@ -110,7 +110,7 @@ impl FuncProcessor {
         }
         if matches!(info.func_type, Event) {
             self.wrap_fn_arg_decl.push(quote! { __vp: *mut vmod_priv });
-            self.wrap_fn_arg_decl.push(quote! { __ev: vcl_event_e });
+            self.wrap_fn_arg_decl.push(quote! { __ev: VclEvent });
         }
         if info.has_optional_args {
             self.func_pre_call
@@ -210,9 +210,7 @@ impl FuncProcessor {
                     .push(quote! { let __obj = __obj.as_ref().unwrap(); });
             }
             ParamType::Event => {
-                let r_arg = quote! { Event::from_raw(__ev) };
-                self.func_pre_call.push(quote! { let #temp_var = #r_arg; });
-                self.func_call_vars.push(quote! { #temp_var });
+                self.func_call_vars.push(quote! { __ev });
                 let json = Self::arg_to_json(arg_info.ident.clone(), false, "EVENT", Value::Null);
                 self.args_json.push(json.into());
             }

--- a/varnish-macros/src/generator.rs
+++ b/varnish-macros/src/generator.rs
@@ -185,7 +185,7 @@ impl Generator {
                     VCL_VOID,
                     VMOD_ABI_Version,
                     VMOD_PRIV_METHODS_MAGIC,
-                    vcl_event_e,
+                    VclEvent,
                     vmod_priv,
                     vmod_priv_methods,
                     vrt_ctx,

--- a/varnish-sys/Cargo.toml
+++ b/varnish-sys/Cargo.toml
@@ -24,6 +24,7 @@ version = "7.6"
 
 [build-dependencies]
 bindgen.workspace = true
+convert_case.workspace = true
 pkg-config.workspace = true
 
 [dependencies]

--- a/varnish-sys/bindings.for-docs
+++ b/varnish-sys/bindings.for-docs
@@ -4409,21 +4409,23 @@ extern "C" {
     pub fn VRT_CTX_Assert(ctx: *const vrt_ctx);
 }
 #[repr(u32)]
+#[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum vcl_func_call_e {
-    VSUB_STATIC = 0,
-    VSUB_DYNAMIC = 1,
-    VSUB_CHECK = 2,
+pub enum VclFuncCall {
+    Static = 0,
+    Dynamic = 1,
+    Check = 2,
 }
 #[repr(u32)]
+#[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum vcl_func_fail_e {
-    VSUB_E_OK = 0,
-    VSUB_E_RECURSE = 1,
-    VSUB_E_METHOD = 2,
+pub enum VclFuncFail {
+    Ok = 0,
+    Recurse = 1,
+    Method = 2,
 }
 pub type vcl_func_f = ::std::option::Option<
-    unsafe extern "C" fn(ctx: *const vrt_ctx, arg1: vcl_func_call_e, arg2: *mut vcl_func_fail_e),
+    unsafe extern "C" fn(ctx: *const vrt_ctx, arg1: VclFuncCall, arg2: *mut VclFuncFail),
 >;
 #[doc = " This is the interface structure to a compiled VMOD\n (produced by vmodtool.py)"]
 #[repr(C)]
@@ -4468,19 +4470,20 @@ impl Default for vmod_data {
     }
 }
 #[repr(u32)]
+#[non_exhaustive]
 #[doc = " VCL events sent to VMODs"]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum vcl_event_e {
-    VCL_EVENT_LOAD = 0,
-    VCL_EVENT_WARM = 1,
-    VCL_EVENT_COLD = 2,
-    VCL_EVENT_DISCARD = 3,
+pub enum VclEvent {
+    Load = 0,
+    Warm = 1,
+    Cold = 2,
+    Discard = 3,
 }
 pub type vmod_event_f = ::std::option::Option<
     unsafe extern "C" fn(
         ctx: *const vrt_ctx,
         arg1: *mut vmod_priv,
-        arg2: vcl_event_e,
+        arg2: VclEvent,
     ) -> ::std::ffi::c_int,
 >;
 extern "C" {
@@ -4777,20 +4780,21 @@ extern "C" {
     pub fn VRT_Endpoint_Clone(vep: *const vrt_endpoint) -> *mut vrt_endpoint;
 }
 #[repr(u32)]
+#[non_exhaustive]
 #[doc = " Getting hold of the various struct http"]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum gethdr_e {
-    HDR_REQ = 0,
-    HDR_REQ_TOP = 1,
-    HDR_RESP = 2,
-    HDR_OBJ = 3,
-    HDR_BEREQ = 4,
-    HDR_BERESP = 5,
+pub enum GetHeader {
+    Req = 0,
+    ReqTop = 1,
+    Resp = 2,
+    Obj = 3,
+    Bereq = 4,
+    Beresp = 5,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct gethdr_s {
-    pub where_: gethdr_e,
+    pub where_: GetHeader,
     pub what: *const ::std::ffi::c_char,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
@@ -4810,19 +4814,20 @@ impl Default for gethdr_s {
     }
 }
 extern "C" {
-    pub fn VRT_selecthttp(ctx: *const vrt_ctx, arg1: gethdr_e) -> VCL_HTTP;
+    pub fn VRT_selecthttp(ctx: *const vrt_ctx, arg1: GetHeader) -> VCL_HTTP;
 }
 extern "C" {
     pub fn VRT_GetHdr(ctx: *const vrt_ctx, arg1: VCL_HEADER) -> VCL_STRING;
 }
 #[repr(u32)]
+#[non_exhaustive]
 #[doc = " req related"]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum lbody_e {
-    LBODY_SET_STRING = 0,
-    LBODY_ADD_STRING = 1,
-    LBODY_SET_BLOB = 2,
-    LBODY_ADD_BLOB = 3,
+pub enum Body {
+    SetString = 0,
+    AddString = 1,
+    SetBlob = 2,
+    AddBlob = 3,
 }
 extern "C" {
     pub fn VRT_CacheReqBody(ctx: *const vrt_ctx, maxsize: VCL_BYTES) -> VCL_BYTES;
@@ -4900,7 +4905,7 @@ pub type vdi_http1pipe_f = ::std::option::Option<
     unsafe extern "C" fn(ctx: *const vrt_ctx, arg1: VCL_BACKEND) -> stream_close_t,
 >;
 pub type vdi_event_f =
-    ::std::option::Option<unsafe extern "C" fn(arg1: VCL_BACKEND, arg2: vcl_event_e)>;
+    ::std::option::Option<unsafe extern "C" fn(arg1: VCL_BACKEND, arg2: VclEvent)>;
 pub type vdi_release_f = ::std::option::Option<unsafe extern "C" fn(arg1: VCL_BACKEND)>;
 pub type vdi_destroy_f = ::std::option::Option<unsafe extern "C" fn(arg1: VCL_BACKEND)>;
 pub type vdi_panic_f =
@@ -5166,19 +5171,23 @@ extern "C" {
 extern "C" {
     pub fn VAS_errtxt(e: ::std::ffi::c_int) -> *const ::std::ffi::c_char;
 }
-pub const vas_e_VAS_WRONG: vas_e = 0;
-pub const vas_e_VAS_MISSING: vas_e = 1;
-pub const vas_e_VAS_ASSERT: vas_e = 2;
-pub const vas_e_VAS_INCOMPLETE: vas_e = 3;
-pub const vas_e_VAS_VCL: vas_e = 4;
-pub type vas_e = ::std::ffi::c_uint;
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum Vas {
+    Wrong = 0,
+    Missing = 1,
+    Assert = 2,
+    Incomplete = 3,
+    Vcl = 4,
+}
 pub type vas_f = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: *const ::std::ffi::c_char,
         arg2: *const ::std::ffi::c_char,
         arg3: ::std::ffi::c_int,
         arg4: *const ::std::ffi::c_char,
-        arg5: vas_e,
+        arg5: Vas,
     ),
 >;
 extern "C" {
@@ -5188,7 +5197,7 @@ extern "C" {
             arg2: *const ::std::ffi::c_char,
             arg3: ::std::ffi::c_int,
             arg4: *const ::std::ffi::c_char,
-            arg5: vas_e,
+            arg5: Vas,
         ) -> !,
     >;
 }
@@ -5198,106 +5207,110 @@ extern "C" {
         arg2: *const ::std::ffi::c_char,
         arg3: ::std::ffi::c_int,
         arg4: *const ::std::ffi::c_char,
-        arg5: vas_e,
+        arg5: Vas,
     ) -> !;
 }
-pub const VSL_tag_e_SLT__Bogus: VSL_tag_e = 0;
-pub const VSL_tag_e_SLT_Debug: VSL_tag_e = 1;
-pub const VSL_tag_e_SLT_Error: VSL_tag_e = 2;
-pub const VSL_tag_e_SLT_CLI: VSL_tag_e = 3;
-pub const VSL_tag_e_SLT_SessOpen: VSL_tag_e = 4;
-pub const VSL_tag_e_SLT_SessClose: VSL_tag_e = 5;
-pub const VSL_tag_e_SLT_BackendOpen: VSL_tag_e = 6;
-pub const VSL_tag_e_SLT_BackendClose: VSL_tag_e = 7;
-pub const VSL_tag_e_SLT_HttpGarbage: VSL_tag_e = 8;
-pub const VSL_tag_e_SLT_Proxy: VSL_tag_e = 9;
-pub const VSL_tag_e_SLT_ProxyGarbage: VSL_tag_e = 10;
-pub const VSL_tag_e_SLT_Length: VSL_tag_e = 11;
-pub const VSL_tag_e_SLT_FetchError: VSL_tag_e = 12;
-pub const VSL_tag_e_SLT_ReqMethod: VSL_tag_e = 13;
-pub const VSL_tag_e_SLT_ReqURL: VSL_tag_e = 14;
-pub const VSL_tag_e_SLT_ReqProtocol: VSL_tag_e = 15;
-pub const VSL_tag_e_SLT_ReqStatus: VSL_tag_e = 16;
-pub const VSL_tag_e_SLT_ReqReason: VSL_tag_e = 17;
-pub const VSL_tag_e_SLT_ReqHeader: VSL_tag_e = 18;
-pub const VSL_tag_e_SLT_ReqUnset: VSL_tag_e = 19;
-pub const VSL_tag_e_SLT_ReqLost: VSL_tag_e = 20;
-pub const VSL_tag_e_SLT_RespMethod: VSL_tag_e = 21;
-pub const VSL_tag_e_SLT_RespURL: VSL_tag_e = 22;
-pub const VSL_tag_e_SLT_RespProtocol: VSL_tag_e = 23;
-pub const VSL_tag_e_SLT_RespStatus: VSL_tag_e = 24;
-pub const VSL_tag_e_SLT_RespReason: VSL_tag_e = 25;
-pub const VSL_tag_e_SLT_RespHeader: VSL_tag_e = 26;
-pub const VSL_tag_e_SLT_RespUnset: VSL_tag_e = 27;
-pub const VSL_tag_e_SLT_RespLost: VSL_tag_e = 28;
-pub const VSL_tag_e_SLT_BereqMethod: VSL_tag_e = 29;
-pub const VSL_tag_e_SLT_BereqURL: VSL_tag_e = 30;
-pub const VSL_tag_e_SLT_BereqProtocol: VSL_tag_e = 31;
-pub const VSL_tag_e_SLT_BereqStatus: VSL_tag_e = 32;
-pub const VSL_tag_e_SLT_BereqReason: VSL_tag_e = 33;
-pub const VSL_tag_e_SLT_BereqHeader: VSL_tag_e = 34;
-pub const VSL_tag_e_SLT_BereqUnset: VSL_tag_e = 35;
-pub const VSL_tag_e_SLT_BereqLost: VSL_tag_e = 36;
-pub const VSL_tag_e_SLT_BerespMethod: VSL_tag_e = 37;
-pub const VSL_tag_e_SLT_BerespURL: VSL_tag_e = 38;
-pub const VSL_tag_e_SLT_BerespProtocol: VSL_tag_e = 39;
-pub const VSL_tag_e_SLT_BerespStatus: VSL_tag_e = 40;
-pub const VSL_tag_e_SLT_BerespReason: VSL_tag_e = 41;
-pub const VSL_tag_e_SLT_BerespHeader: VSL_tag_e = 42;
-pub const VSL_tag_e_SLT_BerespUnset: VSL_tag_e = 43;
-pub const VSL_tag_e_SLT_BerespLost: VSL_tag_e = 44;
-pub const VSL_tag_e_SLT_ObjMethod: VSL_tag_e = 45;
-pub const VSL_tag_e_SLT_ObjURL: VSL_tag_e = 46;
-pub const VSL_tag_e_SLT_ObjProtocol: VSL_tag_e = 47;
-pub const VSL_tag_e_SLT_ObjStatus: VSL_tag_e = 48;
-pub const VSL_tag_e_SLT_ObjReason: VSL_tag_e = 49;
-pub const VSL_tag_e_SLT_ObjHeader: VSL_tag_e = 50;
-pub const VSL_tag_e_SLT_ObjUnset: VSL_tag_e = 51;
-pub const VSL_tag_e_SLT_ObjLost: VSL_tag_e = 52;
-pub const VSL_tag_e_SLT_BogoHeader: VSL_tag_e = 53;
-pub const VSL_tag_e_SLT_LostHeader: VSL_tag_e = 54;
-pub const VSL_tag_e_SLT_TTL: VSL_tag_e = 55;
-pub const VSL_tag_e_SLT_Fetch_Body: VSL_tag_e = 56;
-pub const VSL_tag_e_SLT_VCL_acl: VSL_tag_e = 57;
-pub const VSL_tag_e_SLT_VCL_call: VSL_tag_e = 58;
-pub const VSL_tag_e_SLT_VCL_trace: VSL_tag_e = 59;
-pub const VSL_tag_e_SLT_VCL_return: VSL_tag_e = 60;
-pub const VSL_tag_e_SLT_ReqStart: VSL_tag_e = 61;
-pub const VSL_tag_e_SLT_Hit: VSL_tag_e = 62;
-pub const VSL_tag_e_SLT_HitPass: VSL_tag_e = 63;
-pub const VSL_tag_e_SLT_ExpBan: VSL_tag_e = 64;
-pub const VSL_tag_e_SLT_ExpKill: VSL_tag_e = 65;
-pub const VSL_tag_e_SLT_WorkThread: VSL_tag_e = 66;
-pub const VSL_tag_e_SLT_ESI_xmlerror: VSL_tag_e = 67;
-pub const VSL_tag_e_SLT_Hash: VSL_tag_e = 68;
-pub const VSL_tag_e_SLT_Backend_health: VSL_tag_e = 69;
-pub const VSL_tag_e_SLT_VCL_Log: VSL_tag_e = 70;
-pub const VSL_tag_e_SLT_VCL_Error: VSL_tag_e = 71;
-pub const VSL_tag_e_SLT_Gzip: VSL_tag_e = 72;
-pub const VSL_tag_e_SLT_Link: VSL_tag_e = 73;
-pub const VSL_tag_e_SLT_Begin: VSL_tag_e = 74;
-pub const VSL_tag_e_SLT_End: VSL_tag_e = 75;
-pub const VSL_tag_e_SLT_VSL: VSL_tag_e = 76;
-pub const VSL_tag_e_SLT_Storage: VSL_tag_e = 77;
-pub const VSL_tag_e_SLT_Timestamp: VSL_tag_e = 78;
-pub const VSL_tag_e_SLT_ReqAcct: VSL_tag_e = 79;
-pub const VSL_tag_e_SLT_PipeAcct: VSL_tag_e = 80;
-pub const VSL_tag_e_SLT_BereqAcct: VSL_tag_e = 81;
-pub const VSL_tag_e_SLT_VfpAcct: VSL_tag_e = 82;
-pub const VSL_tag_e_SLT_Witness: VSL_tag_e = 83;
-pub const VSL_tag_e_SLT_H2RxHdr: VSL_tag_e = 84;
-pub const VSL_tag_e_SLT_H2RxBody: VSL_tag_e = 85;
-pub const VSL_tag_e_SLT_H2TxHdr: VSL_tag_e = 86;
-pub const VSL_tag_e_SLT_H2TxBody: VSL_tag_e = 87;
-pub const VSL_tag_e_SLT_HitMiss: VSL_tag_e = 88;
-pub const VSL_tag_e_SLT_Filters: VSL_tag_e = 89;
-pub const VSL_tag_e_SLT_SessError: VSL_tag_e = 90;
-pub const VSL_tag_e_SLT_VCL_use: VSL_tag_e = 91;
-pub const VSL_tag_e_SLT_Notice: VSL_tag_e = 92;
-pub const VSL_tag_e_SLT_VdpAcct: VSL_tag_e = 93;
-pub const VSL_tag_e_SLT__Reserved: VSL_tag_e = 254;
-pub const VSL_tag_e_SLT__Batch: VSL_tag_e = 255;
-pub type VSL_tag_e = ::std::ffi::c_uint;
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum VslTag {
+    Bogus = 0,
+    Debug = 1,
+    Error = 2,
+    Cli = 3,
+    SessOpen = 4,
+    SessClose = 5,
+    BackendOpen = 6,
+    BackendClose = 7,
+    HttpGarbage = 8,
+    Proxy = 9,
+    ProxyGarbage = 10,
+    Length = 11,
+    FetchError = 12,
+    ReqMethod = 13,
+    ReqUrl = 14,
+    ReqProtocol = 15,
+    ReqStatus = 16,
+    ReqReason = 17,
+    ReqHeader = 18,
+    ReqUnset = 19,
+    ReqLost = 20,
+    RespMethod = 21,
+    RespUrl = 22,
+    RespProtocol = 23,
+    RespStatus = 24,
+    RespReason = 25,
+    RespHeader = 26,
+    RespUnset = 27,
+    RespLost = 28,
+    BereqMethod = 29,
+    BereqUrl = 30,
+    BereqProtocol = 31,
+    BereqStatus = 32,
+    BereqReason = 33,
+    BereqHeader = 34,
+    BereqUnset = 35,
+    BereqLost = 36,
+    BerespMethod = 37,
+    BerespUrl = 38,
+    BerespProtocol = 39,
+    BerespStatus = 40,
+    BerespReason = 41,
+    BerespHeader = 42,
+    BerespUnset = 43,
+    BerespLost = 44,
+    ObjMethod = 45,
+    ObjUrl = 46,
+    ObjProtocol = 47,
+    ObjStatus = 48,
+    ObjReason = 49,
+    ObjHeader = 50,
+    ObjUnset = 51,
+    ObjLost = 52,
+    BogoHeader = 53,
+    LostHeader = 54,
+    Ttl = 55,
+    FetchBody = 56,
+    VclAcl = 57,
+    VclCall = 58,
+    VclTrace = 59,
+    VclReturn = 60,
+    ReqStart = 61,
+    Hit = 62,
+    HitPass = 63,
+    ExpBan = 64,
+    ExpKill = 65,
+    WorkThread = 66,
+    EsiXmlerror = 67,
+    Hash = 68,
+    BackendHealth = 69,
+    VclLog = 70,
+    VclError = 71,
+    Gzip = 72,
+    Link = 73,
+    Begin = 74,
+    End = 75,
+    Vsl = 76,
+    Storage = 77,
+    Timestamp = 78,
+    ReqAcct = 79,
+    PipeAcct = 80,
+    BereqAcct = 81,
+    VfpAcct = 82,
+    Witness = 83,
+    H2RxHdr = 84,
+    H2RxBody = 85,
+    H2TxHdr = 86,
+    H2TxBody = 87,
+    HitMiss = 88,
+    Filters = 89,
+    SessError = 90,
+    VclUse = 91,
+    Notice = 92,
+    VdpAcct = 93,
+    Reserved = 254,
+    Batch = 255,
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct vxids {
@@ -5584,7 +5597,7 @@ pub struct http {
     pub hd: *mut txt,
     pub hdf: *mut ::std::ffi::c_uchar,
     pub nhd: u16,
-    pub logtag: VSL_tag_e,
+    pub logtag: VslTag,
     pub vsl: *mut vsl_log,
     pub ws: *mut ws,
     pub status: u16,
@@ -5755,14 +5768,18 @@ impl Default for pool_task {
         }
     }
 }
-pub const task_prio_TASK_QUEUE_BO: task_prio = 0;
-pub const task_prio_TASK_QUEUE_RUSH: task_prio = 1;
-pub const task_prio_TASK_QUEUE_REQ: task_prio = 2;
-pub const task_prio_TASK_QUEUE_STR: task_prio = 3;
-pub const task_prio_TASK_QUEUE_VCA: task_prio = 4;
-pub const task_prio_TASK_QUEUE_BG: task_prio = 5;
-pub const task_prio_TASK_QUEUE__END: task_prio = 6;
-pub type task_prio = ::std::ffi::c_uint;
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum TaskPriority {
+    Bo = 0,
+    Rush = 1,
+    Req = 2,
+    Str = 3,
+    Vca = 4,
+    Bg = 5,
+    End = 6,
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct worker {
@@ -5834,13 +5851,17 @@ impl Default for storeobj {
         }
     }
 }
-pub const boc_state_e_BOS_INVALID: boc_state_e = 0;
-pub const boc_state_e_BOS_REQ_DONE: boc_state_e = 1;
-pub const boc_state_e_BOS_PREP_STREAM: boc_state_e = 2;
-pub const boc_state_e_BOS_STREAM: boc_state_e = 3;
-pub const boc_state_e_BOS_FINISHED: boc_state_e = 4;
-pub const boc_state_e_BOS_FAILED: boc_state_e = 5;
-pub type boc_state_e = ::std::ffi::c_uint;
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum BocState {
+    Invalid = 0,
+    ReqDone = 1,
+    PrepStream = 2,
+    Stream = 3,
+    Finished = 4,
+    Failed = 5,
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct boc {
@@ -5849,7 +5870,7 @@ pub struct boc {
     pub mtx: lock,
     pub cond: pthread_cond_t,
     pub stevedore_priv: *mut ::std::ffi::c_void,
-    pub state: boc_state_e,
+    pub state: BocState,
     pub vary: *mut u8,
     pub fetched_so_far: u64,
     pub delivered_so_far: u64,
@@ -6068,10 +6089,14 @@ impl Default for objcore {
         }
     }
 }
-pub const director_state_e_DIR_S_NULL: director_state_e = 0;
-pub const director_state_e_DIR_S_HDRS: director_state_e = 1;
-pub const director_state_e_DIR_S_BODY: director_state_e = 2;
-pub type director_state_e = ::std::ffi::c_uint;
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum DirectorState {
+    Null = 0,
+    Headers = 1,
+    Body = 2,
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct busyobj {
@@ -6107,7 +6132,7 @@ pub struct busyobj {
     pub storage: *const stevedore,
     pub director_req: *const director,
     pub director_resp: *const director,
-    pub director_state: director_state_e,
+    pub director_state: DirectorState,
     pub vcl: *mut vcl,
     pub vsl: [vsl_log; 1usize],
     pub digest: [u8; 32usize],
@@ -6717,17 +6742,21 @@ impl req {
         __bindgen_bitfield_unit
     }
 }
-pub const sess_attr_SA_TRANSPORT: sess_attr = 0;
-pub const sess_attr_SA_REMOTE_ADDR: sess_attr = 1;
-pub const sess_attr_SA_LOCAL_ADDR: sess_attr = 2;
-pub const sess_attr_SA_CLIENT_ADDR: sess_attr = 3;
-pub const sess_attr_SA_SERVER_ADDR: sess_attr = 4;
-pub const sess_attr_SA_CLIENT_IP: sess_attr = 5;
-pub const sess_attr_SA_CLIENT_PORT: sess_attr = 6;
-pub const sess_attr_SA_PROXY_TLV: sess_attr = 7;
-pub const sess_attr_SA_PROTO_PRIV: sess_attr = 8;
-pub const sess_attr_SA_LAST: sess_attr = 9;
-pub type sess_attr = ::std::ffi::c_uint;
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum SessionAttr {
+    Transport = 0,
+    RemoteAddr = 1,
+    LocalAddr = 2,
+    ClientAddr = 3,
+    ServerAddr = 4,
+    ClientIp = 5,
+    ClientPort = 6,
+    ProxyTlv = 7,
+    ProtoPriv = 8,
+    Last = 9,
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sess {
@@ -6876,7 +6905,7 @@ extern "C" {
     pub fn http_ForceField(to: *mut http, n: ::std::ffi::c_uint, t: *const ::std::ffi::c_char);
 }
 extern "C" {
-    pub fn HTTP_Setup(arg1: *mut http, arg2: *mut ws, arg3: *mut vsl_log, arg4: VSL_tag_e);
+    pub fn HTTP_Setup(arg1: *mut http, arg2: *mut ws, arg3: *mut vsl_log, arg4: VslTag);
 }
 extern "C" {
     pub fn http_Teardown(ht: *mut http);
@@ -7370,38 +7399,33 @@ extern "C" {
     pub fn SES_Get_proto_priv(sp: *const sess, dst: *mut *mut usize) -> ::std::ffi::c_int;
 }
 extern "C" {
-    pub fn SES_Get_String_Attr(sp: *const sess, a: sess_attr) -> *const ::std::ffi::c_char;
+    pub fn SES_Get_String_Attr(sp: *const sess, a: SessionAttr) -> *const ::std::ffi::c_char;
 }
 extern "C" {
-    pub fn VSLv(
-        tag: VSL_tag_e,
-        vxid: vxid_t,
-        fmt: *const ::std::ffi::c_char,
-        va: *mut __va_list_tag,
-    );
+    pub fn VSLv(tag: VslTag, vxid: vxid_t, fmt: *const ::std::ffi::c_char, va: *mut __va_list_tag);
 }
 extern "C" {
-    pub fn VSL(tag: VSL_tag_e, vxid: vxid_t, fmt: *const ::std::ffi::c_char, ...);
+    pub fn VSL(tag: VslTag, vxid: vxid_t, fmt: *const ::std::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn VSLs(tag: VSL_tag_e, vxid: vxid_t, s: *const strands);
+    pub fn VSLs(tag: VslTag, vxid: vxid_t, s: *const strands);
 }
 extern "C" {
     pub fn VSLbv(
         arg1: *mut vsl_log,
-        tag: VSL_tag_e,
+        tag: VslTag,
         fmt: *const ::std::ffi::c_char,
         va: *mut __va_list_tag,
     );
 }
 extern "C" {
-    pub fn VSLb(arg1: *mut vsl_log, tag: VSL_tag_e, fmt: *const ::std::ffi::c_char, ...);
+    pub fn VSLb(arg1: *mut vsl_log, tag: VslTag, fmt: *const ::std::ffi::c_char, ...);
 }
 extern "C" {
-    pub fn VSLbt(arg1: *mut vsl_log, tag: VSL_tag_e, t: txt);
+    pub fn VSLbt(arg1: *mut vsl_log, tag: VslTag, t: txt);
 }
 extern "C" {
-    pub fn VSLbs(arg1: *mut vsl_log, tag: VSL_tag_e, s: *const strands);
+    pub fn VSLbs(arg1: *mut vsl_log, tag: VslTag, s: *const strands);
 }
 extern "C" {
     pub fn VSLb_ts(
@@ -7413,15 +7437,10 @@ extern "C" {
     );
 }
 extern "C" {
-    pub fn VSLb_bin(
-        arg1: *mut vsl_log,
-        arg2: VSL_tag_e,
-        arg3: isize,
-        arg4: *const ::std::ffi::c_void,
-    );
+    pub fn VSLb_bin(arg1: *mut vsl_log, arg2: VslTag, arg3: isize, arg4: *const ::std::ffi::c_void);
 }
 extern "C" {
-    pub fn VSL_tag_is_masked(tag: VSL_tag_e) -> ::std::ffi::c_int;
+    pub fn VSL_tag_is_masked(tag: VslTag) -> ::std::ffi::c_int;
 }
 extern "C" {
     pub fn VCL_Name(arg1: *const vcl) -> *const ::std::ffi::c_char;
@@ -7623,19 +7642,20 @@ extern "C" {
     pub static VDI_AH_DELETED: *const vdi_ahealth;
 }
 #[repr(i32)]
+#[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum vfp_status {
-    VFP_ERROR = -1,
-    VFP_OK = 0,
-    VFP_END = 1,
-    VFP_NULL = 2,
+pub enum VfpStatus {
+    Error = -1,
+    Ok = 0,
+    End = 1,
+    Null = 2,
 }
 pub type vfp_init_f = ::std::option::Option<
     unsafe extern "C" fn(
         ctx: *const vrt_ctx,
         arg1: *mut vfp_ctx,
         arg2: *mut vfp_entry,
-    ) -> vfp_status,
+    ) -> VfpStatus,
 >;
 pub type vfp_pull_f = ::std::option::Option<
     unsafe extern "C" fn(
@@ -7643,7 +7663,7 @@ pub type vfp_pull_f = ::std::option::Option<
         arg2: *mut vfp_entry,
         ptr: *mut ::std::ffi::c_void,
         len: *mut isize,
-    ) -> vfp_status,
+    ) -> VfpStatus,
 >;
 pub type vfp_fini_f =
     ::std::option::Option<unsafe extern "C" fn(arg1: *mut vfp_ctx, arg2: *mut vfp_entry)>;
@@ -7679,7 +7699,7 @@ impl Default for vfp {
 #[derive(Debug, Copy, Clone)]
 pub struct vfp_entry {
     pub magic: ::std::ffi::c_uint,
-    pub closed: vfp_status,
+    pub closed: VfpStatus,
     pub vfp: *const vfp,
     pub priv1: *mut ::std::ffi::c_void,
     pub priv2: isize,
@@ -7796,10 +7816,10 @@ impl Default for vfp_ctx {
     }
 }
 extern "C" {
-    pub fn VFP_Suck(arg1: *mut vfp_ctx, p: *mut ::std::ffi::c_void, lp: *mut isize) -> vfp_status;
+    pub fn VFP_Suck(arg1: *mut vfp_ctx, p: *mut ::std::ffi::c_void, lp: *mut isize) -> VfpStatus;
 }
 extern "C" {
-    pub fn VFP_Error(arg1: *mut vfp_ctx, fmt: *const ::std::ffi::c_char, ...) -> vfp_status;
+    pub fn VFP_Error(arg1: *mut vfp_ctx, fmt: *const ::std::ffi::c_char, ...) -> VfpStatus;
 }
 extern "C" {
     pub fn VRT_AddVFP(ctx: *const vrt_ctx, arg1: *const vfp);
@@ -7807,10 +7827,14 @@ extern "C" {
 extern "C" {
     pub fn VRT_RemoveVFP(ctx: *const vrt_ctx, arg1: *const vfp);
 }
-pub const vdp_action_VDP_NULL: vdp_action = 0;
-pub const vdp_action_VDP_FLUSH: vdp_action = 1;
-pub const vdp_action_VDP_END: vdp_action = 2;
-pub type vdp_action = ::std::ffi::c_uint;
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum VdpAction {
+    Null = 0,
+    Flush = 1,
+    End = 2,
+}
 pub type vdp_init_f = ::std::option::Option<
     unsafe extern "C" fn(
         ctx: *const vrt_ctx,
@@ -7827,7 +7851,7 @@ pub type vdp_fini_f = ::std::option::Option<
 pub type vdp_bytes_f = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: *mut vdp_ctx,
-        arg2: vdp_action,
+        arg2: VdpAction,
         priv_: *mut *mut ::std::ffi::c_void,
         ptr: *const ::std::ffi::c_void,
         len: isize,
@@ -7865,7 +7889,7 @@ impl Default for vdp {
 #[derive(Debug, Copy, Clone)]
 pub struct vdp_entry {
     pub magic: ::std::ffi::c_uint,
-    pub end: vdp_action,
+    pub end: VdpAction,
     pub vdp: *const vdp,
     pub priv_: *mut ::std::ffi::c_void,
     pub list: vdp_entry__bindgen_ty_1,
@@ -7983,7 +8007,7 @@ impl Default for vdp_ctx {
 extern "C" {
     pub fn VDP_bytes(
         arg1: *mut vdp_ctx,
-        act: vdp_action,
+        act: VdpAction,
         arg2: *const ::std::ffi::c_void,
         arg3: isize,
     ) -> ::std::ffi::c_int;

--- a/varnish-sys/build.rs
+++ b/varnish-sys/build.rs
@@ -1,5 +1,64 @@
+use convert_case::Case::Pascal;
+use convert_case::Casing;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::{env, fs};
+
+#[derive(Debug, Default)]
+struct ParseCallbacks {
+    /// C items and their Rust names
+    item_names: HashMap<&'static str, &'static str>,
+    /// C enums (i.e. "enum foo"),  the prefix to remove from their values,
+    /// and explicit renames for some values without prefix
+    enum_renames: HashMap<&'static str, (&'static str, HashMap<&'static str, &'static str>)>,
+}
+
+impl ParseCallbacks {
+    fn get_regex_str(&self) -> String {
+        self.item_names.keys().fold(String::new(), |mut acc, x| {
+            if !acc.is_empty() {
+                acc.push('|');
+            }
+            acc.push_str(x);
+            acc
+        })
+    }
+}
+
+impl bindgen::callbacks::ParseCallbacks for ParseCallbacks {
+    fn enum_variant_name(
+        &self,
+        enum_name: Option<&str>,
+        value: &str,
+        _variant_value: bindgen::callbacks::EnumVariantValue,
+    ) -> Option<String> {
+        self.enum_renames.get(enum_name?).map(|v| {
+            let val = value.trim_start_matches(v.0);
+            v.1.get(val)
+                .map(|x| (*x).to_string())
+                .unwrap_or(val.to_case(Pascal))
+        })
+        // // Print unrecognized enum values for debugging
+        // .or_else(|| {
+        //     let name = enum_name.unwrap();
+        //     println!("cargo::warning=Unrecognized {name} - {value}");
+        //     None
+        // })
+    }
+
+    fn item_name(&self, item_name: &str) -> Option<String> {
+        self.item_names.get(item_name).map(|x| (*x).to_string())
+    }
+}
+
+macro_rules! rename {
+    ( $cb:expr, $name_c:literal, $name_rs:literal, $rm_prefix:literal $(, $itm:literal => $ren:literal)* $(,)? ) => {
+        $cb.item_names.insert($name_c, $name_rs);
+        $cb.enum_renames.insert(concat!("enum ", $name_c), (
+            $rm_prefix,
+            vec![$( ($itm, $ren), )*].into_iter().collect()));
+    };
+}
 
 fn main() {
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
@@ -48,7 +107,21 @@ fn main() {
         }
     };
 
-    // Only link to varnishapi if we found it
+    let mut cb = ParseCallbacks::default();
+    rename!(cb, "VSL_tag_e", "VslTag", "SLT_"); // SLT_Debug
+    rename!(cb, "boc_state_e", "BocState", "BOS_"); // BOS_INVALID
+    rename!(cb, "director_state_e", "DirectorState", "DIR_S_", "HDRS" => "Headers"); // DIR_S_NULL
+    rename!(cb, "gethdr_e", "GetHeader", "HDR_"); // HDR_REQ_TOP
+    rename!(cb, "sess_attr", "SessionAttr", "SA_"); // SA_TRANSPORT
+    rename!(cb, "lbody_e", "Body", "LBODY_"); // LBODY_SET_STRING
+    rename!(cb, "task_prio", "TaskPriority", "TASK_QUEUE_"); // TASK_QUEUE_BO
+    rename!(cb, "vas_e", "Vas", "VAS_"); // VAS_WRONG
+    rename!(cb, "vcl_event_e", "VclEvent", "VCL_EVENT_"); // VCL_EVENT_LOAD
+    rename!(cb, "vcl_func_call_e", "VclFuncCall", "VSUB_"); // VSUB_STATIC
+    rename!(cb, "vcl_func_fail_e", "VclFuncFail", "VSUB_E_"); // VSUB_E_OK
+    rename!(cb, "vdp_action", "VdpAction", "VDP_"); // VDP_NULL
+    rename!(cb, "vfp_status", "VfpStatus", "VFP_"); // VFP_ERROR
+
     println!("cargo:rustc-link-lib=varnishapi");
     println!("cargo:rerun-if-changed=src/wrapper.h");
     let bindings = bindgen::Builder::default()
@@ -91,12 +164,9 @@ fn main() {
         // .new_type_alias("VCL_VCL") // *mut vcl
         // .new_type_alias("VCL_VOID") // ::std::os::raw::c_void
         //
-        .rustified_enum("vfp_status") // ::std::ffi::c_int
-        .rustified_enum("vcl_func_call_e") // ::std::ffi::c_int
-        .rustified_enum("vcl_func_fail_e") // ::std::ffi::c_int
-        .rustified_enum("vcl_event_e") // ::std::ffi::c_int
-        .rustified_enum("gethdr_e") // ::std::ffi::c_int
-        .rustified_enum("lbody_e") // ::std::ffi::c_int
+        // FIXME: some enums should probably be done as rustified_enum (exhaustive)
+        .rustified_non_exhaustive_enum(cb.get_regex_str())
+        .parse_callbacks(Box::new(cb))
         //
         .generate()
         .expect("Unable to generate bindings");

--- a/varnish-sys/src/vcl/http.rs
+++ b/varnish-sys/src/vcl/http.rs
@@ -12,10 +12,11 @@
 //! this [issue](https://github.com/gquintard/varnish-rs/issues/4).
 
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
-use std::ffi::c_uint;
+use std::mem::transmute;
 use std::slice::from_raw_parts_mut;
 
 use crate::ffi;
+use crate::ffi::VslTag;
 use crate::vcl::{VclResult, WS};
 
 // C constants pop up as u32, but header indexing uses u16, redefine
@@ -71,7 +72,7 @@ impl<'a> HTTP<'a> {
             unsafe {
                 ffi::VSLbt(
                     self.raw.vsl,
-                    self.raw.logtag as c_uint + HDR_FIRST as c_uint,
+                    transmute::<u32, VslTag>((self.raw.logtag as u32) + (HDR_FIRST as u32)),
                     *self.raw.hd.add(idx as usize),
                 );
             }
@@ -93,7 +94,9 @@ impl<'a> HTTP<'a> {
                 unsafe {
                     ffi::VSLbt(
                         self.raw.vsl,
-                        self.raw.logtag + HDR_UNSET as u32 - HDR_METHOD as u32,
+                        transmute::<u32, VslTag>(
+                            (self.raw.logtag as u32) + (HDR_UNSET as u32) + (HDR_METHOD as u32),
+                        ),
                         *self.raw.hd.add(HDR_FIRST as usize + idx),
                     );
                 }

--- a/varnish-sys/src/vcl/mod.rs
+++ b/varnish-sys/src/vcl/mod.rs
@@ -17,3 +17,5 @@ pub use probe::*;
 pub use processor::*;
 pub use vsb::*;
 pub use ws::*;
+
+pub use crate::ffi::{VclEvent as Event, VslTag as LogTag};


### PR DESCRIPTION
* as part of binder build, auto-rename all enum values into Rust values to make them usable and consistent in the user code. For example, `vcl_event_e::VCL_EVENT_LOAD` is now `VclEvent::Load`, and it does NOT need a wrapper enum.
* All enums are tagged as "non-exhaustive" because we do not want to promise that the list of enums will always stay stable (i.e. they can be modified upstream) - so it shouldn't be a breaking change for us.