### PR TITLE
Rename `new` to `from_ptr` for several structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   initialized
 - Rename `VSC` &rarr; `Stats`, `VSCBuilder` &rarr; `StatsBuilder`, and `VSCInternal` into `StatsImpl`
 - Consolidate `Probe` and `CowProbe<'a>` into one `Probe<T>` struct with a generic `String` or `Cow<str>`.
+- Rename `new` to `from_ptr` for `Buffer`, `Workspace`, `HttpHeaders`, `FetchProcCtx`, `DeliveryProcCtx`, and make them private. Only `Ctx::from_ptr` is public because it gets created by a macro-generated function.
 
 # 0.1.0 (2024-11-12)
 

--- a/varnish-sys/src/vcl/backend.rs
+++ b/varnish-sys/src/vcl/backend.rs
@@ -323,13 +323,13 @@ unsafe extern "C" fn wrap_list<S: Serve<T>, T: Transfer>(
     json: i32,
 ) {
     let mut ctx = Ctx::from_ptr(ctxp);
-    let mut vsb = Buffer::new(vsbp);
+    let mut vsb = Buffer::from_ptr(vsbp);
     let backend: &S = get_backend(validate_director(be));
     backend.list(&mut ctx, &mut vsb, detailed != 0, json != 0);
 }
 
 unsafe extern "C" fn wrap_panic<S: Serve<T>, T: Transfer>(be: VCL_BACKEND, vsbp: *mut ffi::vsb) {
-    let mut vsb = Buffer::new(vsbp);
+    let mut vsb = Buffer::from_ptr(vsbp);
     let backend: &S = get_backend(validate_director(be));
     backend.panic(&mut vsb);
 }
@@ -413,7 +413,7 @@ unsafe extern "C" fn wrap_gethdrs<S: Serve<T>, T: Transfer>(
                             ctx.fail(format!("{}: insufficient workspace", backend.get_type()));
                             return -1;
                         };
-                        let Ok(t) = Workspace::new(bo.ws.as_mut_ptr())
+                        let Ok(t) = Workspace::from_ptr(bo.ws.as_mut_ptr())
                             .copy_bytes_with_null(&backend.get_type())
                         else {
                             ctx.fail(format!("{}: insufficient workspace", backend.get_type()));

--- a/varnish-sys/src/vcl/ctx.rs
+++ b/varnish-sys/src/vcl/ctx.rs
@@ -51,12 +51,12 @@ impl<'a> Ctx<'a> {
     pub fn from_ref(raw: &'a mut vrt_ctx) -> Self {
         assert_eq!(raw.magic, VRT_CTX_MAGIC);
         Self {
-            http_req: HttpHeaders::new(raw.http_req),
-            http_req_top: HttpHeaders::new(raw.http_req_top),
-            http_resp: HttpHeaders::new(raw.http_resp),
-            http_bereq: HttpHeaders::new(raw.http_bereq),
-            http_beresp: HttpHeaders::new(raw.http_beresp),
-            ws: Workspace::new(raw.ws),
+            http_req: HttpHeaders::from_ptr(raw.http_req),
+            http_req_top: HttpHeaders::from_ptr(raw.http_req_top),
+            http_resp: HttpHeaders::from_ptr(raw.http_resp),
+            http_bereq: HttpHeaders::from_ptr(raw.http_bereq),
+            http_beresp: HttpHeaders::from_ptr(raw.http_beresp),
+            ws: Workspace::from_ptr(raw.ws),
             raw,
         }
     }

--- a/varnish-sys/src/vcl/http.rs
+++ b/varnish-sys/src/vcl/http.rs
@@ -37,7 +37,7 @@ pub struct HttpHeaders<'a> {
 
 impl<'a> HttpHeaders<'a> {
     /// Wrap a raw pointer into an object we can use.
-    pub fn new(p: ffi::VCL_HTTP) -> Option<Self> {
+    pub(crate) fn from_ptr(p: ffi::VCL_HTTP) -> Option<Self> {
         Some(HttpHeaders {
             raw: unsafe { p.0.as_mut()? },
         })
@@ -47,7 +47,7 @@ impl<'a> HttpHeaders<'a> {
         assert!(idx < self.raw.nhd);
 
         /* XXX: aliasing warning, it's the same pointer as the one in Ctx */
-        let mut ws = Workspace::new(self.raw.ws);
+        let mut ws = Workspace::from_ptr(self.raw.ws);
         unsafe {
             let hd = self.raw.hd.offset(idx as isize).as_mut().unwrap();
             *hd = ffi::txt::from_cstr(ws.copy_bytes_with_null(&value)?);

--- a/varnish-sys/src/vcl/vsb.rs
+++ b/varnish-sys/src/vcl/vsb.rs
@@ -12,7 +12,7 @@ pub struct Buffer<'a> {
 impl<'a> Buffer<'a> {
     /// Create a `Vsb` from a C pointer
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn new(raw: *mut ffi::vsb) -> Self {
+    pub(crate) fn from_ptr(raw: *mut ffi::vsb) -> Self {
         let raw = unsafe { raw.as_mut().unwrap() };
         assert_eq!(raw.magic, ffi::VSB_MAGIC);
         Self { raw }

--- a/varnish-sys/src/vcl/ws.rs
+++ b/varnish-sys/src/vcl/ws.rs
@@ -37,7 +37,7 @@ pub struct Workspace<'a> {
 
 impl<'a> Workspace<'a> {
     /// Wrap a raw pointer into an object we can use.
-    pub(crate) fn new(raw: *mut ffi::ws) -> Self {
+    pub(crate) fn from_ptr(raw: *mut ffi::ws) -> Self {
         assert!(!raw.is_null(), "raw pointer was null");
         Self {
             raw,
@@ -282,7 +282,7 @@ impl TestWS {
 
     /// build a `Workspace`
     pub fn workspace(&mut self) -> Workspace {
-        Workspace::new(self.as_ptr())
+        Workspace::from_ptr(self.as_ptr())
     }
 }
 


### PR DESCRIPTION
For consistency with other structs like `Ctx`, whenever we create a wrapper for a C pointer, we should use the same function - `from_ptr`:  `Buffer`, `Workspace`, `HttpHeaders`, and `FetchProcCtx`