### PR TITLE
Speed up `VclError`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10.8"
 syn = "2.0.77"
+thiserror = "1.0.68"
 trybuild = "1.0"
 
 [profile.dev.package]

--- a/varnish-sys/Cargo.toml
+++ b/varnish-sys/Cargo.toml
@@ -29,6 +29,7 @@ pkg-config.workspace = true
 
 [dependencies]
 serde.workspace = true
+thiserror.workspace = true
 
 [lints]
 workspace = true

--- a/varnish-sys/src/vcl/backend.rs
+++ b/varnish-sys/src/vcl/backend.rs
@@ -294,7 +294,7 @@ unsafe extern "C" fn vfp_pull<T: Transfer>(
         Err(e) => {
             // TODO: we should grow a VSL object
             // SAFETY: we assume ffi::VSLbt() will not store the pointer to the string's content
-            let msg = ffi::txt::from_str(e.as_ref());
+            let msg = ffi::txt::from_str(e.as_str().as_ref());
             ffi::VSLbt(ctx.req.as_ref().unwrap().vsl, ffi::VslTag::Error, msg);
             VfpStatus::Error
         }

--- a/varnish-sys/src/vcl/ctx.rs
+++ b/varnish-sys/src/vcl/ctx.rs
@@ -67,7 +67,7 @@ impl<'a> Ctx<'a> {
     /// and will return a synthetic error to the client.
     pub fn fail(&mut self, msg: impl Into<VclError>) {
         let msg = msg.into();
-        let msg = msg.as_ref();
+        let msg = msg.as_str();
         unsafe {
             VRT_fail(self.raw, c"%.*s".as_ptr(), msg.len(), msg.as_ptr());
         }

--- a/varnish-sys/src/vcl/error.rs
+++ b/varnish-sys/src/vcl/error.rs
@@ -1,61 +1,55 @@
+use std::borrow::Cow;
 use std::str::Utf8Error;
 
-/// custom vcl `Error` type
+// TODO: at some point we may want to add a `txt` variant - e.g. if user wants to handle error creation directly.
+
+/// An `Error` describing all issues with the VCL module
 ///
-/// The C errors aren't typed and are just C strings, so we just wrap them into a proper rust
-/// `Error`
-pub struct VclError {
-    s: String,
+/// This enum is used to describe all the possible errors that can happen when working with the VCL module,
+/// or converting between Rust and C types.
+#[derive(thiserror::Error, Debug)]
+pub enum VclError {
+    /// Create a new `Error` from a string
+    #[error("{0}")]
+    String(String),
+    /// Create a new `Error` from a UTF-8 error
+    #[error("{0}")]
+    Utf8Error(#[from] Utf8Error),
+    /// Create a new `Error` from a string slice
+    #[error("{0}")]
+    Str(&'static str),
+    /// Create a new `Error` from a boxed error
+    #[error("{0}")]
+    Box(#[from] Box<dyn std::error::Error>),
 }
 
 impl VclError {
     /// Create a new `Error` from a string
     pub fn new(s: String) -> Self {
-        Self { s }
+        Self::String(s)
+    }
+
+    pub fn as_str(&self) -> Cow<str> {
+        match self {
+            Self::String(s) => Cow::Borrowed(s.as_str()),
+            Self::Utf8Error(e) => Cow::Owned(e.to_string()),
+            Self::Str(s) => Cow::Borrowed(s),
+            Self::Box(e) => Cow::Owned(e.to_string()),
+        }
     }
 }
 
-impl std::fmt::Debug for VclError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Debug::fmt(&self.s, f)
-    }
-}
-
-impl std::fmt::Display for VclError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self.s, f)
-    }
-}
-
-impl std::error::Error for VclError {}
+// Any error types are done with the #[from] attribute, so we don't need to implement From for them
 
 impl From<String> for VclError {
     fn from(s: String) -> Self {
-        Self { s }
+        Self::String(s)
     }
 }
 
-impl From<Utf8Error> for VclError {
-    fn from(s: Utf8Error) -> Self {
-        Self { s: s.to_string() }
-    }
-}
-
-impl From<&str> for VclError {
-    fn from(s: &str) -> Self {
-        Self { s: s.into() }
-    }
-}
-
-impl From<Box<dyn std::error::Error>> for VclError {
-    fn from(s: Box<dyn std::error::Error>) -> Self {
-        Self { s: s.to_string() }
-    }
-}
-
-impl AsRef<str> for VclError {
-    fn as_ref(&self) -> &str {
-        &self.s
+impl From<&'static str> for VclError {
+    fn from(s: &'static str) -> Self {
+        Self::Str(s)
     }
 }
 


### PR DESCRIPTION
Convert it to an enum, implementing automatic `Display` and `From` support using `thiserror`. With enum, we no longer need to allocate a string in some cases in order to send it to the logging.