### PR TITLE
Name cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,17 @@
   - supports debug mode - keeps the temporary files and always prints the output: `run_vtc_tests!!("tests/*.vtc", true)`
 - Multi-version support for `libvarnish` headers now allows the same code to be used with Varnish v7.4, v7.5, and v7.6
 - Renamed a few types for clarity and to be more consistent:
+  - `COWProbe` struct to `CowProbe`
+  - `COWRequest` struct to `CowRequest`
+  - `HTTP` struct to `HttpHeaders`
+  - `HTTPIter` struct to `HttpHeadersIter`
+  - `VDPCtx` struct to `DeliveryProcCtx`
   - `VDP` trait to `DeliveryProcessor`
+  - `VFPCtx` struct to `FetchProcCtx`
   - `VFP` trait to `FetchProcessor`
+  - `VSB` struct to `Buffer`
+  - `VSB::cat` function to `Buffer::write`
+  - `WS` struct to `Workspace`
 
 # 0.0.19 (2024-03-24)
 

--- a/examples/vmod_vdp/src/lib.rs
+++ b/examples/vmod_vdp/src/lib.rs
@@ -1,7 +1,7 @@
 use std::ffi::CStr;
 
 use varnish::ffi::VdpAction;
-use varnish::vcl::{Ctx, DeliveryProcessor, InitResult, PushResult, VDPCtx};
+use varnish::vcl::{Ctx, DeliveryProcCtx, DeliveryProcessor, InitResult, PushResult};
 
 varnish::run_vtc_tests!("tests/*.vtc");
 
