### PR TITLE
Make Probe and CowProbe into one struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Mark `Workspace::alloc` as unsafe because the allocated array is not
   initialized
 - Rename `VSC` &rarr; `Stats`, `VSCBuilder` &rarr; `StatsBuilder`, and `VSCInternal` into `StatsImpl`
+- Consolidate `Probe` and `CowProbe<'a>` into one `Probe<T>` struct with a generic `String` or `Cow<str>`.
 
 # 0.1.0 (2024-11-12)
 

--- a/vmod_test/src/lib.rs
+++ b/vmod_test/src/lib.rs
@@ -16,9 +16,7 @@ mod rustest {
 
     use varnish::ffi;
     use varnish::ffi::VCL_STRING;
-    use varnish::vcl::{
-        new_vfp, CowProbe, CowRequest, Ctx, Event, Probe, Request, VclError, Workspace,
-    };
+    use varnish::vcl::{new_vfp, CowProbe, Ctx, Event, Probe, Request, VclError, Workspace};
 
     use super::VFPTest;
 
@@ -126,8 +124,8 @@ mod rustest {
             Some(probe) => format!(
                 "{}-{}-{}-{}-{}-{}",
                 match probe.request {
-                    CowRequest::URL(url) => format!("url:{url}"),
-                    CowRequest::Text(text) => format!("text:{text}"),
+                    Request::URL(url) => format!("url:{url}"),
+                    Request::Text(text) => format!("text:{text}"),
                 },
                 probe.threshold,
                 probe.timeout.as_secs(),


### PR DESCRIPTION
Keeping it much simpler - the only real difference between them is `String` vs `Cow<str>` for two fields.  A simple generic fixes that.