### PR TITLE
hide constructors, minor nits

### DIFF
--- a/varnish-sys/src/vcl/vsb.rs
+++ b/varnish-sys/src/vcl/vsb.rs
@@ -12,7 +12,7 @@ pub struct Buffer<'a> {
 impl<'a> Buffer<'a> {
     /// Create a `Vsb` from a C pointer
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub fn new(raw: *mut ffi::vsb) -> Self {
+    pub(crate) fn new(raw: *mut ffi::vsb) -> Self {
         let raw = unsafe { raw.as_mut().unwrap() };
         assert_eq!(raw.magic, ffi::VSB_MAGIC);
         Self { raw }

--- a/varnish-sys/src/vcl/ws.rs
+++ b/varnish-sys/src/vcl/ws.rs
@@ -37,7 +37,7 @@ pub struct Workspace<'a> {
 
 impl<'a> Workspace<'a> {
     /// Wrap a raw pointer into an object we can use.
-    pub fn new(raw: *mut ffi::ws) -> Self {
+    pub(crate) fn new(raw: *mut ffi::ws) -> Self {
         assert!(!raw.is_null(), "raw pointer was null");
         Self {
             raw,


### PR DESCRIPTION
* constructors for wrapper types make no sense to be exposed. we can always re-enable them later if someone comes up with a reasonable usecase.
* a few minor inlining