### PR TITLE
Rework error handling with TryFrom

### DIFF
--- a/varnish-macros/snapshots/docs_types@code.snap
+++ b/varnish-macros/snapshots/docs_types@code.snap
@@ -13,8 +13,8 @@ mod types {
      * The end
      */
     #[allow(non_snake_case, unused_imports, unused_qualifications, unused_variables)]
+    #[allow(clippy::needless_question_mark)]
     mod varnish_generated {
-        use std::borrow::Cow;
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
@@ -27,10 +27,12 @@ mod types {
         unsafe extern "C" fn vmod_c_with_docs(__ctx: *mut vrt_ctx) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __result = super::with_docs();
+            __result
         }
         unsafe extern "C" fn vmod_c_no_docs(__ctx: *mut vrt_ctx) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __result = super::no_docs();
+            __result
         }
         unsafe extern "C" fn vmod_c_doctest(
             __ctx: *mut vrt_ctx,
@@ -38,14 +40,13 @@ mod types {
             _v: VCL_INT,
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0: i64 = _no_docs.into();
-            let __var1: i64 = _v.into();
-            let __result = super::doctest(__var0, __var1);
+            let __result = super::doctest(_no_docs.into(), _v.into());
+            __result
         }
         unsafe extern "C" fn vmod_c_arg_only(__ctx: *mut vrt_ctx, _v: VCL_INT) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0: i64 = _v.into();
-            let __result = super::arg_only(__var0);
+            let __result = super::arg_only(_v.into());
+            __result
         }
         #[repr(C)]
         struct arg_vmod_types_DocStruct__init {
@@ -60,18 +61,19 @@ mod types {
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
-            let __var0: Option<i64> = if __args.valid_cap != 0 {
-                __args.cap.into()
-            } else {
-                None
-            };
-            let __result = super::DocStruct::new(__var0);
+            let __result = super::DocStruct::new(
+                if __args.valid_cap != 0 { __args.cap.into() } else { None },
+            );
             let __result = Box::new(__result);
             *__objp = Box::into_raw(__result);
+            let __result = ();
+            __result
         }
         unsafe extern "C" fn vmod_c_DocStruct__fini(__objp: *mut *mut DocStruct) {
             drop(Box::from_raw(*__objp));
             *__objp = ::std::ptr::null_mut();
+            let __result = ();
+            __result
         }
         unsafe extern "C" fn vmod_c_DocStruct_function(
             __ctx: *mut vrt_ctx,
@@ -80,9 +82,15 @@ mod types {
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __obj = __obj.as_ref().unwrap();
-            let __var1: Cow<'_, str> = key.into();
-            let __var1 = __var1.as_ref();
-            let __result = __obj.function(__var1);
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = __obj.function(key.try_into()?);
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
+                    __ctx.fail(err);
+                })
         }
         #[repr(C)]
         pub struct VmodExports {

--- a/varnish-macros/snapshots/event1_event@code.snap
+++ b/varnish-macros/snapshots/event1_event@code.snap
@@ -4,8 +4,8 @@ snapshot_kind: text
 ---
 mod event {
     #[allow(non_snake_case, unused_imports, unused_qualifications, unused_variables)]
+    #[allow(clippy::needless_question_mark)]
     mod varnish_generated {
-        use std::borrow::Cow;
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
@@ -22,7 +22,8 @@ mod event {
         ) -> VCL_INT {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __result = super::on_event(__ev);
-            VCL_INT(0)
+            let __result = VCL_INT(0);
+            __result
         }
         #[repr(C)]
         pub struct VmodExports {

--- a/varnish-macros/snapshots/event2_event2@code.snap
+++ b/varnish-macros/snapshots/event2_event2@code.snap
@@ -4,8 +4,8 @@ snapshot_kind: text
 ---
 mod event2 {
     #[allow(non_snake_case, unused_imports, unused_qualifications, unused_variables)]
+    #[allow(clippy::needless_question_mark)]
     mod varnish_generated {
-        use std::borrow::Cow;
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
@@ -21,14 +21,17 @@ mod event2 {
             __ev: VclEvent,
         ) -> VCL_INT {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::on_event(&__ctx, __ev);
-            match __result {
-                Ok(_) => VCL_INT(0),
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::on_event(&__ctx, __ev)?;
+                let __result = VCL_INT(0);
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     VCL_INT(1)
-                }
-            }
+                })
         }
         #[repr(C)]
         pub struct VmodExports {

--- a/varnish-macros/snapshots/function_types@code.snap
+++ b/varnish-macros/snapshots/function_types@code.snap
@@ -4,8 +4,8 @@ snapshot_kind: text
 ---
 mod types {
     #[allow(non_snake_case, unused_imports, unused_qualifications, unused_variables)]
+    #[allow(clippy::needless_question_mark)]
     mod varnish_generated {
-        use std::borrow::Cow;
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
@@ -18,46 +18,53 @@ mod types {
         unsafe extern "C" fn vmod_c_to_void(__ctx: *mut vrt_ctx) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __result = super::to_void();
+            __result
         }
         unsafe extern "C" fn vmod_c_to_res_void_err(__ctx: *mut vrt_ctx) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_res_void_err();
-            match __result {
-                Ok(__result) => {}
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_res_void_err()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_to_res_str_err(__ctx: *mut vrt_ctx) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_res_str_err();
-            match __result {
-                Ok(__result) => {}
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_res_str_err()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_to_res_box_err(__ctx: *mut vrt_ctx) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_res_box_err();
-            match __result {
-                Ok(__result) => {}
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_res_box_err()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_type_bool(__ctx: *mut vrt_ctx, _v: VCL_BOOL) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0: bool = _v.into();
-            let __result = super::type_bool(__var0);
+            let __result = super::type_bool(_v.into());
+            __result
         }
         unsafe extern "C" fn vmod_c_type_bool_dflt(__ctx: *mut vrt_ctx, _v: VCL_BOOL) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0: bool = _v.into();
-            let __result = super::type_bool_dflt(__var0);
+            let __result = super::type_bool_dflt(_v.into());
+            __result
         }
         #[repr(C)]
         struct arg_vmod_types_opt_bool {
@@ -70,47 +77,43 @@ mod types {
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
-            let __var0: Option<bool> = if __args.valid__v != 0 {
-                __args._v.into()
-            } else {
-                None
-            };
-            let __result = super::opt_bool(__var0);
+            let __result = super::opt_bool(
+                if __args.valid__v != 0 { __args._v.into() } else { None },
+            );
+            __result
         }
         unsafe extern "C" fn vmod_c_to_bool(__ctx: *mut vrt_ctx) -> VCL_BOOL {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_bool();
-            match __result.into_vcl(&mut __ctx.ws) {
-                Ok(v) => v,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_bool();
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_to_res_bool(__ctx: *mut vrt_ctx) -> VCL_BOOL {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_res_bool();
-            match __result {
-                Ok(__result) => {
-                    match __result.into_vcl(&mut __ctx.ws) {
-                        Ok(v) => v,
-                        Err(err) => {
-                            __ctx.fail(err);
-                            Default::default()
-                        }
-                    }
-                }
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_res_bool()?;
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_type_cstr(__ctx: *mut vrt_ctx, _v: VCL_STRING) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0: &CStr = _v.into();
-            let __result = super::type_cstr(__var0);
+            let __result = super::type_cstr(_v.into());
+            __result
         }
         #[repr(C)]
         struct arg_vmod_types_opt_cstr {
@@ -123,30 +126,28 @@ mod types {
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
-            let __var0: Option<&CStr> = if __args.valid__v != 0 {
-                __args._v.into()
-            } else {
-                None
-            };
-            let __result = super::opt_cstr(__var0);
+            let __result = super::opt_cstr(
+                if __args.valid__v != 0 { __args._v.into() } else { None },
+            );
+            __result
         }
         unsafe extern "C" fn vmod_c_opt_cstr_req(__ctx: *mut vrt_ctx, _v: VCL_STRING) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0: Option<&CStr> = _v.into();
-            let __result = super::opt_cstr_req(__var0);
+            let __result = super::opt_cstr_req(_v.into());
+            __result
         }
         unsafe extern "C" fn vmod_c_type_cstr_dflt(__ctx: *mut vrt_ctx, _v: VCL_STRING) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0: &CStr = _v.into();
-            let __result = super::type_cstr_dflt(__var0);
+            let __result = super::type_cstr_dflt(_v.into());
+            __result
         }
         unsafe extern "C" fn vmod_c_type_cstr_dflt2(
             __ctx: *mut vrt_ctx,
             _v: VCL_STRING,
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0: &CStr = _v.into();
-            let __result = super::type_cstr_dflt2(__var0);
+            let __result = super::type_cstr_dflt2(_v.into());
+            __result
         }
         #[repr(C)]
         struct arg_vmod_types_opt_cstr_dflt {
@@ -159,25 +160,23 @@ mod types {
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
-            let __var0: Option<&CStr> = if __args.valid__v != 0 {
-                __args._v.into()
-            } else {
-                None
-            };
-            let __result = super::opt_cstr_dflt(__var0);
+            let __result = super::opt_cstr_dflt(
+                if __args.valid__v != 0 { __args._v.into() } else { None },
+            );
+            __result
         }
         unsafe extern "C" fn vmod_c_opt_cstr_dflt2(__ctx: *mut vrt_ctx, _v: VCL_STRING) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0: &CStr = _v.into();
-            let __result = super::opt_cstr_dflt2(__var0);
+            let __result = super::opt_cstr_dflt2(_v.into());
+            __result
         }
         unsafe extern "C" fn vmod_c_type_duration(
             __ctx: *mut vrt_ctx,
             _v: VCL_DURATION,
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0: Duration = _v.into();
-            let __result = super::type_duration(__var0);
+            let __result = super::type_duration(_v.into());
+            __result
         }
         #[repr(C)]
         struct arg_vmod_types_opt_duration {
@@ -190,54 +189,50 @@ mod types {
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
-            let __var0: Option<Duration> = if __args.valid__v != 0 {
-                __args._v.into()
-            } else {
-                None
-            };
-            let __result = super::opt_duration(__var0);
+            let __result = super::opt_duration(
+                if __args.valid__v != 0 { __args._v.into() } else { None },
+            );
+            __result
         }
         unsafe extern "C" fn vmod_c_to_duration(__ctx: *mut vrt_ctx) -> VCL_DURATION {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_duration();
-            match __result.into_vcl(&mut __ctx.ws) {
-                Ok(v) => v,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_duration();
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_to_res_duration(
             __ctx: *mut vrt_ctx,
         ) -> VCL_DURATION {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_res_duration();
-            match __result {
-                Ok(__result) => {
-                    match __result.into_vcl(&mut __ctx.ws) {
-                        Ok(v) => v,
-                        Err(err) => {
-                            __ctx.fail(err);
-                            Default::default()
-                        }
-                    }
-                }
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_res_duration()?;
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_type_f64(__ctx: *mut vrt_ctx, _v: VCL_REAL) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0: f64 = _v.into();
-            let __result = super::type_f64(__var0);
+            let __result = super::type_f64(_v.into());
+            __result
         }
         unsafe extern "C" fn vmod_c_type_f64_dflt(__ctx: *mut vrt_ctx, _v: VCL_REAL) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0: f64 = _v.into();
-            let __result = super::type_f64_dflt(__var0);
+            let __result = super::type_f64_dflt(_v.into());
+            __result
         }
         #[repr(C)]
         struct arg_vmod_types_opt_f64 {
@@ -250,52 +245,48 @@ mod types {
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
-            let __var0: Option<f64> = if __args.valid__v != 0 {
-                __args._v.into()
-            } else {
-                None
-            };
-            let __result = super::opt_f64(__var0);
+            let __result = super::opt_f64(
+                if __args.valid__v != 0 { __args._v.into() } else { None },
+            );
+            __result
         }
         unsafe extern "C" fn vmod_c_to_f64(__ctx: *mut vrt_ctx) -> VCL_REAL {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_f64();
-            match __result.into_vcl(&mut __ctx.ws) {
-                Ok(v) => v,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_f64();
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_to_res_f64(__ctx: *mut vrt_ctx) -> VCL_REAL {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_res_f64();
-            match __result {
-                Ok(__result) => {
-                    match __result.into_vcl(&mut __ctx.ws) {
-                        Ok(v) => v,
-                        Err(err) => {
-                            __ctx.fail(err);
-                            Default::default()
-                        }
-                    }
-                }
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_res_f64()?;
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_type_i64(__ctx: *mut vrt_ctx, _v: VCL_INT) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0: i64 = _v.into();
-            let __result = super::type_i64(__var0);
+            let __result = super::type_i64(_v.into());
+            __result
         }
         unsafe extern "C" fn vmod_c_type_i64_dflt(__ctx: *mut vrt_ctx, _v: VCL_INT) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0: i64 = _v.into();
-            let __result = super::type_i64_dflt(__var0);
+            let __result = super::type_i64_dflt(_v.into());
+            __result
         }
         #[repr(C)]
         struct arg_vmod_types_opt_i64 {
@@ -308,48 +299,50 @@ mod types {
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
-            let __var0: Option<i64> = if __args.valid__v != 0 {
-                __args._v.into()
-            } else {
-                None
-            };
-            let __result = super::opt_i64(__var0);
+            let __result = super::opt_i64(
+                if __args.valid__v != 0 { __args._v.into() } else { None },
+            );
+            __result
         }
         unsafe extern "C" fn vmod_c_to_i64(__ctx: *mut vrt_ctx) -> VCL_INT {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_i64();
-            match __result.into_vcl(&mut __ctx.ws) {
-                Ok(v) => v,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_i64();
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_to_res_i64(__ctx: *mut vrt_ctx) -> VCL_INT {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_res_i64();
-            match __result {
-                Ok(__result) => {
-                    match __result.into_vcl(&mut __ctx.ws) {
-                        Ok(v) => v,
-                        Err(err) => {
-                            __ctx.fail(err);
-                            Default::default()
-                        }
-                    }
-                }
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_res_i64()?;
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_type_str(__ctx: *mut vrt_ctx, _v: VCL_STRING) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0: Cow<'_, str> = _v.into();
-            let __var0 = __var0.as_ref();
-            let __result = super::type_str(__var0);
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::type_str(_v.try_into()?);
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
+                    __ctx.fail(err);
+                })
         }
         #[repr(C)]
         struct arg_vmod_types_opt_str {
@@ -362,25 +355,41 @@ mod types {
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
-            let __var0: Option<Cow<'_, str>> = if __args.valid__v != 0 {
-                __args._v.into()
-            } else {
-                None
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::opt_str(
+                    if __args.valid__v != 0 { __args._v.try_into()? } else { None },
+                );
+                Ok(__result)
             };
-            let __var0 = __var0.as_deref();
-            let __result = super::opt_str(__var0);
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
+                    __ctx.fail(err);
+                })
         }
         unsafe extern "C" fn vmod_c_opt_str_req(__ctx: *mut vrt_ctx, _v: VCL_STRING) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0: Option<Cow<'_, str>> = _v.into();
-            let __var0 = __var0.as_deref();
-            let __result = super::opt_str_req(__var0);
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::opt_str_req(_v.try_into()?);
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
+                    __ctx.fail(err);
+                })
         }
         unsafe extern "C" fn vmod_c_type_str_dflt(__ctx: *mut vrt_ctx, _v: VCL_STRING) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0: Cow<'_, str> = _v.into();
-            let __var0 = __var0.as_ref();
-            let __result = super::type_str_dflt(__var0);
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::type_str_dflt(_v.try_into()?);
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
+                    __ctx.fail(err);
+                })
         }
         #[repr(C)]
         struct arg_vmod_types_opt_str_dflt {
@@ -393,105 +402,103 @@ mod types {
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
-            let __var0: Option<Cow<'_, str>> = if __args.valid__v != 0 {
-                __args._v.into()
-            } else {
-                None
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::opt_str_dflt(
+                    if __args.valid__v != 0 { __args._v.try_into()? } else { None },
+                );
+                Ok(__result)
             };
-            let __var0 = __var0.as_deref();
-            let __result = super::opt_str_dflt(__var0);
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
+                    __ctx.fail(err);
+                })
         }
         unsafe extern "C" fn vmod_c_to_str(__ctx: *mut vrt_ctx) -> VCL_STRING {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_str();
-            match __result.into_vcl(&mut __ctx.ws) {
-                Ok(v) => v,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_str();
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_to_res_str(__ctx: *mut vrt_ctx) -> VCL_STRING {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_res_str();
-            match __result {
-                Ok(__result) => {
-                    match __result.into_vcl(&mut __ctx.ws) {
-                        Ok(v) => v,
-                        Err(err) => {
-                            __ctx.fail(err);
-                            Default::default()
-                        }
-                    }
-                }
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_res_str()?;
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_to_string(__ctx: *mut vrt_ctx) -> VCL_STRING {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_string();
-            match __result.into_vcl(&mut __ctx.ws) {
-                Ok(v) => v,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_string();
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_to_opt_string(__ctx: *mut vrt_ctx) -> VCL_STRING {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_opt_string();
-            match __result.into_vcl(&mut __ctx.ws) {
-                Ok(v) => v,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_opt_string();
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_to_res_string(__ctx: *mut vrt_ctx) -> VCL_STRING {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_res_string();
-            match __result {
-                Ok(__result) => {
-                    match __result.into_vcl(&mut __ctx.ws) {
-                        Ok(v) => v,
-                        Err(err) => {
-                            __ctx.fail(err);
-                            Default::default()
-                        }
-                    }
-                }
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_res_string()?;
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_to_res_opt_string(
             __ctx: *mut vrt_ctx,
         ) -> VCL_STRING {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_res_opt_string();
-            match __result {
-                Ok(__result) => {
-                    match __result.into_vcl(&mut __ctx.ws) {
-                        Ok(v) => v,
-                        Err(err) => {
-                            __ctx.fail(err);
-                            Default::default()
-                        }
-                    }
-                }
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_res_opt_string()?;
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         #[repr(C)]
         struct arg_vmod_types_type_probe {
@@ -504,47 +511,43 @@ mod types {
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
-            let __var0: Option<Probe> = if __args.valid__v != 0 {
-                __args._v.into()
-            } else {
-                None
-            };
-            let __result = super::type_probe(__var0);
+            let __result = super::type_probe(
+                if __args.valid__v != 0 { __args._v.into() } else { None },
+            );
+            __result
         }
         unsafe extern "C" fn vmod_c_type_probe_req(__ctx: *mut vrt_ctx, _v: VCL_PROBE) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0: Option<Probe> = _v.into();
-            let __result = super::type_probe_req(__var0);
+            let __result = super::type_probe_req(_v.into());
+            __result
         }
         unsafe extern "C" fn vmod_c_to_probe(__ctx: *mut vrt_ctx) -> VCL_PROBE {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_probe();
-            match __result.into_vcl(&mut __ctx.ws) {
-                Ok(v) => v,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_probe();
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_to_res_probe(__ctx: *mut vrt_ctx) -> VCL_PROBE {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_res_probe();
-            match __result {
-                Ok(__result) => {
-                    match __result.into_vcl(&mut __ctx.ws) {
-                        Ok(v) => v,
-                        Err(err) => {
-                            __ctx.fail(err);
-                            Default::default()
-                        }
-                    }
-                }
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_res_probe()?;
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         #[repr(C)]
         struct arg_vmod_types_type_cow_probe {
@@ -557,50 +560,46 @@ mod types {
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
-            let __var0: Option<CowProbe> = if __args.valid__v != 0 {
-                __args._v.into()
-            } else {
-                None
-            };
-            let __result = super::type_cow_probe(__var0);
+            let __result = super::type_cow_probe(
+                if __args.valid__v != 0 { __args._v.into() } else { None },
+            );
+            __result
         }
         unsafe extern "C" fn vmod_c_type_cow_probe_req(
             __ctx: *mut vrt_ctx,
             _v: VCL_PROBE,
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0: Option<CowProbe> = _v.into();
-            let __result = super::type_cow_probe_req(__var0);
+            let __result = super::type_cow_probe_req(_v.into());
+            __result
         }
         unsafe extern "C" fn vmod_c_to_cow_probe(__ctx: *mut vrt_ctx) -> VCL_PROBE {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_cow_probe();
-            match __result.into_vcl(&mut __ctx.ws) {
-                Ok(v) => v,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_cow_probe();
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_to_res_cow_probe(__ctx: *mut vrt_ctx) -> VCL_PROBE {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_res_cow_probe();
-            match __result {
-                Ok(__result) => {
-                    match __result.into_vcl(&mut __ctx.ws) {
-                        Ok(v) => v,
-                        Err(err) => {
-                            __ctx.fail(err);
-                            Default::default()
-                        }
-                    }
-                }
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_res_cow_probe()?;
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         #[repr(C)]
         struct arg_vmod_types_type_ip {
@@ -613,47 +612,43 @@ mod types {
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
-            let __var0: Option<SocketAddr> = if __args.valid__v != 0 {
-                __args._v.into()
-            } else {
-                None
-            };
-            let __result = super::type_ip(__var0);
+            let __result = super::type_ip(
+                if __args.valid__v != 0 { __args._v.into() } else { None },
+            );
+            __result
         }
         unsafe extern "C" fn vmod_c_type_ip_req(__ctx: *mut vrt_ctx, _v: VCL_IP) {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __var0: Option<SocketAddr> = _v.into();
-            let __result = super::type_ip_req(__var0);
+            let __result = super::type_ip_req(_v.into());
+            __result
         }
         unsafe extern "C" fn vmod_c_to_ip(__ctx: *mut vrt_ctx) -> VCL_IP {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_ip();
-            match __result.into_vcl(&mut __ctx.ws) {
-                Ok(v) => v,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_ip();
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_to_res_ip(__ctx: *mut vrt_ctx) -> VCL_IP {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_res_ip();
-            match __result {
-                Ok(__result) => {
-                    match __result.into_vcl(&mut __ctx.ws) {
-                        Ok(v) => v,
-                        Err(err) => {
-                            __ctx.fail(err);
-                            Default::default()
-                        }
-                    }
-                }
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_res_ip()?;
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_to_vcl_string(__ctx: *mut vrt_ctx) -> VCL_STRING {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -664,14 +659,16 @@ mod types {
             __ctx: *mut vrt_ctx,
         ) -> VCL_STRING {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::to_res_vcl_string();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::to_res_vcl_string()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         #[repr(C)]
         struct arg_vmod_types_opt_i64_opt_i64 {
@@ -686,29 +683,31 @@ mod types {
         ) -> VCL_STRING {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
-            let __var0: i64 = __args.a1.into();
-            let __var1: Option<i64> = if __args.valid_a2 != 0 {
-                __args.a2.into()
-            } else {
-                None
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::opt_i64_opt_i64(
+                    __args.a1.into(),
+                    if __args.valid_a2 != 0 { __args.a2.into() } else { None },
+                    __args.a3.into(),
+                );
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
             };
-            let __var2: i64 = __args.a3.into();
-            let __result = super::opt_i64_opt_i64(__var0, __var1, __var2);
-            match __result.into_vcl(&mut __ctx.ws) {
-                Ok(v) => v,
-                Err(err) => {
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_get_ws_mut(__ctx: *mut vrt_ctx) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __result = super::get_ws_mut(&mut __ctx.ws);
+            __result
         }
         unsafe extern "C" fn vmod_c_get_ws_ref(__ctx: *mut vrt_ctx) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __result = super::get_ws_ref(&__ctx.ws);
+            __result
         }
         #[repr(C)]
         pub struct VmodExports {

--- a/varnish-macros/snapshots/object_obj@code.snap
+++ b/varnish-macros/snapshots/object_obj@code.snap
@@ -4,8 +4,8 @@ snapshot_kind: text
 ---
 mod obj {
     #[allow(non_snake_case, unused_imports, unused_qualifications, unused_variables)]
+    #[allow(clippy::needless_question_mark)]
     mod varnish_generated {
-        use std::borrow::Cow;
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
@@ -28,18 +28,19 @@ mod obj {
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
-            let __var0: Option<i64> = if __args.valid_cap != 0 {
-                __args.cap.into()
-            } else {
-                None
-            };
-            let __result = super::kv1::new(__var0);
+            let __result = super::kv1::new(
+                if __args.valid_cap != 0 { __args.cap.into() } else { None },
+            );
             let __result = Box::new(__result);
             *__objp = Box::into_raw(__result);
+            let __result = ();
+            __result
         }
         unsafe extern "C" fn vmod_c_kv1__fini(__objp: *mut *mut kv1) {
             drop(Box::from_raw(*__objp));
             *__objp = ::std::ptr::null_mut();
+            let __result = ();
+            __result
         }
         unsafe extern "C" fn vmod_c_kv1_set(
             __ctx: *mut vrt_ctx,
@@ -49,11 +50,15 @@ mod obj {
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __obj = __obj.as_ref().unwrap();
-            let __var1: Cow<'_, str> = key.into();
-            let __var1 = __var1.as_ref();
-            let __var2: Cow<'_, str> = value.into();
-            let __var2 = __var2.as_ref();
-            let __result = __obj.set(__var1, __var2);
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = __obj.set(key.try_into()?, value.try_into()?);
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
+                    __ctx.fail(err);
+                })
         }
         unsafe extern "C" fn vmod_c_kv1_get(
             __ctx: *mut vrt_ctx,
@@ -62,16 +67,17 @@ mod obj {
         ) -> VCL_STRING {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __obj = __obj.as_ref().unwrap();
-            let __var1: Cow<'_, str> = key.into();
-            let __var1 = __var1.as_ref();
-            let __result = __obj.get(__var1);
-            match __result.into_vcl(&mut __ctx.ws) {
-                Ok(v) => v,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = __obj.get(key.try_into()?);
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         #[repr(C)]
         struct arg_vmod_obj_kv2__init {
@@ -86,19 +92,27 @@ mod obj {
         ) {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
-            let __var0: Option<i64> = if __args.valid_cap != 0 {
-                __args.cap.into()
-            } else {
-                None
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::kv2::new(
+                    if __args.valid_cap != 0 { __args.cap.into() } else { None },
+                    VCL_STRING(__vcl_name).try_into()?,
+                );
+                let __result = Box::new(__result);
+                *__objp = Box::into_raw(__result);
+                let __result = ();
+                Ok(__result)
             };
-            let __var1: Cow<'_, str> = VCL_STRING(__vcl_name).into();
-            let __result = super::kv2::new(__var0, &__var1);
-            let __result = Box::new(__result);
-            *__objp = Box::into_raw(__result);
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
+                    __ctx.fail(err);
+                })
         }
         unsafe extern "C" fn vmod_c_kv2__fini(__objp: *mut *mut kv2) {
             drop(Box::from_raw(*__objp));
             *__objp = ::std::ptr::null_mut();
+            let __result = ();
+            __result
         }
         #[repr(C)]
         struct arg_vmod_obj_kv2_set {
@@ -114,15 +128,92 @@ mod obj {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
             let __obj = __obj.as_ref().unwrap();
-            let __var1: Cow<'_, str> = __args.key.into();
-            let __var1 = __var1.as_ref();
-            let __var2: Option<Cow<'_, str>> = if __args.valid_value != 0 {
-                __args.value.into()
-            } else {
-                None
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = __obj
+                    .set(
+                        __args.key.try_into()?,
+                        if __args.valid_value != 0 {
+                            __args.value.try_into()?
+                        } else {
+                            None
+                        },
+                    );
+                Ok(__result)
             };
-            let __var2 = __var2.as_deref();
-            let __result = __obj.set(__var1, __var2);
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
+                    __ctx.fail(err);
+                })
+        }
+        #[repr(C)]
+        struct arg_vmod_obj_kv3__init {
+            valid_cap: c_char,
+            cap: VCL_INT,
+        }
+        unsafe extern "C" fn vmod_c_kv3__init(
+            __ctx: *mut vrt_ctx,
+            __objp: *mut *mut kv3,
+            __vcl_name: *const c_char,
+            __args: *const arg_vmod_obj_kv3__init,
+        ) {
+            let mut __ctx = Ctx::from_ptr(__ctx);
+            let __args = __args.as_ref().unwrap();
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::kv3::new(
+                    &mut __ctx,
+                    if __args.valid_cap != 0 { __args.cap.into() } else { None },
+                    VCL_STRING(__vcl_name).try_into()?,
+                );
+                let __result = Box::new(__result);
+                *__objp = Box::into_raw(__result);
+                let __result = ();
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
+                    __ctx.fail(err);
+                })
+        }
+        unsafe extern "C" fn vmod_c_kv3__fini(__objp: *mut *mut kv3) {
+            drop(Box::from_raw(*__objp));
+            *__objp = ::std::ptr::null_mut();
+            let __result = ();
+            __result
+        }
+        #[repr(C)]
+        struct arg_vmod_obj_kv3_set {
+            key: VCL_STRING,
+            valid_value: c_char,
+            value: VCL_STRING,
+        }
+        unsafe extern "C" fn vmod_c_kv3_set(
+            __ctx: *mut vrt_ctx,
+            __obj: *const super::kv3,
+            __args: *const arg_vmod_obj_kv3_set,
+        ) {
+            let mut __ctx = Ctx::from_ptr(__ctx);
+            let __args = __args.as_ref().unwrap();
+            let __obj = __obj.as_ref().unwrap();
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = __obj
+                    .set(
+                        &mut __ctx,
+                        __args.key.try_into()?,
+                        if __args.valid_value != 0 {
+                            __args.value.try_into()?
+                        } else {
+                            None
+                        },
+                    );
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
+                    __ctx.fail(err);
+                })
         }
         #[repr(C)]
         pub struct VmodExports {
@@ -166,6 +257,22 @@ mod obj {
                     __args: *const arg_vmod_obj_kv2_set,
                 ),
             >,
+            vmod_c_kv3__init: Option<
+                unsafe extern "C" fn(
+                    __ctx: *mut vrt_ctx,
+                    __objp: *mut *mut kv3,
+                    __vcl_name: *const c_char,
+                    __args: *const arg_vmod_obj_kv3__init,
+                ),
+            >,
+            vmod_c_kv3__fini: Option<unsafe extern "C" fn(__objp: *mut *mut kv3)>,
+            vmod_c_kv3_set: Option<
+                unsafe extern "C" fn(
+                    __ctx: *mut vrt_ctx,
+                    __obj: *const super::kv3,
+                    __args: *const arg_vmod_obj_kv3_set,
+                ),
+            >,
         }
         pub static VMOD_EXPORTS: VmodExports = VmodExports {
             vmod_c_kv1__init: Some(vmod_c_kv1__init),
@@ -175,6 +282,9 @@ mod obj {
             vmod_c_kv2__init: Some(vmod_c_kv2__init),
             vmod_c_kv2__fini: Some(vmod_c_kv2__fini),
             vmod_c_kv2_set: Some(vmod_c_kv2_set),
+            vmod_c_kv3__init: Some(vmod_c_kv3__init),
+            vmod_c_kv3__fini: Some(vmod_c_kv3__fini),
+            vmod_c_kv3_set: Some(vmod_c_kv3_set),
         };
         #[repr(C)]
         pub struct VmodData {
@@ -195,7 +305,7 @@ mod obj {
         pub static Vmod_obj_Data: VmodData = VmodData {
             vrt_major: 0,
             vrt_minor: 0,
-            file_id: c"79cb748900492e5342714b34b48d76ded2837331a6f485b5a24e6a4f66dd78a0"
+            file_id: c"e521945d1e83012d3578e37701d9ae0c1bb1e5a106db37349e5b6c79890e1e56"
                 .as_ptr(),
             name: c"obj".as_ptr(),
             func_name: c"Vmod_vmod_obj_Func".as_ptr(),
@@ -205,8 +315,9 @@ mod obj {
             json: JSON.as_ptr(),
             proto: null(),
         };
-        const JSON: &CStr = c"VMOD_JSON_SPEC\u{2}\n[\n  [\n    \"$VMOD\",\n    \"1.0\",\n    \"obj\",\n    \"Vmod_vmod_obj_Func\",\n    \"79cb748900492e5342714b34b48d76ded2837331a6f485b5a24e6a4f66dd78a0\",\n    \"Varnish (version) (hash)\",\n    \"0\",\n    \"0\"\n  ],\n  [\n    \"$CPROTO\",\n    \"\\nstruct vmod_obj_kv1;\\n\\nstruct vmod_obj_kv2;\\n\\nstruct arg_vmod_obj_kv1__init {\\n  char valid_cap;\\n  VCL_INT cap;\\n};\\n\\ntypedef VCL_VOID td_vmod_obj_kv1__init(\\n    VRT_CTX,\\n    struct vmod_obj_kv1 **,\\n    const char *,\\n    struct arg_vmod_obj_kv1__init *\\n);\\n\\ntypedef VCL_VOID td_vmod_obj_kv1__fini(\\n    struct vmod_obj_kv1 **\\n);\\n\\ntypedef VCL_VOID td_vmod_obj_kv1_set(\\n    VRT_CTX,\\n    struct vmod_obj_kv1 *,\\n    VCL_STRING,\\n    VCL_STRING\\n);\\n\\ntypedef VCL_STRING td_vmod_obj_kv1_get(\\n    VRT_CTX,\\n    struct vmod_obj_kv1 *,\\n    VCL_STRING\\n);\\n\\nstruct arg_vmod_obj_kv2__init {\\n  char valid_cap;\\n  VCL_INT cap;\\n};\\n\\ntypedef VCL_VOID td_vmod_obj_kv2__init(\\n    VRT_CTX,\\n    struct vmod_obj_kv2 **,\\n    const char *,\\n    struct arg_vmod_obj_kv2__init *\\n);\\n\\ntypedef VCL_VOID td_vmod_obj_kv2__fini(\\n    struct vmod_obj_kv2 **\\n);\\n\\nstruct arg_vmod_obj_kv2_set {\\n  VCL_STRING key;\\n  char valid_value;\\n  VCL_STRING value;\\n};\\n\\ntypedef VCL_VOID td_vmod_obj_kv2_set(\\n    VRT_CTX,\\n    struct vmod_obj_kv2 *,\\n    struct arg_vmod_obj_kv2_set *\\n);\\n\\nstruct Vmod_vmod_obj_Func {\\n  td_vmod_obj_kv1__init *f_kv1__init;\\n  td_vmod_obj_kv1__fini *f_kv1__fini;\\n  td_vmod_obj_kv1_set *f_kv1_set;\\n  td_vmod_obj_kv1_get *f_kv1_get;\\n  td_vmod_obj_kv2__init *f_kv2__init;\\n  td_vmod_obj_kv2__fini *f_kv2__fini;\\n  td_vmod_obj_kv2_set *f_kv2_set;\\n};\\n\\nstatic struct Vmod_vmod_obj_Func Vmod_vmod_obj_Func;\"\n  ],\n  [\n    \"$OBJ\",\n    \"kv1\",\n    {\n      \"NULL_OK\": false\n    },\n    \"struct vmod_obj_kv1\",\n    [\n      \"$INIT\",\n      [\n        [\n          \"VOID\"\n        ],\n        \"Vmod_vmod_obj_Func.f_kv1__init\",\n        \"struct arg_vmod_obj_kv1__init\",\n        [\n          \"INT\",\n          \"cap\",\n          null,\n          null,\n          true\n        ]\n      ]\n    ],\n    [\n      \"$FINI\",\n      [\n        [\n          \"VOID\"\n        ],\n        \"Vmod_vmod_obj_Func.f_kv1__fini\",\n        \"\"\n      ]\n    ],\n    [\n      \"$METHOD\",\n      \"set\",\n      [\n        [\n          \"VOID\"\n        ],\n        \"Vmod_vmod_obj_Func.f_kv1_set\",\n        \"\",\n        [\n          \"STRING\",\n          \"key\"\n        ],\n        [\n          \"STRING\",\n          \"value\"\n        ]\n      ]\n    ],\n    [\n      \"$METHOD\",\n      \"get\",\n      [\n        [\n          \"STRING\"\n        ],\n        \"Vmod_vmod_obj_Func.f_kv1_get\",\n        \"\",\n        [\n          \"STRING\",\n          \"key\"\n        ]\n      ]\n    ]\n  ],\n  [\n    \"$OBJ\",\n    \"kv2\",\n    {\n      \"NULL_OK\": false\n    },\n    \"struct vmod_obj_kv2\",\n    [\n      \"$INIT\",\n      [\n        [\n          \"VOID\"\n        ],\n        \"Vmod_vmod_obj_Func.f_kv2__init\",\n        \"struct arg_vmod_obj_kv2__init\",\n        [\n          \"INT\",\n          \"cap\",\n          null,\n          null,\n          true\n        ]\n      ]\n    ],\n    [\n      \"$FINI\",\n      [\n        [\n          \"VOID\"\n        ],\n        \"Vmod_vmod_obj_Func.f_kv2__fini\",\n        \"\"\n      ]\n    ],\n    [\n      \"$METHOD\",\n      \"set\",\n      [\n        [\n          \"VOID\"\n        ],\n        \"Vmod_vmod_obj_Func.f_kv2_set\",\n        \"struct arg_vmod_obj_kv2_set\",\n        [\n          \"STRING\",\n          \"key\"\n        ],\n        [\n          \"STRING\",\n          \"value\",\n          null,\n          null,\n          true\n        ]\n      ]\n    ]\n  ]\n]\n\u{3}";
+        const JSON: &CStr = c"VMOD_JSON_SPEC\u{2}\n[\n  [\n    \"$VMOD\",\n    \"1.0\",\n    \"obj\",\n    \"Vmod_vmod_obj_Func\",\n    \"e521945d1e83012d3578e37701d9ae0c1bb1e5a106db37349e5b6c79890e1e56\",\n    \"Varnish (version) (hash)\",\n    \"0\",\n    \"0\"\n  ],\n  [\n    \"$CPROTO\",\n    \"\\nstruct vmod_obj_kv1;\\n\\nstruct vmod_obj_kv2;\\n\\nstruct vmod_obj_kv3;\\n\\nstruct arg_vmod_obj_kv1__init {\\n  char valid_cap;\\n  VCL_INT cap;\\n};\\n\\ntypedef VCL_VOID td_vmod_obj_kv1__init(\\n    VRT_CTX,\\n    struct vmod_obj_kv1 **,\\n    const char *,\\n    struct arg_vmod_obj_kv1__init *\\n);\\n\\ntypedef VCL_VOID td_vmod_obj_kv1__fini(\\n    struct vmod_obj_kv1 **\\n);\\n\\ntypedef VCL_VOID td_vmod_obj_kv1_set(\\n    VRT_CTX,\\n    struct vmod_obj_kv1 *,\\n    VCL_STRING,\\n    VCL_STRING\\n);\\n\\ntypedef VCL_STRING td_vmod_obj_kv1_get(\\n    VRT_CTX,\\n    struct vmod_obj_kv1 *,\\n    VCL_STRING\\n);\\n\\nstruct arg_vmod_obj_kv2__init {\\n  char valid_cap;\\n  VCL_INT cap;\\n};\\n\\ntypedef VCL_VOID td_vmod_obj_kv2__init(\\n    VRT_CTX,\\n    struct vmod_obj_kv2 **,\\n    const char *,\\n    struct arg_vmod_obj_kv2__init *\\n);\\n\\ntypedef VCL_VOID td_vmod_obj_kv2__fini(\\n    struct vmod_obj_kv2 **\\n);\\n\\nstruct arg_vmod_obj_kv2_set {\\n  VCL_STRING key;\\n  char valid_value;\\n  VCL_STRING value;\\n};\\n\\ntypedef VCL_VOID td_vmod_obj_kv2_set(\\n    VRT_CTX,\\n    struct vmod_obj_kv2 *,\\n    struct arg_vmod_obj_kv2_set *\\n);\\n\\nstruct arg_vmod_obj_kv3__init {\\n  char valid_cap;\\n  VCL_INT cap;\\n};\\n\\ntypedef VCL_VOID td_vmod_obj_kv3__init(\\n    VRT_CTX,\\n    struct vmod_obj_kv3 **,\\n    const char *,\\n    struct arg_vmod_obj_kv3__init *\\n);\\n\\ntypedef VCL_VOID td_vmod_obj_kv3__fini(\\n    struct vmod_obj_kv3 **\\n);\\n\\nstruct arg_vmod_obj_kv3_set {\\n  VCL_STRING key;\\n  char valid_value;\\n  VCL_STRING value;\\n};\\n\\ntypedef VCL_VOID td_vmod_obj_kv3_set(\\n    VRT_CTX,\\n    struct vmod_obj_kv3 *,\\n    struct arg_vmod_obj_kv3_set *\\n);\\n\\nstruct Vmod_vmod_obj_Func {\\n  td_vmod_obj_kv1__init *f_kv1__init;\\n  td_vmod_obj_kv1__fini *f_kv1__fini;\\n  td_vmod_obj_kv1_set *f_kv1_set;\\n  td_vmod_obj_kv1_get *f_kv1_get;\\n  td_vmod_obj_kv2__init *f_kv2__init;\\n  td_vmod_obj_kv2__fini *f_kv2__fini;\\n  td_vmod_obj_kv2_set *f_kv2_set;\\n  td_vmod_obj_kv3__init *f_kv3__init;\\n  td_vmod_obj_kv3__fini *f_kv3__fini;\\n  td_vmod_obj_kv3_set *f_kv3_set;\\n};\\n\\nstatic struct Vmod_vmod_obj_Func Vmod_vmod_obj_Func;\"\n  ],\n  [\n    \"$OBJ\",\n    \"kv1\",\n    {\n      \"NULL_OK\": false\n    },\n    \"struct vmod_obj_kv1\",\n    [\n      \"$INIT\",\n      [\n        [\n          \"VOID\"\n        ],\n        \"Vmod_vmod_obj_Func.f_kv1__init\",\n        \"struct arg_vmod_obj_kv1__init\",\n        [\n          \"INT\",\n          \"cap\",\n          null,\n          null,\n          true\n        ]\n      ]\n    ],\n    [\n      \"$FINI\",\n      [\n        [\n          \"VOID\"\n        ],\n        \"Vmod_vmod_obj_Func.f_kv1__fini\",\n        \"\"\n      ]\n    ],\n    [\n      \"$METHOD\",\n      \"set\",\n      [\n        [\n          \"VOID\"\n        ],\n        \"Vmod_vmod_obj_Func.f_kv1_set\",\n        \"\",\n        [\n          \"STRING\",\n          \"key\"\n        ],\n        [\n          \"STRING\",\n          \"value\"\n        ]\n      ]\n    ],\n    [\n      \"$METHOD\",\n      \"get\",\n      [\n        [\n          \"STRING\"\n        ],\n        \"Vmod_vmod_obj_Func.f_kv1_get\",\n        \"\",\n        [\n          \"STRING\",\n          \"key\"\n        ]\n      ]\n    ]\n  ],\n  [\n    \"$OBJ\",\n    \"kv2\",\n    {\n      \"NULL_OK\": false\n    },\n    \"struct vmod_obj_kv2\",\n    [\n      \"$INIT\",\n      [\n        [\n          \"VOID\"\n        ],\n        \"Vmod_vmod_obj_Func.f_kv2__init\",\n        \"struct arg_vmod_obj_kv2__init\",\n        [\n          \"INT\",\n          \"cap\",\n          null,\n          null,\n          true\n        ]\n      ]\n    ],\n    [\n      \"$FINI\",\n      [\n        [\n          \"VOID\"\n        ],\n        \"Vmod_vmod_obj_Func.f_kv2__fini\",\n        \"\"\n      ]\n    ],\n    [\n      \"$METHOD\",\n      \"set\",\n      [\n        [\n          \"VOID\"\n        ],\n        \"Vmod_vmod_obj_Func.f_kv2_set\",\n        \"struct arg_vmod_obj_kv2_set\",\n        [\n          \"STRING\",\n          \"key\"\n        ],\n        [\n          \"STRING\",\n          \"value\",\n          null,\n          null,\n          true\n        ]\n      ]\n    ]\n  ],\n  [\n    \"$OBJ\",\n    \"kv3\",\n    {\n      \"NULL_OK\": false\n    },\n    \"struct vmod_obj_kv3\",\n    [\n      \"$INIT\",\n      [\n        [\n          \"VOID\"\n        ],\n        \"Vmod_vmod_obj_Func.f_kv3__init\",\n        \"struct arg_vmod_obj_kv3__init\",\n        [\n          \"INT\",\n          \"cap\",\n          null,\n          null,\n          true\n        ]\n      ]\n    ],\n    [\n      \"$FINI\",\n      [\n        [\n          \"VOID\"\n        ],\n        \"Vmod_vmod_obj_Func.f_kv3__fini\",\n        \"\"\n      ]\n    ],\n    [\n      \"$METHOD\",\n      \"set\",\n      [\n        [\n          \"VOID\"\n        ],\n        \"Vmod_vmod_obj_Func.f_kv3_set\",\n        \"struct arg_vmod_obj_kv3_set\",\n        [\n          \"STRING\",\n          \"key\"\n        ],\n        [\n          \"STRING\",\n          \"value\",\n          null,\n          null,\n          true\n        ]\n      ]\n    ]\n  ]\n]\n\u{3}";
     }
+    use varnish::vcl::Ctx;
     pub struct kv1;
     impl kv1 {
         pub fn new(cap: Option<i64>) -> Self {
@@ -223,5 +334,12 @@ mod obj {
             kv2
         }
         pub fn set(&self, key: &str, value: Option<&str>) {}
+    }
+    pub struct kv3;
+    impl kv3 {
+        pub fn new(ctx: &mut Ctx, cap: Option<i64>, name: &str) -> Self {
+            kv3
+        }
+        pub fn set(&self, ctx: &mut Ctx, key: &str, value: Option<&str>) {}
     }
 }

--- a/varnish-macros/snapshots/object_obj@docs.snap
+++ b/varnish-macros/snapshots/object_obj@docs.snap
@@ -44,3 +44,14 @@ sub vcl_init {
 ```
 
 #### Method `VOID set(STRING key, [STRING value])`
+
+### Object `kv3`
+
+```vcl
+// Create a new instance of the object in your VCL init function
+sub vcl_init {
+    new new = kv3.new([INT cap]);
+}
+```
+
+#### Method `VOID set(STRING key, [STRING value])`

--- a/varnish-macros/snapshots/object_obj@json.snap
+++ b/varnish-macros/snapshots/object_obj@json.snap
@@ -9,7 +9,7 @@ VMOD_JSON_SPEC
     "1.0",
     "obj",
     "Vmod_vmod_obj_Func",
-    "79cb748900492e5342714b34b48d76ded2837331a6f485b5a24e6a4f66dd78a0",
+    "e521945d1e83012d3578e37701d9ae0c1bb1e5a106db37349e5b6c79890e1e56",
     "Varnish (version) (hash)",
     "0",
     "0"
@@ -20,6 +20,8 @@ VMOD_JSON_SPEC
 struct vmod_obj_kv1;
 
 struct vmod_obj_kv2;
+
+struct vmod_obj_kv3;
 
 struct arg_vmod_obj_kv1__init {
   char valid_cap;
@@ -78,6 +80,34 @@ typedef VCL_VOID td_vmod_obj_kv2_set(
     struct arg_vmod_obj_kv2_set *
 );
 
+struct arg_vmod_obj_kv3__init {
+  char valid_cap;
+  VCL_INT cap;
+};
+
+typedef VCL_VOID td_vmod_obj_kv3__init(
+    VRT_CTX,
+    struct vmod_obj_kv3 **,
+    const char *,
+    struct arg_vmod_obj_kv3__init *
+);
+
+typedef VCL_VOID td_vmod_obj_kv3__fini(
+    struct vmod_obj_kv3 **
+);
+
+struct arg_vmod_obj_kv3_set {
+  VCL_STRING key;
+  char valid_value;
+  VCL_STRING value;
+};
+
+typedef VCL_VOID td_vmod_obj_kv3_set(
+    VRT_CTX,
+    struct vmod_obj_kv3 *,
+    struct arg_vmod_obj_kv3_set *
+);
+
 struct Vmod_vmod_obj_Func {
   td_vmod_obj_kv1__init *f_kv1__init;
   td_vmod_obj_kv1__fini *f_kv1__fini;
@@ -86,6 +116,9 @@ struct Vmod_vmod_obj_Func {
   td_vmod_obj_kv2__init *f_kv2__init;
   td_vmod_obj_kv2__fini *f_kv2__fini;
   td_vmod_obj_kv2_set *f_kv2_set;
+  td_vmod_obj_kv3__init *f_kv3__init;
+  td_vmod_obj_kv3__fini *f_kv3__fini;
+  td_vmod_obj_kv3_set *f_kv3_set;
 };
 
 static struct Vmod_vmod_obj_Func Vmod_vmod_obj_Func;"
@@ -202,6 +235,63 @@ static struct Vmod_vmod_obj_Func Vmod_vmod_obj_Func;"
         ],
         "Vmod_vmod_obj_Func.f_kv2_set",
         "struct arg_vmod_obj_kv2_set",
+        [
+          "STRING",
+          "key"
+        ],
+        [
+          "STRING",
+          "value",
+          null,
+          null,
+          true
+        ]
+      ]
+    ]
+  ],
+  [
+    "$OBJ",
+    "kv3",
+    {
+      "NULL_OK": false
+    },
+    "struct vmod_obj_kv3",
+    [
+      "$INIT",
+      [
+        [
+          "VOID"
+        ],
+        "Vmod_vmod_obj_Func.f_kv3__init",
+        "struct arg_vmod_obj_kv3__init",
+        [
+          "INT",
+          "cap",
+          null,
+          null,
+          true
+        ]
+      ]
+    ],
+    [
+      "$FINI",
+      [
+        [
+          "VOID"
+        ],
+        "Vmod_vmod_obj_Func.f_kv3__fini",
+        ""
+      ]
+    ],
+    [
+      "$METHOD",
+      "set",
+      [
+        [
+          "VOID"
+        ],
+        "Vmod_vmod_obj_Func.f_kv3_set",
+        "struct arg_vmod_obj_kv3_set",
         [
           "STRING",
           "key"

--- a/varnish-macros/snapshots/object_obj@model.snap
+++ b/varnish-macros/snapshots/object_obj@model.snap
@@ -140,7 +140,13 @@ VmodInfo {
                         ident: "name",
                         docs: "",
                         idx: 1,
-                        ty: VclName,
+                        ty: VclName(
+                            ParamInfo {
+                                kind: Regular,
+                                default: Null,
+                                ty_info: Str,
+                            },
+                        ),
                     },
                 ],
                 output_ty: SelfType,
@@ -184,6 +190,111 @@ VmodInfo {
                             ident: "value",
                             docs: "",
                             idx: 2,
+                            ty: Value(
+                                ParamInfo {
+                                    kind: Optional,
+                                    default: Null,
+                                    ty_info: Str,
+                                },
+                            ),
+                        },
+                    ],
+                    output_ty: Default,
+                    out_result: false,
+                },
+            ],
+        },
+        ObjInfo {
+            ident: "kv3",
+            docs: "",
+            constructor: FuncInfo {
+                func_type: Constructor,
+                ident: "new",
+                docs: "",
+                has_optional_args: true,
+                args: [
+                    ParamTypeInfo {
+                        ident: "ctx",
+                        docs: "",
+                        idx: 0,
+                        ty: Context {
+                            is_mut: true,
+                        },
+                    },
+                    ParamTypeInfo {
+                        ident: "cap",
+                        docs: "",
+                        idx: 1,
+                        ty: Value(
+                            ParamInfo {
+                                kind: Optional,
+                                default: Null,
+                                ty_info: I64,
+                            },
+                        ),
+                    },
+                    ParamTypeInfo {
+                        ident: "name",
+                        docs: "",
+                        idx: 2,
+                        ty: VclName(
+                            ParamInfo {
+                                kind: Regular,
+                                default: Null,
+                                ty_info: Str,
+                            },
+                        ),
+                    },
+                ],
+                output_ty: SelfType,
+                out_result: false,
+            },
+            destructor: FuncInfo {
+                func_type: Destructor,
+                ident: "_fini",
+                docs: "",
+                has_optional_args: false,
+                args: [],
+                output_ty: Default,
+                out_result: false,
+            },
+            funcs: [
+                FuncInfo {
+                    func_type: Method,
+                    ident: "set",
+                    docs: "",
+                    has_optional_args: true,
+                    args: [
+                        ParamTypeInfo {
+                            ident: "self",
+                            docs: "",
+                            idx: 0,
+                            ty: SelfType,
+                        },
+                        ParamTypeInfo {
+                            ident: "ctx",
+                            docs: "",
+                            idx: 1,
+                            ty: Context {
+                                is_mut: true,
+                            },
+                        },
+                        ParamTypeInfo {
+                            ident: "key",
+                            docs: "",
+                            idx: 2,
+                            ty: Value(
+                                ParamInfo {
+                                    kind: Regular,
+                                    default: Null,
+                                    ty_info: Str,
+                                },
+                            ),
+                        },
+                        ParamTypeInfo {
+                            ident: "value",
+                            docs: "",
+                            idx: 3,
                             ty: Value(
                                 ParamInfo {
                                     kind: Optional,

--- a/varnish-macros/snapshots/shared2_tuple@code.snap
+++ b/varnish-macros/snapshots/shared2_tuple@code.snap
@@ -4,8 +4,8 @@ snapshot_kind: text
 ---
 mod tuple {
     #[allow(non_snake_case, unused_imports, unused_qualifications, unused_variables)]
+    #[allow(clippy::needless_question_mark)]
     mod varnish_generated {
-        use std::borrow::Cow;
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
@@ -33,10 +33,11 @@ mod tuple {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let mut __var0 = (*__vp).take();
             let __result = super::on_event(&mut __var0);
+            let __result = VCL_INT(0);
             if let Some(obj) = __var0 {
                 (*__vp).put(obj, &PRIV_VCL_METHODS);
             }
-            VCL_INT(0)
+            __result
         }
         unsafe extern "C" fn vmod_c_per_tsk_val(
             __ctx: *mut vrt_ctx,
@@ -50,6 +51,7 @@ mod tuple {
             if let Some(obj) = __var0 {
                 (*tsk_vals).put(obj, &PRIV_TASK_METHODS);
             }
+            __result
         }
         #[repr(C)]
         pub struct VmodExports {

--- a/varnish-macros/snapshots/shared3_tuple@code.snap
+++ b/varnish-macros/snapshots/shared3_tuple@code.snap
@@ -4,8 +4,8 @@ snapshot_kind: text
 ---
 mod tuple {
     #[allow(non_snake_case, unused_imports, unused_qualifications, unused_variables)]
+    #[allow(clippy::needless_question_mark)]
     mod varnish_generated {
-        use std::borrow::Cow;
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
@@ -26,17 +26,20 @@ mod tuple {
         ) -> VCL_STRING {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let mut __var0 = (*tsk_vals).take();
-            let __result = super::ref_to_slice_lifetime(&mut __var0);
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::ref_to_slice_lifetime(&mut __var0);
+                let __result = __result.into_vcl(&mut __ctx.ws)?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
             if let Some(obj) = __var0 {
                 (*tsk_vals).put(obj, &PRIV_TASK_METHODS);
             }
-            match __result.into_vcl(&mut __ctx.ws) {
-                Ok(v) => v,
-                Err(err) => {
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         #[repr(C)]
         pub struct VmodExports {

--- a/varnish-macros/snapshots/shared_task@code.snap
+++ b/varnish-macros/snapshots/shared_task@code.snap
@@ -4,8 +4,8 @@ snapshot_kind: text
 ---
 mod task {
     #[allow(non_snake_case, unused_imports, unused_qualifications, unused_variables)]
+    #[allow(clippy::needless_question_mark)]
     mod varnish_generated {
-        use std::borrow::Cow;
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
@@ -33,10 +33,11 @@ mod task {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let mut __var2 = (*__vp).take();
             let __result = super::on_event(__ev, &mut __ctx, &mut __var2);
+            let __result = VCL_INT(0);
             if let Some(obj) = __var2 {
                 (*__vp).put(obj, &PRIV_VCL_METHODS);
             }
-            VCL_INT(0)
+            __result
         }
         unsafe extern "C" fn vmod_c_per_vcl_val(
             __ctx: *mut vrt_ctx,
@@ -45,6 +46,7 @@ mod task {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __var0 = vcl.as_ref().and_then(|v| v.get_ref());
             let __result = super::per_vcl_val(__var0);
+            __result
         }
         #[repr(C)]
         struct arg_vmod_task_per_vcl_opt {
@@ -59,12 +61,11 @@ mod task {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
             let __var0 = __args.vcl.as_ref().and_then(|v| v.get_ref());
-            let __var1: Option<i64> = if __args.valid_op != 0 {
-                __args.op.into()
-            } else {
-                None
-            };
-            let __result = super::per_vcl_opt(__var0, __var1);
+            let __result = super::per_vcl_opt(
+                __var0,
+                if __args.valid_op != 0 { __args.op.into() } else { None },
+            );
+            __result
         }
         unsafe extern "C" fn vmod_c_per_tsk_val(
             __ctx: *mut vrt_ctx,
@@ -76,6 +77,7 @@ mod task {
             if let Some(obj) = __var0 {
                 (*tsk).put(obj, &PRIV_TASK_METHODS);
             }
+            __result
         }
         #[repr(C)]
         struct arg_vmod_task_per_tsk_opt {
@@ -90,15 +92,14 @@ mod task {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
             let mut __var0 = (*__args.tsk).take();
-            let __var1: Option<i64> = if __args.valid_op != 0 {
-                __args.op.into()
-            } else {
-                None
-            };
-            let __result = super::per_tsk_opt(&mut __var0, __var1);
+            let __result = super::per_tsk_opt(
+                &mut __var0,
+                if __args.valid_op != 0 { __args.op.into() } else { None },
+            );
             if let Some(obj) = __var0 {
                 (*__args.tsk).put(obj, &PRIV_TASK_METHODS);
             }
+            __result
         }
         unsafe extern "C" fn vmod_c_PerVcl__init(
             __ctx: *mut vrt_ctx,
@@ -109,15 +110,19 @@ mod task {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let mut __var0 = (*vcl).take();
             let __result = super::PerVcl::new(&mut __var0);
+            let __result = Box::new(__result);
+            *__objp = Box::into_raw(__result);
+            let __result = ();
             if let Some(obj) = __var0 {
                 (*vcl).put(obj, &PRIV_VCL_METHODS);
             }
-            let __result = Box::new(__result);
-            *__objp = Box::into_raw(__result);
+            __result
         }
         unsafe extern "C" fn vmod_c_PerVcl__fini(__objp: *mut *mut PerVcl) {
             drop(Box::from_raw(*__objp));
             *__objp = ::std::ptr::null_mut();
+            let __result = ();
+            __result
         }
         unsafe extern "C" fn vmod_c_PerVcl_both(
             __ctx: *mut vrt_ctx,
@@ -133,6 +138,7 @@ mod task {
             if let Some(obj) = __var1 {
                 (*tsk).put(obj, &PRIV_TASK_METHODS);
             }
+            __result
         }
         unsafe extern "C" fn vmod_c_PerVcl_both_pos(
             __ctx: *mut vrt_ctx,
@@ -145,11 +151,11 @@ mod task {
             let __obj = __obj.as_ref().unwrap();
             let mut __var1 = (*tsk).take();
             let __var2 = vcl.as_ref().and_then(|v| v.get_ref());
-            let __var3: i64 = val.into();
-            let __result = __obj.both_pos(&mut __var1, __var2, __var3);
+            let __result = __obj.both_pos(&mut __var1, __var2, val.into());
             if let Some(obj) = __var1 {
                 (*tsk).put(obj, &PRIV_TASK_METHODS);
             }
+            __result
         }
         #[repr(C)]
         struct arg_vmod_task_PerVcl_both_opt {
@@ -168,15 +174,16 @@ mod task {
             let __obj = __obj.as_ref().unwrap();
             let mut __var1 = (*__args.tsk).take();
             let __var2 = __args.vcl.as_ref().and_then(|v| v.get_ref());
-            let __var3: Option<i64> = if __args.valid_opt != 0 {
-                __args.opt.into()
-            } else {
-                None
-            };
-            let __result = __obj.both_opt(&mut __var1, __var2, __var3);
+            let __result = __obj
+                .both_opt(
+                    &mut __var1,
+                    __var2,
+                    if __args.valid_opt != 0 { __args.opt.into() } else { None },
+                );
             if let Some(obj) = __var1 {
                 (*__args.tsk).put(obj, &PRIV_TASK_METHODS);
             }
+            __result
         }
         #[repr(C)]
         pub struct VmodExports {

--- a/varnish-macros/snapshots/vcl_returns_vcl_returns@code.snap
+++ b/varnish-macros/snapshots/vcl_returns_vcl_returns@code.snap
@@ -4,8 +4,8 @@ snapshot_kind: text
 ---
 mod vcl_returns {
     #[allow(non_snake_case, unused_imports, unused_qualifications, unused_variables)]
+    #[allow(clippy::needless_question_mark)]
     mod varnish_generated {
-        use std::borrow::Cow;
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
@@ -22,14 +22,16 @@ mod vcl_returns {
         }
         unsafe extern "C" fn vmod_c_res_acl(__ctx: *mut vrt_ctx) -> VCL_ACL {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::res_acl();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::res_acl()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_val_backend(__ctx: *mut vrt_ctx) -> VCL_BACKEND {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -38,14 +40,16 @@ mod vcl_returns {
         }
         unsafe extern "C" fn vmod_c_res_backend(__ctx: *mut vrt_ctx) -> VCL_BACKEND {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::res_backend();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::res_backend()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_val_blob(__ctx: *mut vrt_ctx) -> VCL_BLOB {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -54,14 +58,16 @@ mod vcl_returns {
         }
         unsafe extern "C" fn vmod_c_res_blob(__ctx: *mut vrt_ctx) -> VCL_BLOB {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::res_blob();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::res_blob()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_val_body(__ctx: *mut vrt_ctx) -> VCL_BODY {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -70,14 +76,16 @@ mod vcl_returns {
         }
         unsafe extern "C" fn vmod_c_res_body(__ctx: *mut vrt_ctx) -> VCL_BODY {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::res_body();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::res_body()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_val_bool(__ctx: *mut vrt_ctx) -> VCL_BOOL {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -86,14 +94,16 @@ mod vcl_returns {
         }
         unsafe extern "C" fn vmod_c_res_bool(__ctx: *mut vrt_ctx) -> VCL_BOOL {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::res_bool();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::res_bool()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_val_bytes(__ctx: *mut vrt_ctx) -> VCL_BYTES {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -102,14 +112,16 @@ mod vcl_returns {
         }
         unsafe extern "C" fn vmod_c_res_bytes(__ctx: *mut vrt_ctx) -> VCL_BYTES {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::res_bytes();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::res_bytes()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_val_duration(__ctx: *mut vrt_ctx) -> VCL_DURATION {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -118,14 +130,16 @@ mod vcl_returns {
         }
         unsafe extern "C" fn vmod_c_res_duration(__ctx: *mut vrt_ctx) -> VCL_DURATION {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::res_duration();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::res_duration()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_val_enum(__ctx: *mut vrt_ctx) -> VCL_ENUM {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -134,14 +148,16 @@ mod vcl_returns {
         }
         unsafe extern "C" fn vmod_c_res_enum(__ctx: *mut vrt_ctx) -> VCL_ENUM {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::res_enum();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::res_enum()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_val_header(__ctx: *mut vrt_ctx) -> VCL_HEADER {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -150,14 +166,16 @@ mod vcl_returns {
         }
         unsafe extern "C" fn vmod_c_res_header(__ctx: *mut vrt_ctx) -> VCL_HEADER {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::res_header();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::res_header()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_val_http(__ctx: *mut vrt_ctx) -> VCL_HTTP {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -166,14 +184,16 @@ mod vcl_returns {
         }
         unsafe extern "C" fn vmod_c_res_http(__ctx: *mut vrt_ctx) -> VCL_HTTP {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::res_http();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::res_http()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_val_instance(__ctx: *mut vrt_ctx) -> VCL_INSTANCE {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -187,14 +207,16 @@ mod vcl_returns {
         }
         unsafe extern "C" fn vmod_c_res_int(__ctx: *mut vrt_ctx) -> VCL_INT {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::res_int();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::res_int()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_val_ip(__ctx: *mut vrt_ctx) -> VCL_IP {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -203,14 +225,16 @@ mod vcl_returns {
         }
         unsafe extern "C" fn vmod_c_res_ip(__ctx: *mut vrt_ctx) -> VCL_IP {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::res_ip();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::res_ip()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_val_probe(__ctx: *mut vrt_ctx) -> VCL_PROBE {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -219,14 +243,16 @@ mod vcl_returns {
         }
         unsafe extern "C" fn vmod_c_res_probe(__ctx: *mut vrt_ctx) -> VCL_PROBE {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::res_probe();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::res_probe()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_val_real(__ctx: *mut vrt_ctx) -> VCL_REAL {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -235,14 +261,16 @@ mod vcl_returns {
         }
         unsafe extern "C" fn vmod_c_res_real(__ctx: *mut vrt_ctx) -> VCL_REAL {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::res_real();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::res_real()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_val_regex(__ctx: *mut vrt_ctx) -> VCL_REGEX {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -251,14 +279,16 @@ mod vcl_returns {
         }
         unsafe extern "C" fn vmod_c_res_regex(__ctx: *mut vrt_ctx) -> VCL_REGEX {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::res_regex();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::res_regex()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_val_stevedore(__ctx: *mut vrt_ctx) -> VCL_STEVEDORE {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -267,14 +297,16 @@ mod vcl_returns {
         }
         unsafe extern "C" fn vmod_c_res_stevedore(__ctx: *mut vrt_ctx) -> VCL_STEVEDORE {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::res_stevedore();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::res_stevedore()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_val_strands(__ctx: *mut vrt_ctx) -> VCL_STRANDS {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -283,14 +315,16 @@ mod vcl_returns {
         }
         unsafe extern "C" fn vmod_c_res_strands(__ctx: *mut vrt_ctx) -> VCL_STRANDS {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::res_strands();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::res_strands()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_val_string(__ctx: *mut vrt_ctx) -> VCL_STRING {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -299,14 +333,16 @@ mod vcl_returns {
         }
         unsafe extern "C" fn vmod_c_res_string(__ctx: *mut vrt_ctx) -> VCL_STRING {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::res_string();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::res_string()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_val_sub(__ctx: *mut vrt_ctx) -> VCL_SUB {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -315,14 +351,16 @@ mod vcl_returns {
         }
         unsafe extern "C" fn vmod_c_res_sub(__ctx: *mut vrt_ctx) -> VCL_SUB {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::res_sub();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::res_sub()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_val_time(__ctx: *mut vrt_ctx) -> VCL_TIME {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -331,14 +369,16 @@ mod vcl_returns {
         }
         unsafe extern "C" fn vmod_c_res_time(__ctx: *mut vrt_ctx) -> VCL_TIME {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::res_time();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::res_time()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         unsafe extern "C" fn vmod_c_val_vcl(__ctx: *mut vrt_ctx) -> VCL_VCL {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -347,14 +387,16 @@ mod vcl_returns {
         }
         unsafe extern "C" fn vmod_c_res_vcl(__ctx: *mut vrt_ctx) -> VCL_VCL {
             let mut __ctx = Ctx::from_ptr(__ctx);
-            let __result = super::res_vcl();
-            match __result {
-                Ok(__result) => __result,
-                Err(err) => {
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                let __result = super::res_vcl()?;
+                Ok(__result)
+            };
+            let __result = __call_user_func();
+            __result
+                .unwrap_or_else(|err| {
                     __ctx.fail(err);
                     Default::default()
-                }
-            }
+                })
         }
         #[repr(C)]
         pub struct VmodExports {

--- a/varnish-macros/src/generator.rs
+++ b/varnish-macros/src/generator.rs
@@ -169,8 +169,10 @@ impl Generator {
                 unused_qualifications,
                 unused_variables,
             )]
+            #[allow(
+                clippy::needless_question_mark,
+            )]
             mod varnish_generated {
-                use std::borrow::Cow;
                 use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
                 use std::ptr::null;
                 use varnish::ffi::{

--- a/varnish-macros/src/parser_args.rs
+++ b/varnish-macros/src/parser_args.rs
@@ -151,10 +151,11 @@ impl ParamType {
         } else if is_vcl_name.is_some() {
             only_in! { Constructor, "#[vcl_name] params are only allowed in object constructors" }
             unique! { has_vcl_name, "#[vcl_name] param is allowed only once in a function args list" }
-            if !matches!(ParamTy::try_parse(arg_ty), Some(ParamTy::Str)) {
-                error! { "#[vcl_name] params must be declared as `&str`" }
-            }
-            Self::VclName
+            let arg_ty = match ParamTy::try_parse(arg_ty) {
+                Some(ty) if matches!(ty, ParamTy::Str | ParamTy::CStr) => ty,
+                _ => error! { "#[vcl_name] params must be declared as `&str` or `&CStr`" },
+            };
+            Self::VclName(ParamInfo::new(arg_ty, Value::Null, ParamKind::Regular))
         } else if as_simple_ty(arg_ty)
             .filter(|ident| *ident == "Event")
             .is_some()

--- a/varnish-macros/tests/fail/error_obj.stderr
+++ b/varnish-macros/tests/fail/error_obj.stderr
@@ -46,7 +46,7 @@ error: Object must have a constructor called `new`
 15 |     impl Obj {
    |          ^^^
 
-error: #[vcl_name] params must be declared as `&str`
+error: #[vcl_name] params must be declared as `&str` or `&CStr`
   --> tests/fail/error_obj.rs:25:32
    |
 25 |         pub fn new(#[vcl_name] a: String) {}

--- a/varnish-macros/tests/pass/object.rs
+++ b/varnish-macros/tests/pass/object.rs
@@ -7,6 +7,8 @@ fn main() {}
 
 #[vmod]
 mod obj {
+    use varnish::vcl::Ctx;
+
     pub struct kv1;
     impl kv1 {
         pub fn new(cap: Option<i64>) -> Self {
@@ -24,5 +26,13 @@ mod obj {
             kv2
         }
         pub fn set(&self, key: &str, value: Option<&str>) {}
+    }
+
+    pub struct kv3;
+    impl kv3 {
+        pub fn new(ctx: &mut Ctx, cap: Option<i64>, #[vcl_name] name: &str) -> Self {
+            kv3
+        }
+        pub fn set(&self, ctx: &mut Ctx, key: &str, value: Option<&str>) {}
     }
 }

--- a/varnish-sys/src/vcl/convert.rs
+++ b/varnish-sys/src/vcl/convert.rs
@@ -421,16 +421,16 @@ impl From<VCL_STRING> for &CStr {
         <Option<&CStr>>::from(value).unwrap_or_default()
     }
 }
-impl<'a> From<VCL_STRING> for Option<Cow<'a, str>> {
-    fn from(value: VCL_STRING) -> Self {
-        // Lossy string in case of any non-unicode characters
-        <Option<&CStr>>::from(value).map(CStr::to_string_lossy)
+impl<'a> TryFrom<VCL_STRING> for Option<&'a str> {
+    type Error = VclError;
+    fn try_from(value: VCL_STRING) -> Result<Self, Self::Error> {
+        Ok(<Option<&CStr>>::from(value).map(CStr::to_str).transpose()?)
     }
 }
-impl<'a> From<VCL_STRING> for Cow<'a, str> {
-    fn from(value: VCL_STRING) -> Self {
-        // Lossy string and also convert null to ""
-        <Option<Cow<'a, str>>>::from(value).unwrap_or(Cow::Borrowed(""))
+impl<'a> TryFrom<VCL_STRING> for &'a str {
+    type Error = VclError;
+    fn try_from(value: VCL_STRING) -> Result<Self, Self::Error> {
+        Ok(<Option<&'a str>>::try_from(value)?.unwrap_or(""))
     }
 }
 

--- a/varnish-sys/src/vcl/error.rs
+++ b/varnish-sys/src/vcl/error.rs
@@ -1,3 +1,5 @@
+use std::str::Utf8Error;
+
 /// custom vcl `Error` type
 ///
 /// The C errors aren't typed and are just C strings, so we just wrap them into a proper rust
@@ -30,6 +32,12 @@ impl std::error::Error for VclError {}
 impl From<String> for VclError {
     fn from(s: String) -> Self {
         Self { s }
+    }
+}
+
+impl From<Utf8Error> for VclError {
+    fn from(s: Utf8Error) -> Self {
+        Self { s: s.to_string() }
     }
 }
 


### PR DESCRIPTION
Big rework of the wrapper function generation and error handling in the macros:
* input values like `VCL_STRING` can now fail properly when converting to `&str` or `Option<&str>` - i.e. if they are not proper UTF8.
  * on failure, the user function is not called, and the call is considered as failed
  * if the user wants to get "raw" input value, they have to use `Option<&CStr>`, or at least `&CStr` to treat `NULL` and `""` are the same thing.
* after calling the user function, its output conversion with `into_vcl()` can also fail - treat that as a failure of the function execution
* remove `Cow<'a, str>` internal usage - we no longer need it because we never use "lossy conversion" - a string either fails conversion - in which case user function is not called, or everything works as a reference.
* functions that get &mut access of the `#[shared_per_task]` will preserve those values even if they fail:

```rust
pub fn foo(#[shared_per_task] tsk: &mut Option<Box<MyValue>>) -> Result<(), VclError> {
  *tsk = Some(Box::new(...)); // set new value
  Err("failed") // fail the call
}
// if any other function is called, they get new `tsk` value 
```

### New wrapper implementation

We now have a lambda function inside the wrapper function. Lambda function always returns `Result<T, VclErr>`. Any steps inside the lambda can fail and return early using the `?`.  This includes `try_into()` for the input parameter conversion, the user function, and the output conversion using `into_vcl()`.

```rust
unsafe extern "C" fn vmod_c_ref_to_slice_lifetime(
    __ctx: *mut vrt_ctx,
    tsk_vals: *mut vmod_priv,
) -> VCL_STRING {
    let mut __ctx = Ctx::from_ptr(__ctx);
    let mut __var0 = (*tsk_vals).take();
    let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
        let __result = super::ref_to_slice_lifetime(&mut __var0);
        let __result = __result.into_vcl(&mut __ctx.ws)?;
        Ok(__result)
    };
    let __result = __call_user_func();
    if let Some(obj) = __var0 {
        (*tsk_vals).put(obj, &PRIV_TASK_METHODS);
    }
    __result
        .unwrap_or_else(|err| {
            __ctx.fail(err);
            Default::default()
        })
}
```


Fixes #112 