@@ -62,12 +62,12 @@ impl DeliveryProcessor for Flipper {
 
     // `new` is called when the VCL specifies "flipper" in `resp.filters`
     // just return a default struct, thanks to the derive macro
-    fn new(_: &mut Ctx, _: &mut VDPCtx) -> InitResult<Self> {
+    fn new(_: &mut Ctx, _: &mut DeliveryProcCtx) -> InitResult<Self> {
         InitResult::Ok(Flipper::default())
     }
 
     // buffer everything, then reverse the buffer, and send it, easy
-    fn push(&mut self, ctx: &mut VDPCtx, act: VdpAction, buf: &[u8]) -> PushResult {
+    fn push(&mut self, ctx: &mut DeliveryProcCtx, act: VdpAction, buf: &[u8]) -> PushResult {
         // ingest everything we're given
         self.body.extend_from_slice(buf);
 

--- a/examples/vmod_vfp/src/lib.rs
+++ b/examples/vmod_vfp/src/lib.rs
@@ -1,6 +1,6 @@
 use std::ffi::CStr;
 
-use varnish::vcl::{Ctx, FetchProcessor, InitResult, PullResult, VFPCtx};
+use varnish::vcl::{Ctx, FetchProcCtx, FetchProcessor, InitResult, PullResult};
 
 varnish::run_vtc_tests!("tests/*.vtc");
 
@@ -54,11 +54,11 @@ impl FetchProcessor for Lower {
     }
 
     // `new` is called when the VCL specifies "lower" in `beresp.filters`
-    fn new(_: &mut Ctx, _: &mut VFPCtx) -> InitResult<Self> {
+    fn new(_: &mut Ctx, _: &mut FetchProcCtx) -> InitResult<Self> {
         InitResult::Ok(Lower {})
     }
 
-    fn pull(&mut self, ctx: &mut VFPCtx, buf: &mut [u8]) -> PullResult {
+    fn pull(&mut self, ctx: &mut FetchProcCtx, buf: &mut [u8]) -> PullResult {
         let pull_res = ctx.pull(buf);
         let (PullResult::End(len) | PullResult::Ok(len)) = pull_res else {
             return pull_res;

--- a/varnish-macros/snapshots/function_types@code.snap
+++ b/varnish-macros/snapshots/function_types@code.snap
@@ -477,7 +477,7 @@ mod types {
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
-            let __var0: Option<COWProbe> = if __args.valid__v != 0 {
+            let __var0: Option<CowProbe> = if __args.valid__v != 0 {
                 __args._v.into()
             } else {
                 None
@@ -489,7 +489,7 @@ mod types {
             _v: VCL_PROBE,
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0: Option<COWProbe> = _v.into();
+            let __var0: Option<CowProbe> = _v.into();
             let __result = super::type_cow_probe_req(__var0);
         }
         unsafe extern "C" fn vmod_c_to_cow_probe(__ctx: *mut vrt_ctx) -> VCL_PROBE {
@@ -879,7 +879,7 @@ mod types {
     use std::net::SocketAddr;
     use std::time::Duration;
     use varnish::ffi::VCL_STRING;
-    use varnish::vcl::{COWProbe, Probe, Workspace};
+    use varnish::vcl::{CowProbe, Probe, Workspace};
     use varnish_sys::vcl::VclError;
     pub fn to_void() {
         panic!()
@@ -955,12 +955,12 @@ mod types {
     pub fn to_res_probe() -> Result<Probe, &'static str> {
         panic!()
     }
-    pub fn type_cow_probe(_v: Option<COWProbe<'_>>) {}
-    pub fn type_cow_probe_req(_v: Option<COWProbe<'_>>) {}
-    pub fn to_cow_probe() -> COWProbe<'static> {
+    pub fn type_cow_probe(_v: Option<CowProbe<'_>>) {}
+    pub fn type_cow_probe_req(_v: Option<CowProbe<'_>>) {}
+    pub fn to_cow_probe() -> CowProbe<'static> {
         panic!()
     }
-    pub fn to_res_cow_probe() -> Result<COWProbe<'static>, &'static str> {
+    pub fn to_res_cow_probe() -> Result<CowProbe<'static>, &'static str> {
         panic!()
     }
     pub fn type_ip(_v: Option<SocketAddr>) {}

--- a/varnish-macros/src/model.rs
+++ b/varnish-macros/src/model.rs
@@ -150,7 +150,7 @@ impl ParamTy {
             Self::F64 => quote! { f64 },
             Self::I64 => quote! { i64 },
             Self::Probe => quote! { Probe },
-            Self::ProbeCow => quote! { COWProbe },
+            Self::ProbeCow => quote! { CowProbe },
             Self::SocketAddr => quote! { SocketAddr },
             Self::Str => quote! { Cow<'_, str> },
         }

--- a/varnish-macros/src/parser_args.rs
+++ b/varnish-macros/src/parser_args.rs
@@ -300,7 +300,7 @@ impl ParamTy {
             }
         }
 
-        if let Some(GenericArgument::Lifetime(_)) = as_one_gen_arg(ty, "COWProbe") {
+        if let Some(GenericArgument::Lifetime(_)) = as_one_gen_arg(ty, "CowProbe") {
             return Some(Self::ProbeCow);
         }
 

--- a/varnish-macros/tests/pass/function.rs
+++ b/varnish-macros/tests/pass/function.rs
@@ -9,7 +9,7 @@ mod types {
     use std::net::SocketAddr;
     use std::time::Duration;
     use varnish::ffi::VCL_STRING;
-    use varnish::vcl::{COWProbe, Probe, Workspace};
+    use varnish::vcl::{CowProbe, Probe, Workspace};
     use varnish_sys::vcl::VclError;
 
     // void
@@ -102,14 +102,14 @@ mod types {
         panic!()
     }
 
-    // COWProbe<'_
-    pub fn type_cow_probe(_v: Option<COWProbe<'_>>) {}
-    pub fn type_cow_probe_req(#[required] _v: Option<COWProbe<'_>>) {}
-    // FIXME: is it correct to return a COWProbe? If it has a lifetime, it must be tied to something else...
-    pub fn to_cow_probe() -> COWProbe<'static> {
+    // CowProbe<'_
+    pub fn type_cow_probe(_v: Option<CowProbe<'_>>) {}
+    pub fn type_cow_probe_req(#[required] _v: Option<CowProbe<'_>>) {}
+    // FIXME: is it correct to return a CowProbe? If it has a lifetime, it must be tied to something else...
+    pub fn to_cow_probe() -> CowProbe<'static> {
         panic!()
     }
-    pub fn to_res_cow_probe() -> Result<COWProbe<'static>, &'static str> {
+    pub fn to_res_cow_probe() -> Result<CowProbe<'static>, &'static str> {
         panic!()
     }
 

--- a/varnish-sys/src/vcl/ctx.rs
+++ b/varnish-sys/src/vcl/ctx.rs
@@ -4,7 +4,7 @@ use std::ffi::{c_int, c_uint, c_void};
 
 use crate::ffi;
 use crate::ffi::{vrt_ctx, VRT_fail, VRT_CTX_MAGIC};
-use crate::vcl::{LogTag, TestWS, VclError, Workspace, HTTP};
+use crate::vcl::{HttpHeaders, LogTag, TestWS, VclError, Workspace};
 
 /// VCL context
 ///
@@ -31,11 +31,11 @@ use crate::vcl::{LogTag, TestWS, VclError, Workspace, HTTP};
 #[derive(Debug)]
 pub struct Ctx<'a> {
     pub raw: &'a mut vrt_ctx,
-    pub http_req: Option<HTTP<'a>>,
-    pub http_req_top: Option<HTTP<'a>>,
-    pub http_resp: Option<HTTP<'a>>,
-    pub http_bereq: Option<HTTP<'a>>,
-    pub http_beresp: Option<HTTP<'a>>,
+    pub http_req: Option<HttpHeaders<'a>>,
+    pub http_req_top: Option<HttpHeaders<'a>>,
+    pub http_resp: Option<HttpHeaders<'a>>,
+    pub http_bereq: Option<HttpHeaders<'a>>,
+    pub http_beresp: Option<HttpHeaders<'a>>,
     pub ws: Workspace<'a>,
 }
 
@@ -51,11 +51,11 @@ impl<'a> Ctx<'a> {
     pub fn from_ref(raw: &'a mut vrt_ctx) -> Self {
         assert_eq!(raw.magic, VRT_CTX_MAGIC);
         Self {
-            http_req: HTTP::new(raw.http_req),
-            http_req_top: HTTP::new(raw.http_req_top),
-            http_resp: HTTP::new(raw.http_resp),
-            http_bereq: HTTP::new(raw.http_bereq),
-            http_beresp: HTTP::new(raw.http_beresp),
+            http_req: HttpHeaders::new(raw.http_req),
+            http_req_top: HttpHeaders::new(raw.http_req_top),
+            http_resp: HttpHeaders::new(raw.http_resp),
+            http_bereq: HttpHeaders::new(raw.http_bereq),
+            http_beresp: HttpHeaders::new(raw.http_beresp),
             ws: Workspace::new(raw.ws),
             raw,
         }

--- a/varnish-sys/src/vcl/error.rs
+++ b/varnish-sys/src/vcl/error.rs
@@ -9,7 +9,7 @@ pub struct VclError {
 impl VclError {
     /// Create a new `Error` from a string
     pub fn new(s: String) -> Self {
-        VclError { s }
+        Self { s }
     }
 }
 
@@ -29,13 +29,13 @@ impl std::error::Error for VclError {}
 
 impl From<String> for VclError {
     fn from(s: String) -> Self {
-        VclError { s }
+        Self { s }
     }
 }
 
 impl From<&str> for VclError {
     fn from(s: &str) -> Self {
-        VclError { s: s.into() }
+        Self { s: s.into() }
     }
 }
 

--- a/varnish-sys/src/vcl/http.rs
+++ b/varnish-sys/src/vcl/http.rs
@@ -1,6 +1,6 @@
 //! Headers and top line of an HTTP object
 //!
-//! Depending on the VCL subroutine, the `Ctx` will give access to various [`HTTP`] object which
+//! Depending on the VCL subroutine, the `Ctx` will give access to various [`HttpHeaders`] object which
 //! expose the request line (`req`, `req_top` and `bereq`), response line (`resp`, `beresp`) and
 //! headers of the objects Varnish is manipulating.
 //!
@@ -29,16 +29,16 @@ const HDR_STATUS: u16 = ffi::HTTP_HDR_STATUS as u16;
 const HDR_UNSET: u16 = ffi::HTTP_HDR_UNSET as u16;
 const HDR_URL: u16 = ffi::HTTP_HDR_URL as u16;
 
-/// HTTP headers of an object
+/// HTTP headers of an object, wrapping `HTTP` from Varnish
 #[derive(Debug)]
-pub struct HTTP<'a> {
+pub struct HttpHeaders<'a> {
     pub raw: &'a mut ffi::http,
 }
 
-impl<'a> HTTP<'a> {
+impl<'a> HttpHeaders<'a> {
     /// Wrap a raw pointer into an object we can use.
     pub fn new(p: ffi::VCL_HTTP) -> Option<Self> {
-        Some(HTTP {
+        Some(HttpHeaders {
             raw: unsafe { p.0.as_mut()? },
         })
     }
@@ -192,24 +192,24 @@ impl<'a> HTTP<'a> {
     }
 }
 
-impl<'a> IntoIterator for &'a HTTP<'a> {
+impl<'a> IntoIterator for &'a HttpHeaders<'a> {
     type Item = (&'a str, &'a str);
-    type IntoIter = HTTPIter<'a>;
+    type IntoIter = HttpHeadersIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
-        HTTPIter {
+        Self::IntoIter {
             http: self,
             cursor: HDR_FIRST as isize,
         }
     }
 }
 
-impl<'a> IntoIterator for &'a mut HTTP<'a> {
+impl<'a> IntoIterator for &'a mut HttpHeaders<'a> {
     type Item = (&'a str, &'a str);
-    type IntoIter = HTTPIter<'a>;
+    type IntoIter = HttpHeadersIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
-        HTTPIter {
+        Self::IntoIter {
             http: self,
             cursor: HDR_FIRST as isize,
         }
@@ -217,12 +217,12 @@ impl<'a> IntoIterator for &'a mut HTTP<'a> {
 }
 
 #[derive(Debug)]
-pub struct HTTPIter<'a> {
-    http: &'a HTTP<'a>,
+pub struct HttpHeadersIter<'a> {
+    http: &'a HttpHeaders<'a>,
     cursor: isize,
 }
 
-impl<'a> Iterator for HTTPIter<'a> {
+impl<'a> Iterator for HttpHeadersIter<'a> {
     type Item = (&'a str, &'a str);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/varnish-sys/src/vcl/probe.rs
+++ b/varnish-sys/src/vcl/probe.rs
@@ -5,14 +5,14 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub enum COWRequest<'a> {
+pub enum CowRequest<'a> {
     URL(Cow<'a, str>),
     Text(Cow<'a, str>),
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct COWProbe<'a> {
-    pub request: COWRequest<'a>,
+pub struct CowProbe<'a> {
+    pub request: CowRequest<'a>,
     pub timeout: Duration,
     pub interval: Duration,
     pub exp_status: c_uint,
@@ -38,12 +38,12 @@ pub struct Probe {
     pub initial: c_uint,
 }
 
-impl<'a> COWProbe<'a> {
+impl<'a> CowProbe<'a> {
     pub fn to_owned(&self) -> Probe {
         Probe {
             request: match &self.request {
-                COWRequest::URL(cow) => Request::URL(cow.to_string()),
-                COWRequest::Text(cow) => Request::Text(cow.to_string()),
+                CowRequest::URL(cow) => Request::URL(cow.to_string()),
+                CowRequest::Text(cow) => Request::Text(cow.to_string()),
             },
             timeout: self.timeout,
             interval: self.interval,

--- a/varnish-sys/src/vcl/vsb.rs
+++ b/varnish-sys/src/vcl/vsb.rs
@@ -1,26 +1,25 @@
-//! VSB, growable buffer
-
 use std::ffi::c_void;
 
 use crate::ffi;
 
+/// A wrapper for scalable/growable buffer (VSB) managed by Varnish
 #[derive(Debug)]
-pub struct Vsb<'a> {
+pub struct Buffer<'a> {
     /// Raw pointer to the C struct
     pub raw: &'a mut ffi::vsb,
 }
 
-impl<'a> Vsb<'a> {
+impl<'a> Buffer<'a> {
     /// Create a `Vsb` from a C pointer
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn new(raw: *mut ffi::vsb) -> Self {
         let raw = unsafe { raw.as_mut().unwrap() };
         assert_eq!(raw.magic, ffi::VSB_MAGIC);
-        Vsb { raw }
+        Self { raw }
     }
 
-    /// Push a buffer into the `Vsb`
-    pub fn cat<T: AsRef<[u8]>>(&mut self, src: &T) -> Result<(), ()> {
+    /// Push a buffer into the buffer
+    pub fn write<T: AsRef<[u8]>>(&mut self, src: &T) -> Result<(), ()> {
         let buf = src.as_ref().as_ptr().cast::<c_void>();
         let l = src.as_ref().len();
 

--- a/varnish-sys/src/vcl/ws.rs
+++ b/varnish-sys/src/vcl/ws.rs
@@ -37,7 +37,7 @@ impl<'a> Workspace<'a> {
     /// Wrap a raw pointer into an object we can use.
     pub fn new(raw: *mut ffi::ws) -> Self {
         assert!(!raw.is_null(), "raw pointer was null");
-        Workspace {
+        Self {
             raw,
             phantom_a: PhantomData,
         }
@@ -242,7 +242,7 @@ impl TestWS {
         let aligned_sz = (sz / al) * al;
         let mut v: Vec<c_char> = vec![0; sz];
         let s = v.as_mut_ptr();
-        TestWS {
+        Self {
             c_ws: ffi::ws {
                 magic: ffi::WS_MAGIC,
                 id: ['t' as c_char, 's' as c_char, 't' as c_char, '\0' as c_char],

--- a/varnish/src/vsc.rs
+++ b/varnish/src/vsc.rs
@@ -48,7 +48,7 @@ impl<'a> VSCBuilder<'a> {
             assert!(!vsc.is_null());
             // get raw value, we can always clamp them later
             ffi::VSC_Arg(vsc, 'r' as c_char, ptr::null());
-            VSCBuilder {
+            Self {
                 vsm,
                 vsc,
                 phantom: PhantomData,

--- a/vmod_test/src/lib.rs
+++ b/vmod_test/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::ffi::CStr;
 
-use varnish::vcl::{Ctx, FetchProcessor, InitResult, PullResult, VFPCtx};
+use varnish::vcl::{Ctx, FetchProcCtx, FetchProcessor, InitResult, PullResult};
 use varnish::vmod;
 
 varnish::run_vtc_tests!("tests/*.vtc");
@@ -17,7 +17,7 @@ mod rustest {
     use varnish::ffi;
     use varnish::ffi::VCL_STRING;
     use varnish::vcl::{
-        new_vfp, COWProbe, COWRequest, Ctx, Event, Probe, Request, VclError, Workspace,
+        new_vfp, CowProbe, CowRequest, Ctx, Event, Probe, Request, VclError, Workspace,
     };
 
     use super::VFPTest;
@@ -121,13 +121,13 @@ mod rustest {
         arg
     }
 
-    pub fn cowprobe_prop(probe: Option<COWProbe<'_>>) -> String {
+    pub fn cowprobe_prop(probe: Option<CowProbe<'_>>) -> String {
         match probe {
             Some(probe) => format!(
                 "{}-{}-{}-{}-{}-{}",
                 match probe.request {
-                    COWRequest::URL(url) => format!("url:{url}"),
-                    COWRequest::Text(text) => format!("text:{text}"),
+                    CowRequest::URL(url) => format!("url:{url}"),
+                    CowRequest::Text(text) => format!("text:{text}"),
                 },
                 probe.threshold,
                 probe.timeout.as_secs(),
@@ -196,11 +196,11 @@ impl FetchProcessor for VFPTest {
         c"vfptest"
     }
 
-    fn new(_: &mut Ctx, _: &mut VFPCtx) -> InitResult<Self> {
+    fn new(_: &mut Ctx, _: &mut FetchProcCtx) -> InitResult<Self> {
         InitResult::Pass
     }
 
-    fn pull(&mut self, _: &mut VFPCtx, _: &mut [u8]) -> PullResult {
+    fn pull(&mut self, _: &mut FetchProcCtx, _: &mut [u8]) -> PullResult {
         PullResult::Err
     }
 }


### PR DESCRIPTION
* `COWProbe` struct to `CowProbe`
* `COWRequest` struct to `CowRequest`
* `HTTP` struct to `HttpHeaders`
* `HTTPIter` struct to `HttpHeadersIter`
* `VDPCtx` struct to `DeliveryProcCtx`
* `VDP` trait to `DeliveryProcessor`
* `VFPCtx` struct to `FetchProcCtx`
* `VFP` trait to `FetchProcessor`
* `VSB` struct to `Buffer`
* `VSB::cat` function to `Buffer::write`