### PR TITLE
Hide most FFI behind a feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   - supports `VARNISHTEST_DURATION` env var, defaulting to "5s"
   - supports debug mode - keeps the temporary files and always prints the output: `run_vtc_tests!!("tests/*.vtc", true)`
 - Multi-version support for `libvarnish` headers now allows the same code to be used with Varnish v7.4, v7.5, and v7.6
+- Most FFI objects are public only if the user enables the `ffi` feature. This is to prevent users from using the FFI directly and to encourage them to use the safe Rust API.  SemVer guarantees that the public API will not change, but the FFI API may change without warning.
+- Introduce `vsc` feature to enable the `varnish::vsc` module
 - Renamed a few types for clarity and to be more consistent:
   - `COWProbe` struct to `CowProbe`
   - `COWRequest` struct to `CowRequest`

--- a/examples/vmod_infiniteloop/Cargo.toml
+++ b/examples/vmod_infiniteloop/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 edition.workspace = true
 
 [dependencies]
-varnish.workspace = true
+varnish = { workspace = true, features = ["ffi"]}
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/vmod_object/src/lib.rs
+++ b/examples/vmod_object/src/lib.rs
@@ -11,8 +11,9 @@ pub struct kv {
 /// A simple string dictionary in your VCL
 #[varnish::vmod(docs = "README.md")]
 mod object {
-    use super::kv;
     use dashmap::DashMap;
+
+    use super::kv;
 
     // implementation needs the same methods as defined in the vcc, plus "new()"
     // corresponding to the constructor, which requires the context (_ctx) , and the

--- a/examples/vmod_vfp/Cargo.toml
+++ b/examples/vmod_vfp/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 edition.workspace = true
 
 [dependencies]
-varnish.workspace = true
+varnish = { workspace = true, features = ["ffi"]}
 
 [lib]
 crate-type = ["cdylib"]

--- a/justfile
+++ b/justfile
@@ -37,6 +37,10 @@ check:
 build:
     cargo build --workspace --all-targets
 
+# build all
+build-all-features:
+    cargo build --workspace --all-targets --features "ffi,vsc"
+
 # Run all tests
 test: build
     cargo test --workspace --all-targets
@@ -55,7 +59,7 @@ rust-info:
     cargo --version
 
 # Run all tests as expected by CI
-ci-test: rust-info test-fmt clippy test test-doc
+ci-test: rust-info test-fmt clippy test test-doc build-all-features
 
 # Verify that the current version of the crate is not the same as the one published on crates.io
 check-if-published:

--- a/varnish-macros/Cargo.toml
+++ b/varnish-macros/Cargo.toml
@@ -25,7 +25,7 @@ glob.workspace = true
 insta.workspace = true
 regex.workspace = true
 trybuild.workspace = true
-varnish.workspace = true
+varnish = { workspace = true, features = ["ffi"]}
 
 [lints]
 workspace = true

--- a/varnish-macros/src/generator.rs
+++ b/varnish-macros/src/generator.rs
@@ -162,6 +162,25 @@ impl Generator {
         let export_decls: Vec<_> = self.iter_all_funcs().map(|f| &f.export_decl).collect();
         let export_inits: Vec<_> = self.iter_all_funcs().map(|f| &f.export_init).collect();
 
+        // This list must match the list in varnish-macros/src/lib.rs
+        let use_ffi_items = quote![
+            VCL_BACKEND,
+            VCL_BOOL,
+            VCL_DURATION,
+            VCL_INT,
+            VCL_IP,
+            VCL_PROBE,
+            VCL_REAL,
+            VCL_STRING,
+            VCL_VOID,
+            VMOD_ABI_Version,
+            VMOD_PRIV_METHODS_MAGIC,
+            VclEvent,
+            vmod_priv,
+            vmod_priv_methods,
+            vrt_ctx,
+        ];
+
         quote!(
             #[allow(
                 non_snake_case,
@@ -175,23 +194,7 @@ impl Generator {
             mod varnish_generated {
                 use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
                 use std::ptr::null;
-                use varnish::ffi::{
-                    VCL_BACKEND,
-                    VCL_BOOL,
-                    VCL_DURATION,
-                    VCL_INT,
-                    VCL_IP,
-                    VCL_PROBE,
-                    VCL_REAL,
-                    VCL_STRING,
-                    VCL_VOID,
-                    VMOD_ABI_Version,
-                    VMOD_PRIV_METHODS_MAGIC,
-                    VclEvent,
-                    vmod_priv,
-                    vmod_priv_methods,
-                    vrt_ctx,
-                };
+                use varnish::ffi::{#use_ffi_items};
                 use varnish::vcl::{Ctx, IntoVCL, Workspace};
                 use super::*;
 

--- a/varnish/Cargo.toml
+++ b/varnish/Cargo.toml
@@ -17,3 +17,8 @@ varnish-sys.workspace = true
 
 [lints]
 workspace = true
+
+[features]
+default = []
+ffi = []
+vsc = []

--- a/varnish/src/lib.rs
+++ b/varnish/src/lib.rs
@@ -78,10 +78,25 @@
 //!     expect resp.status == 200
 //! ```
 
-// Re-publish varnish_sys::ffi and vcl
-pub use varnish_sys::{ffi, vcl};
+// Re-publish some varnish_sys modules
+pub use varnish_sys::vcl;
+
+#[cfg(not(feature = "ffi"))]
+pub mod ffi {
+    // This list must match the `use_ffi_items` in generator.rs
+    pub use varnish_sys::ffi::{
+        vmod_priv, vmod_priv_methods, vrt_ctx, VMOD_ABI_Version, VclEvent, VCL_BACKEND, VCL_BOOL,
+        VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL, VCL_STRING, VCL_VOID,
+        VMOD_PRIV_METHODS_MAGIC,
+    };
+}
+
+#[cfg(feature = "ffi")]
+pub use varnish_sys::ffi;
 
 pub mod varnishtest;
+
+#[cfg(feature = "vsc")]
 pub mod vsc;
 
 pub use varnish_macros::vmod;

--- a/varnish/src/vsc.rs
+++ b/varnish/src/vsc.rs
@@ -12,9 +12,8 @@ use std::path::Path;
 use std::ptr;
 use std::time::Duration;
 
+use varnish_sys::ffi;
 use varnish_sys::vcl::{VclError, VclResult};
-
-use crate::ffi;
 
 /// A statistics set, created using a [`VSCBuilder`]
 #[derive(Debug)]

--- a/vmod_test/Cargo.toml
+++ b/vmod_test/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 edition.workspace = true
 
 [dependencies]
-varnish.workspace = true
+varnish = { workspace = true, features = ["ffi"]}
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
This PR introduces `ffi` and `vsc` features, highlighting what API we treat as the more stable one.