### PR TITLE
Some tiny clippy lint fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,35 +43,16 @@ similar.opt-level = 3
 unused_qualifications = "warn"
 
 [workspace.lints.clippy]
-# regular warnings - these should probably be fixed first
+# FIXME: safety doc lints are disabled for now, but should be enabled eventually
 missing_safety_doc = "allow"
-new_without_default = "allow"
-len_without_is_empty = "allow"
-not_unsafe_ptr_arg_deref = "allow"  # this one seems pretty bad
-result_unit_err = "allow"
 
 # Pedantic lints - these are more subjective, and some might stay disabled permanently
 pedantic = { level = "warn", priority = -1 }
-bool_to_int_with_if = "allow"
-cast_lossless = "allow"
 cast_possible_truncation = "allow"
 cast_possible_wrap = "allow"
-cast_ptr_alignment = "allow"  # this one is really suspicious
 cast_sign_loss = "allow"
-checked_conversions = "allow"
-derive_partial_eq_without_eq = "allow"
-doc_markdown = "allow"
-implicit_hasher = "allow"
-into_iter_without_iter = "allow"
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"
 module_name_repetitions = "allow"
 must_use_candidate = "allow"
-needless_pass_by_value = "allow"
-ptr_as_ptr = "allow"
-ptr_cast_constness = "allow"
-redundant_closure_for_method_calls = "allow"
-ref_as_ptr = "allow"
 similar_names = "allow"
-struct_field_names = "allow"
-wildcard_imports = "allow"

--- a/examples/vmod_object/src/lib.rs
+++ b/examples/vmod_object/src/lib.rs
@@ -43,7 +43,8 @@ mod object {
                 .lock() // lock the mutex to access the hashmap
                 .unwrap() // panic if unlocking went wrong
                 .get(key) // look for key
-                .map_or(String::new(), |v| v.to_string()) // used EMPTY_STRING if key isn't found
+                .cloned() // create a copy of the value
+                .unwrap_or_default() // used EMPTY_STRING if key isn't found
         }
 
         /// Insert a key-value pair into the store.

--- a/varnish-macros/src/gen_docs.rs
+++ b/varnish-macros/src/gen_docs.rs
@@ -138,8 +138,7 @@ fn fn_sig(func: &FuncInfo, user_args: &Vec<(&ParamTypeInfo, &ParamInfo)>) -> Str
         wrt!(res, "`");
     }
     if matches!(func.func_type, FuncType::Function | FuncType::Method) {
-        let ret = func.returns.value_type().to_vcc_type();
-        wrt!(res, "{ret} ");
+        wrt!(res, "{} ", func.returns.value_type().to_vcc_type());
     }
     wrt!(res, "{}(", func.ident);
     let mut first = true;
@@ -149,7 +148,7 @@ fn fn_sig(func: &FuncInfo, user_args: &Vec<(&ParamTypeInfo, &ParamInfo)>) -> Str
         } else {
             wrt!(res, ", ");
         }
-        wrt!(res, "{}", bracketed_name(arg, ty));
+        res.push_str(&bracketed_name(arg, ty));
         if !ty.default.is_null() {
             wrt!(res, " = {}", ty.default);
         }

