### PR TITLE
Use much faster DashMap with vmod_kv example

### DIFF
--- a/examples/vmod_object/Cargo.toml
+++ b/examples/vmod_object/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 
 [dependencies]
 varnish.workspace = true
+dashmap = "6.1.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/vmod_object/README.md
+++ b/examples/vmod_object/README.md
@@ -43,3 +43,6 @@ to avoid this double-copy.
 #### Method `VOID set(STRING key, STRING value)`
 
 Insert a key-value pair into the store.
+
+Note that varnish-accessible functions use readonly `&self`,
+so the interior mutability pattern should be used to store data.


### PR DESCRIPTION
A few followups to this:
* `pub struct` should NOT be allowed inside the vmod - it should be defined outside of it. Not sure why it is currently allowed.
* We may need to rethink `Send`/`Sync` requirements for objects.  Technically, the ownership of the object is sent to Varnish ... which I guess is like another thread - so must be `Send`?