### PR TITLE
Skip creating `__ctx` when not needed

### DIFF
--- a/varnish/snapshots/docs_types@code.snap
+++ b/varnish/snapshots/docs_types@code.snap
@@ -25,11 +25,9 @@ mod types {
         use varnish::vcl::{Ctx, IntoVCL, Workspace};
         use super::*;
         unsafe extern "C" fn vmod_c_with_docs(__ctx: *mut vrt_ctx) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::with_docs()
         }
         unsafe extern "C" fn vmod_c_no_docs(__ctx: *mut vrt_ctx) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::no_docs()
         }
         unsafe extern "C" fn vmod_c_doctest(
@@ -37,11 +35,9 @@ mod types {
             _no_docs: VCL_INT,
             _v: VCL_INT,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::doctest(_no_docs.into(), _v.into())
         }
         unsafe extern "C" fn vmod_c_arg_only(__ctx: *mut vrt_ctx, _v: VCL_INT) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::arg_only(_v.into())
         }
         #[repr(C)]
@@ -55,7 +51,6 @@ mod types {
             __vcl_name: *const c_char,
             __args: *const arg_vmod_types_DocStruct__init,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
             let __result = Box::new(
                 super::DocStruct::new(

--- a/varnish/snapshots/event1_event@code.snap
+++ b/varnish/snapshots/event1_event@code.snap
@@ -20,7 +20,6 @@ mod event {
             __vp: *mut vmod_priv,
             __ev: VclEvent,
         ) -> VCL_INT {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::on_event(__ev);
             VCL_INT(0)
         }

--- a/varnish/snapshots/function_types@code.snap
+++ b/varnish/snapshots/function_types@code.snap
@@ -16,7 +16,6 @@ mod types {
         use varnish::vcl::{Ctx, IntoVCL, Workspace};
         use super::*;
         unsafe extern "C" fn vmod_c_to_void(__ctx: *mut vrt_ctx) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::to_void()
         }
         unsafe extern "C" fn vmod_c_to_res_void_err(__ctx: *mut vrt_ctx) {
@@ -50,11 +49,9 @@ mod types {
                 })
         }
         unsafe extern "C" fn vmod_c_type_bool(__ctx: *mut vrt_ctx, _v: VCL_BOOL) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::type_bool(_v.into())
         }
         unsafe extern "C" fn vmod_c_type_bool_dflt(__ctx: *mut vrt_ctx, _v: VCL_BOOL) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::type_bool_dflt(_v.into())
         }
         #[repr(C)]
@@ -66,7 +63,6 @@ mod types {
             __ctx: *mut vrt_ctx,
             __args: *const arg_vmod_types_opt_bool,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
             super::opt_bool(if __args.valid__v != 0 { __args._v.into() } else { None })
         }
@@ -93,7 +89,6 @@ mod types {
                 })
         }
         unsafe extern "C" fn vmod_c_type_cstr(__ctx: *mut vrt_ctx, _v: VCL_STRING) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::type_cstr(_v.into())
         }
         #[repr(C)]
@@ -105,23 +100,19 @@ mod types {
             __ctx: *mut vrt_ctx,
             __args: *const arg_vmod_types_opt_cstr,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
             super::opt_cstr(if __args.valid__v != 0 { __args._v.into() } else { None })
         }
         unsafe extern "C" fn vmod_c_opt_cstr_req(__ctx: *mut vrt_ctx, _v: VCL_STRING) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::opt_cstr_req(_v.into())
         }
         unsafe extern "C" fn vmod_c_type_cstr_dflt(__ctx: *mut vrt_ctx, _v: VCL_STRING) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::type_cstr_dflt(_v.into())
         }
         unsafe extern "C" fn vmod_c_type_cstr_dflt2(
             __ctx: *mut vrt_ctx,
             _v: VCL_STRING,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::type_cstr_dflt2(_v.into())
         }
         #[repr(C)]