--- a/varnish-macros/src/gen_func.rs
+++ b/varnish-macros/src/gen_func.rs
@@ -347,16 +347,15 @@ impl FuncProcessor {
         arg_name: String,
         is_optional_arg: bool,
         vcc_type: &str,
-        default: Value,
+        mut default: Value,
     ) -> Vec<Value> {
         // JSON data for each argument:
         //   [VCC_type, arg_name, default_value, spec(?), is_optional]
-        let default = if default == Value::Null {
-            Value::Null
-        } else {
+        if !default.is_null() {
+            // The default value must be a string containing C code (?)
             // This ensures the string is properly escaped and surrounded by quotes
-            default.to_string().into()
-        };
+            default = default.to_string().into();
+        }
         let mut json_arg: Vec<Value> = vec![
             vcc_type.into(),
             arg_name.into(),

--- a/varnish-macros/src/model.rs
+++ b/varnish-macros/src/model.rs
@@ -101,7 +101,7 @@ pub struct ParamTypeInfo {
 /// Represents the type of the function argument.
 #[derive(Debug, Clone)]
 pub enum ParamType {
-    /// An argument representing Varnish context (VRT_CTX) wrapper
+    /// An argument representing Varnish context (`VRT_CTX`) wrapper
     Context { is_mut: bool },
     /// An argument representing Varnish Workspace wrapper
     Workspace { is_mut: bool },

--- a/varnish-macros/src/names.rs
+++ b/varnish-macros/src/names.rs
@@ -13,49 +13,51 @@ use crate::model::FuncType;
 #[derive(Debug, Default)]
 pub struct Names {
     /// Name of the user's `mod`
-    mod_name: String,
-    obj_name: Option<String>,
-    fn_name: Option<(FuncType, String)>,
+    module: String,
+    /// In case this is an object, its name
+    object: Option<String>,
+    /// In case this is a function, its name
+    function: Option<(FuncType, String)>,
 }
 
 impl Names {
     pub fn new(mod_name: &str) -> Self {
         Self {
-            mod_name: mod_name.to_string(),
-            obj_name: None,
-            fn_name: None,
+            module: mod_name.to_string(),
+            object: None,
+            function: None,
         }
     }
 
     pub fn to_obj(&self, obj_name: &str) -> Self {
-        assert!(self.obj_name.is_none());
-        assert!(self.fn_name.is_none());
+        assert!(self.object.is_none());
+        assert!(self.function.is_none());
         Self {
-            mod_name: self.mod_name.clone(),
-            obj_name: Some(obj_name.to_string()),
-            fn_name: None,
+            module: self.module.clone(),
+            object: Some(obj_name.to_string()),
+            function: None,
         }
     }
 
     pub fn to_func(&self, func_type: FuncType, fn_name: &str) -> Self {
-        assert!(self.fn_name.is_none());
+        assert!(self.function.is_none());
         Self {
-            mod_name: self.mod_name.clone(),
-            obj_name: self.obj_name.clone(),
-            fn_name: Some((func_type, fn_name.to_string())),
+            module: self.module.clone(),
+            object: self.object.clone(),
+            function: Some((func_type, fn_name.to_string())),
         }
     }
 
     pub fn mod_name(&self) -> &str {
-        &self.mod_name
+        &self.module
     }
 
     pub fn obj_name(&self) -> &str {
-        self.obj_name.as_ref().unwrap()
+        self.object.as_ref().unwrap()
     }
 
     pub fn fn_name(&self) -> &str {
-        let (ty, name) = self.fn_name.as_ref().unwrap();
+        let (ty, name) = self.function.as_ref().unwrap();
         match *ty {
             FuncType::Constructor => "_init",
             FuncType::Destructor => "_fini",
@@ -64,7 +66,7 @@ impl Names {
     }
 
     pub fn fn_name_user(&self) -> &str {
-        self.fn_name.as_ref().unwrap().1.as_str()
+        self.function.as_ref().unwrap().1.as_str()
     }
 
     pub fn fn_callable_name(&self, func: FuncType) -> TokenStream {
@@ -85,15 +87,15 @@ impl Names {
     }
 
     pub fn func_struct_name(&self) -> String {
-        format!("Vmod_vmod_{}_Func", self.mod_name)
+        format!("Vmod_vmod_{}_Func", self.module)
     }
 
     pub fn data_struct_name(&self) -> String {
-        format!("Vmod_{}_Data", self.mod_name)
+        format!("Vmod_{}_Data", self.module)
     }
 
     pub fn struct_obj_name(&self) -> String {
-        format!("struct vmod_{}_{}", self.mod_name, self.obj_name())
+        format!("struct vmod_{}_{}", self.module, self.obj_name())
     }
 
     pub fn wrapper_fn_name(&self) -> String {
@@ -106,7 +108,7 @@ impl Names {
         let (underscore, obj_name) = self.obj_name_parts();
         format!(
             "arg_vmod_{}{underscore}{obj_name}_{}",
-            self.mod_name,
+            self.module,
             self.fn_name()
         )
     }
@@ -115,7 +117,7 @@ impl Names {
         let (underscore, obj_name) = self.obj_name_parts();
         format!(
             "td_vmod_{}{underscore}{obj_name}_{}",
-            self.mod_name,
+            self.module,
             self.fn_name()
         )
     }
@@ -128,8 +130,8 @@ impl Names {
     // Helper utils
 
     fn obj_name_parts(&self) -> (&str, &str) {
-        let underscore = self.obj_name.as_ref().map_or("", |_| "_");
-        let obj_name = self.obj_name.as_ref().map_or("", |v| v.as_str());
+        let underscore = self.object.as_ref().map_or("", |_| "_");
+        let obj_name = self.object.as_ref().map_or("", |v| v.as_str());
         (underscore, obj_name)
     }
 }

--- a/varnish-macros/src/parser.rs
+++ b/varnish-macros/src/parser.rs
@@ -79,7 +79,7 @@ impl ObjInfo {
     /// Parse an `impl` block and treat all public functions as object methods
     fn parse(item_impl: &mut ItemImpl, shared_types: &mut SharedTypes) -> ProcResult<Self> {
         let mut errors = Errors::new();
-        let ident = parser_utils::as_simple_ty(item_impl.self_ty.as_ref()).map(|v| v.to_string());
+        let ident = parser_utils::as_simple_ty(item_impl.self_ty.as_ref()).map(ToString::to_string);
 
         // Add only one error per object impl declaration
         if item_impl.trait_.as_ref().is_some() {

--- a/varnish-macros/src/parser_utils.rs
+++ b/varnish-macros/src/parser_utils.rs
@@ -11,7 +11,7 @@ use crate::errors::error;
 use crate::model::{FuncInfo, ObjInfo};
 use crate::ProcResult;
 
-/// iterator to go over all functions in a ObjInfo, including constructor and destructor
+/// iterator to go over all functions in a [`ObjInfo`], including constructor and destructor
 pub struct ObjFuncIter<'a> {
     obj: &'a ObjInfo,
     idx: usize,

--- a/varnish-sys/src/extensions.rs
+++ b/varnish-sys/src/extensions.rs
@@ -41,8 +41,7 @@ impl vmod_priv {
     ///
     /// SAFETY: `priv_` must be a valid pointer to a `T` object or `NULL`.
     pub unsafe extern "C" fn on_fini<T>(_ctx: *const vrt_ctx, mut priv_: *mut c_void) {
-        // we get the ownership and don't do anything with it, so it gets dropped at the end of this fn
-        get_owned_bbox::<T>(&mut priv_);
+        drop(get_owned_bbox::<T>(&mut priv_));
     }
 }
 

--- a/varnish-sys/src/vcl/processor.rs
+++ b/varnish-sys/src/vcl/processor.rs
@@ -80,12 +80,12 @@ pub unsafe extern "C" fn gen_vdp_fini<T: DeliveryProcessor>(
     _: *mut vdp_ctx,
     priv_: *mut *mut c_void,
 ) -> c_int {
-    if priv_.is_null() {
-        return 0;
+    if !priv_.is_null() {
+        assert_ne!(*priv_, ptr::null_mut());
+        drop(Box::from_raw((*priv_).cast::<T>()));
+        *priv_ = ptr::null_mut();
     }
-    assert_ne!(*priv_, ptr::null_mut());
-    drop(Box::from_raw((*priv_).cast::<T>()));
-    *priv_ = ptr::null_mut();
+
     0
 }
 

--- a/varnish-sys/src/vcl/vsb.rs
+++ b/varnish-sys/src/vcl/vsb.rs
@@ -19,6 +19,7 @@ impl<'a> Buffer<'a> {
     }
 
     /// Push a buffer into the buffer
+    #[expect(clippy::result_unit_err)] // FIXME: what should the error be? VclError?
     pub fn write<T: AsRef<[u8]>>(&mut self, src: &T) -> Result<(), ()> {
         let buf = src.as_ref().as_ptr().cast::<c_void>();
         let l = src.as_ref().len();

--- a/varnish-sys/src/vcl/ws.rs
+++ b/varnish-sys/src/vcl/ws.rs
@@ -258,7 +258,7 @@ impl TestWS {
     /// Return a pointer to the underlying C ws struct. As usual, the caller needs to ensure that
     /// self doesn't outlive the returned pointer.
     pub fn as_ptr(&mut self) -> *mut ffi::ws {
-        &mut self.c_ws as *mut ffi::ws
+        ptr::from_mut::<ffi::ws>(&mut self.c_ws)
     }
 
     /// build a `Workspace`

--- a/varnish/src/vsc.rs
+++ b/varnish/src/vsc.rs
@@ -40,6 +40,7 @@ pub struct VSCBuilder<'a> {
 
 impl<'a> VSCBuilder<'a> {
     /// Create a new `VSCBuilder`
+    #[expect(clippy::new_without_default)] // TODO: consider implementing
     pub fn new() -> Self {
         unsafe {
             let vsm = ffi::VSM_New();
@@ -130,7 +131,7 @@ impl<'a> VSCBuilder<'a> {
                     self.vsc,
                     Some(add_point),
                     Some(del_point),
-                    (&mut *internal as *mut VSCInternal).cast::<c_void>(),
+                    ptr::from_mut::<VSCInternal>(&mut *internal).cast::<c_void>(),
                 );
             }
             let vsm = self.vsm;
@@ -310,7 +311,7 @@ impl<'a> Stat<'a> {
         // the pointer is valid as long as VSC exist, and
         // VSC.update() isn't called (which uses `&mut self`)
         let v = unsafe { *self.value };
-        if v <= i64::MAX as u64 {
+        if i64::try_from(v).is_ok() {
             v
         } else {
             0

--- a/vmod_test/src/lib.rs
+++ b/vmod_test/src/lib.rs
@@ -45,7 +45,7 @@ mod rustest {
             Ok(()) => {
                 let final_buf = rbuf.release(0);
                 assert_eq!(final_buf.len(), 3 * s.len() + 3);
-                Ok(VCL_STRING(final_buf.as_ptr() as *const i8))
+                Ok(VCL_STRING(final_buf.as_ptr().cast::<i8>()))
             }
             _ => Err("workspace issue"),
         }
@@ -114,7 +114,7 @@ mod rustest {
         for chunk in body_chunks {
             r.buf.write_all(chunk).map_err(|_| "workspace issue")?;
         }
-        Ok(VCL_STRING(r.release(0).as_ptr() as *const i8))
+        Ok(VCL_STRING(r.release(0).as_ptr().cast::<i8>()))
     }
 
     pub fn default_arg(#[default("foo")] arg: &str) -> &str {


### PR DESCRIPTION
Many fixes were suggested by clippy (some are no longer listed in the Cargo.toml).  Other than cosmetic changes, did a few minor improvements:

* Add `Clone, Copy` traits to `StreamClose` enum
* `HttpHeaders` now has `iter()` method used by `IntoIterator` implementation. I also removed the IntoIterator on `&mut` - it does not seem to be needed.
* I am still really worried about `transmute::<u32, VslTag>((self.raw.logtag as u32) + u32::from(HDR_FIRST))` -- seems like a major hack, but need feedback if this logic was correct.
* The `ws.alloc` API returns a pointer to the u8, which could be mis-aligned for bigger objects, and is currently marked as "safe". Need to rethink it.
* The `Buffer::write` returns `Result<(), ()>` -- we should return proper error - any thoughts?
* Should `Transfer` trait have an `is_empty()` method?  Clippy suggests it when there is a `len()` method.