@@ -133,14 +124,12 @@ mod types {
             __ctx: *mut vrt_ctx,
             __args: *const arg_vmod_types_opt_cstr_dflt,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
             super::opt_cstr_dflt(
                 if __args.valid__v != 0 { __args._v.into() } else { None },
             )
         }
         unsafe extern "C" fn vmod_c_opt_cstr_dflt2(__ctx: *mut vrt_ctx, _v: VCL_STRING) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::opt_cstr_dflt2(_v.into())
         }
         unsafe extern "C" fn vmod_c_to_cstr(__ctx: *mut vrt_ctx) -> VCL_STRING {
@@ -180,7 +169,6 @@ mod types {
             __ctx: *mut vrt_ctx,
             _v: VCL_DURATION,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::type_duration(_v.into())
         }
         #[repr(C)]
@@ -192,7 +180,6 @@ mod types {
             __ctx: *mut vrt_ctx,
             __args: *const arg_vmod_types_opt_duration,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
             super::opt_duration(
                 if __args.valid__v != 0 { __args._v.into() } else { None },
@@ -223,11 +210,9 @@ mod types {
                 })
         }
         unsafe extern "C" fn vmod_c_type_f64(__ctx: *mut vrt_ctx, _v: VCL_REAL) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::type_f64(_v.into())
         }
         unsafe extern "C" fn vmod_c_type_f64_dflt(__ctx: *mut vrt_ctx, _v: VCL_REAL) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::type_f64_dflt(_v.into())
         }
         #[repr(C)]
@@ -239,7 +224,6 @@ mod types {
             __ctx: *mut vrt_ctx,
             __args: *const arg_vmod_types_opt_f64,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
             super::opt_f64(if __args.valid__v != 0 { __args._v.into() } else { None })
         }
@@ -266,11 +250,9 @@ mod types {
                 })
         }
         unsafe extern "C" fn vmod_c_type_i64(__ctx: *mut vrt_ctx, _v: VCL_INT) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::type_i64(_v.into())
         }
         unsafe extern "C" fn vmod_c_type_i64_dflt(__ctx: *mut vrt_ctx, _v: VCL_INT) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::type_i64_dflt(_v.into())
         }
         #[repr(C)]
@@ -282,7 +264,6 @@ mod types {
             __ctx: *mut vrt_ctx,
             __args: *const arg_vmod_types_opt_i64,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
             super::opt_i64(if __args.valid__v != 0 { __args._v.into() } else { None })
         }
@@ -461,12 +442,10 @@ mod types {
             __ctx: *mut vrt_ctx,
             __args: *const arg_vmod_types_type_probe,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
             super::type_probe(if __args.valid__v != 0 { __args._v.into() } else { None })
         }
         unsafe extern "C" fn vmod_c_type_probe_req(__ctx: *mut vrt_ctx, _v: VCL_PROBE) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::type_probe_req(_v.into())
         }
         unsafe extern "C" fn vmod_c_to_probe(__ctx: *mut vrt_ctx) -> VCL_PROBE {
@@ -500,7 +479,6 @@ mod types {
             __ctx: *mut vrt_ctx,
             __args: *const arg_vmod_types_type_cow_probe,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
             super::type_cow_probe(
                 if __args.valid__v != 0 { __args._v.into() } else { None },
@@ -510,7 +488,6 @@ mod types {
             __ctx: *mut vrt_ctx,
             _v: VCL_PROBE,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::type_cow_probe_req(_v.into())
         }
         unsafe extern "C" fn vmod_c_to_cow_probe(__ctx: *mut vrt_ctx) -> VCL_PROBE {
@@ -544,12 +521,10 @@ mod types {
             __ctx: *mut vrt_ctx,
             __args: *const arg_vmod_types_type_ip,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
             super::type_ip(if __args.valid__v != 0 { __args._v.into() } else { None })
         }
         unsafe extern "C" fn vmod_c_type_ip_req(__ctx: *mut vrt_ctx, _v: VCL_IP) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::type_ip_req(_v.into())
         }
         unsafe extern "C" fn vmod_c_to_ip(__ctx: *mut vrt_ctx) -> VCL_IP {
@@ -575,7 +550,6 @@ mod types {
                 })
         }
         unsafe extern "C" fn vmod_c_to_vcl_string(__ctx: *mut vrt_ctx) -> VCL_STRING {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::to_vcl_string()
         }
         unsafe extern "C" fn vmod_c_to_res_vcl_string(

--- a/varnish/snapshots/object_obj@code.snap
+++ b/varnish/snapshots/object_obj@code.snap
@@ -26,7 +26,6 @@ mod obj {
             __vcl_name: *const c_char,
             __args: *const arg_vmod_obj_kv1__init,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
             let __result = Box::new(
                 super::kv1::new(

--- a/varnish/snapshots/shared1_task@code.snap
+++ b/varnish/snapshots/shared1_task@code.snap
@@ -43,7 +43,6 @@ mod task {
             __ctx: *mut vrt_ctx,
             vcl: *const vmod_priv,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::per_vcl_val(vcl.as_ref().and_then(|v| v.get_ref()))
         }
         #[repr(C)]
@@ -56,7 +55,6 @@ mod task {
             __ctx: *mut vrt_ctx,
             __args: *const arg_vmod_task_per_vcl_opt,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
             super::per_vcl_opt(
                 __args.vcl.as_ref().and_then(|v| v.get_ref()),
@@ -67,7 +65,6 @@ mod task {
             __ctx: *mut vrt_ctx,
             tsk: *mut vmod_priv,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             let mut __obj_per_task = (*tsk).take();
             let __result = super::per_tsk_val(&mut __obj_per_task);
             if let Some(obj) = __obj_per_task {
@@ -85,7 +82,6 @@ mod task {
             __ctx: *mut vrt_ctx,
             __args: *const arg_vmod_task_per_tsk_opt,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
             let mut __obj_per_task = (*__args.tsk).take();
             let __result = super::per_tsk_opt(
@@ -103,7 +99,6 @@ mod task {
             __vcl_name: *const c_char,
             vcl: *mut vmod_priv,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             let mut __obj_per_vcl = (*vcl).take();
             let __result = Box::new(super::PerVcl::new(&mut __obj_per_vcl));
             *__objp = Box::into_raw(__result);
@@ -121,7 +116,6 @@ mod task {
             tsk: *mut vmod_priv,
             vcl: *const vmod_priv,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             let __obj = __obj.as_ref().unwrap();
             let mut __obj_per_task = (*tsk).take();
             let __result = __obj
@@ -138,7 +132,6 @@ mod task {
             vcl: *const vmod_priv,
             val: VCL_INT,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             let __obj = __obj.as_ref().unwrap();
             let mut __obj_per_task = (*tsk).take();
             let __result = __obj
@@ -164,7 +157,6 @@ mod task {
             __obj: *const super::PerVcl,
             __args: *const arg_vmod_task_PerVcl_both_opt,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             let __args = __args.as_ref().unwrap();
             let __obj = __obj.as_ref().unwrap();
             let mut __obj_per_task = (*__args.tsk).take();

--- a/varnish/snapshots/shared2_tuple@code.snap
+++ b/varnish/snapshots/shared2_tuple@code.snap
@@ -30,7 +30,6 @@ mod tuple {
             __vp: *mut vmod_priv,
             __ev: VclEvent,
         ) -> VCL_INT {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             let mut __obj_per_vcl = (*__vp).take();
             super::on_event(&mut __obj_per_vcl);
             let __result = VCL_INT(0);
@@ -44,7 +43,6 @@ mod tuple {
             tsk_vals: *mut vmod_priv,
             vcl_vals: *const vmod_priv,
         ) {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             let mut __obj_per_task = (*tsk_vals).take();
             let __result = super::per_tsk_val(
                 &mut __obj_per_task,

--- a/varnish/snapshots/vcl_returns_vcl_returns@code.snap
+++ b/varnish/snapshots/vcl_returns_vcl_returns@code.snap
@@ -16,7 +16,6 @@ mod vcl_returns {
         use varnish::vcl::{Ctx, IntoVCL, Workspace};
         use super::*;
         unsafe extern "C" fn vmod_c_val_acl(__ctx: *mut vrt_ctx) -> VCL_ACL {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_acl()
         }
         unsafe extern "C" fn vmod_c_res_acl(__ctx: *mut vrt_ctx) -> VCL_ACL {
@@ -31,7 +30,6 @@ mod vcl_returns {
                 })
         }
         unsafe extern "C" fn vmod_c_val_backend(__ctx: *mut vrt_ctx) -> VCL_BACKEND {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_backend()
         }
         unsafe extern "C" fn vmod_c_res_backend(__ctx: *mut vrt_ctx) -> VCL_BACKEND {
@@ -46,7 +44,6 @@ mod vcl_returns {
                 })
         }
         unsafe extern "C" fn vmod_c_val_blob(__ctx: *mut vrt_ctx) -> VCL_BLOB {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_blob()
         }
         unsafe extern "C" fn vmod_c_res_blob(__ctx: *mut vrt_ctx) -> VCL_BLOB {
@@ -61,7 +58,6 @@ mod vcl_returns {
                 })
         }
         unsafe extern "C" fn vmod_c_val_body(__ctx: *mut vrt_ctx) -> VCL_BODY {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_body()
         }
         unsafe extern "C" fn vmod_c_res_body(__ctx: *mut vrt_ctx) -> VCL_BODY {
@@ -76,7 +72,6 @@ mod vcl_returns {
                 })
         }
         unsafe extern "C" fn vmod_c_val_bool(__ctx: *mut vrt_ctx) -> VCL_BOOL {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_bool()
         }
         unsafe extern "C" fn vmod_c_res_bool(__ctx: *mut vrt_ctx) -> VCL_BOOL {
@@ -91,7 +86,6 @@ mod vcl_returns {
                 })
         }
         unsafe extern "C" fn vmod_c_val_bytes(__ctx: *mut vrt_ctx) -> VCL_BYTES {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_bytes()
         }
         unsafe extern "C" fn vmod_c_res_bytes(__ctx: *mut vrt_ctx) -> VCL_BYTES {
@@ -106,7 +100,6 @@ mod vcl_returns {
                 })
         }
         unsafe extern "C" fn vmod_c_val_duration(__ctx: *mut vrt_ctx) -> VCL_DURATION {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_duration()
         }
         unsafe extern "C" fn vmod_c_res_duration(__ctx: *mut vrt_ctx) -> VCL_DURATION {
@@ -121,7 +114,6 @@ mod vcl_returns {
                 })
         }
         unsafe extern "C" fn vmod_c_val_enum(__ctx: *mut vrt_ctx) -> VCL_ENUM {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_enum()
         }
         unsafe extern "C" fn vmod_c_res_enum(__ctx: *mut vrt_ctx) -> VCL_ENUM {
@@ -136,7 +128,6 @@ mod vcl_returns {
                 })
         }
         unsafe extern "C" fn vmod_c_val_header(__ctx: *mut vrt_ctx) -> VCL_HEADER {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_header()
         }
         unsafe extern "C" fn vmod_c_res_header(__ctx: *mut vrt_ctx) -> VCL_HEADER {
@@ -151,7 +142,6 @@ mod vcl_returns {
                 })
         }
         unsafe extern "C" fn vmod_c_val_http(__ctx: *mut vrt_ctx) -> VCL_HTTP {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_http()
         }
         unsafe extern "C" fn vmod_c_res_http(__ctx: *mut vrt_ctx) -> VCL_HTTP {
@@ -166,11 +156,9 @@ mod vcl_returns {
                 })
         }
         unsafe extern "C" fn vmod_c_val_instance(__ctx: *mut vrt_ctx) -> VCL_INSTANCE {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_instance()
         }
         unsafe extern "C" fn vmod_c_val_int(__ctx: *mut vrt_ctx) -> VCL_INT {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_int()
         }
         unsafe extern "C" fn vmod_c_res_int(__ctx: *mut vrt_ctx) -> VCL_INT {
@@ -185,7 +173,6 @@ mod vcl_returns {
                 })
         }
         unsafe extern "C" fn vmod_c_val_ip(__ctx: *mut vrt_ctx) -> VCL_IP {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_ip()
         }
         unsafe extern "C" fn vmod_c_res_ip(__ctx: *mut vrt_ctx) -> VCL_IP {
@@ -200,7 +187,6 @@ mod vcl_returns {
                 })
         }
         unsafe extern "C" fn vmod_c_val_probe(__ctx: *mut vrt_ctx) -> VCL_PROBE {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_probe()
         }
         unsafe extern "C" fn vmod_c_res_probe(__ctx: *mut vrt_ctx) -> VCL_PROBE {
@@ -215,7 +201,6 @@ mod vcl_returns {
                 })
         }
         unsafe extern "C" fn vmod_c_val_real(__ctx: *mut vrt_ctx) -> VCL_REAL {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_real()
         }
         unsafe extern "C" fn vmod_c_res_real(__ctx: *mut vrt_ctx) -> VCL_REAL {
@@ -230,7 +215,6 @@ mod vcl_returns {
                 })
         }
         unsafe extern "C" fn vmod_c_val_regex(__ctx: *mut vrt_ctx) -> VCL_REGEX {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_regex()
         }
         unsafe extern "C" fn vmod_c_res_regex(__ctx: *mut vrt_ctx) -> VCL_REGEX {
@@ -245,7 +229,6 @@ mod vcl_returns {
                 })
         }
         unsafe extern "C" fn vmod_c_val_stevedore(__ctx: *mut vrt_ctx) -> VCL_STEVEDORE {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_stevedore()
         }
         unsafe extern "C" fn vmod_c_res_stevedore(__ctx: *mut vrt_ctx) -> VCL_STEVEDORE {
@@ -260,7 +243,6 @@ mod vcl_returns {
                 })
         }
         unsafe extern "C" fn vmod_c_val_strands(__ctx: *mut vrt_ctx) -> VCL_STRANDS {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_strands()
         }
         unsafe extern "C" fn vmod_c_res_strands(__ctx: *mut vrt_ctx) -> VCL_STRANDS {
@@ -275,7 +257,6 @@ mod vcl_returns {
                 })
         }
         unsafe extern "C" fn vmod_c_val_string(__ctx: *mut vrt_ctx) -> VCL_STRING {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_string()
         }
         unsafe extern "C" fn vmod_c_res_string(__ctx: *mut vrt_ctx) -> VCL_STRING {
@@ -290,7 +271,6 @@ mod vcl_returns {
                 })
         }
         unsafe extern "C" fn vmod_c_val_sub(__ctx: *mut vrt_ctx) -> VCL_SUB {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_sub()
         }
         unsafe extern "C" fn vmod_c_res_sub(__ctx: *mut vrt_ctx) -> VCL_SUB {
@@ -305,7 +285,6 @@ mod vcl_returns {
                 })
         }
         unsafe extern "C" fn vmod_c_val_time(__ctx: *mut vrt_ctx) -> VCL_TIME {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_time()
         }
         unsafe extern "C" fn vmod_c_res_time(__ctx: *mut vrt_ctx) -> VCL_TIME {
@@ -320,7 +299,6 @@ mod vcl_returns {
                 })
         }
         unsafe extern "C" fn vmod_c_val_vcl(__ctx: *mut vrt_ctx) -> VCL_VCL {
-            let mut __ctx = Ctx::from_ptr(__ctx);
             super::val_vcl()
         }
         unsafe extern "C" fn vmod_c_res_vcl(__ctx: *mut vrt_ctx) -> VCL_VCL {


### PR DESCRIPTION
A minor optimization - in a macro-generated function, check if the Rust context wrapper `Ctx` is needed, and if not, skip its creation.