### PR TITLE
A few minor refactorings

### DIFF
--- a/varnish-macros/src/errors.rs
+++ b/varnish-macros/src/errors.rs
@@ -64,7 +64,7 @@ impl Errors {
 
 impl From<syn::Error> for Errors {
     fn from(err: syn::Error) -> Self {
-        let mut errors = Errors::new();
+        let mut errors = Self::new();
         errors.push(err);
         errors
     }
@@ -72,7 +72,7 @@ impl From<syn::Error> for Errors {
 
 impl From<darling::Error> for Errors {
     fn from(err: darling::Error) -> Self {
-        let mut errors = Errors::new();
+        let mut errors = Self::new();
         errors.push(err.into());
         errors
     }

--- a/varnish-macros/src/model.rs
+++ b/varnish-macros/src/model.rs
@@ -14,6 +14,22 @@ pub struct VmodInfo {
     pub shared_types: SharedTypes,
 }
 
+impl VmodInfo {
+    fn iter_all_funcs(&self) -> impl Iterator<Item = &FuncInfo> {
+        self.funcs
+            .iter()
+            .chain(self.objects.iter().flat_map(|o| o.funcs.iter()))
+    }
+
+    pub fn count_funcs<F: FnMut(&&FuncInfo) -> bool>(&self, filter: F) -> usize {
+        self.iter_all_funcs().filter(filter).count()
+    }
+
+    pub fn count_args<F: Copy + Fn(&&ParamTypeInfo) -> bool>(&self, filter: F) -> usize {
+        self.iter_all_funcs().map(|f| f.count_args(filter)).sum()
+    }
+}
+
 /// Represents the shared types used by multiple functions. Each of these types is unique per VMOD.
 #[derive(Debug, Default)]
 pub struct SharedTypes {
@@ -48,6 +64,12 @@ pub struct FuncInfo {
     pub args: Vec<ParamTypeInfo>,
     pub output_ty: OutputTy,
     pub out_result: bool,
+}
+
+impl FuncInfo {
+    pub fn count_args<F: Fn(&&ParamTypeInfo) -> bool>(&self, filter: F) -> usize {
+        self.args.iter().filter(filter).count()
+    }
 }
 
 /// What kind of function is this?

--- a/varnish-macros/src/parser_args.rs
+++ b/varnish-macros/src/parser_args.rs
@@ -93,12 +93,12 @@ impl ParamType {
     ) -> ProcResult<Self> {
         // Make param validation a bit more readable
         macro_rules! error {
-            ($msg:literal) => {
+            ($msg:expr) => {
                 Err(error(pat_ty, $msg))?
             };
         }
         macro_rules! unique {
-            ($var:ident, $msg:literal) => {
+            ($var:ident, $msg:expr) => {
                 if status.$var {
                     error!($msg);
                 }
@@ -106,14 +106,14 @@ impl ParamType {
             };
         }
         macro_rules! only_in {
-            ($pat:pat, $msg:literal) => {
+            ($pat:pat, $msg:expr) => {
                 if !matches!(status.func_type, $pat) {
                     error!($msg);
                 }
             };
         }
         macro_rules! not_in {
-            ($pat:pat, $msg:literal) => {
+            ($pat:pat, $msg:expr) => {
                 if matches!(status.func_type, $pat) {
                     error!($msg);
                 }

--- a/varnish-sys/src/extensions.rs
+++ b/varnish-sys/src/extensions.rs
@@ -12,6 +12,7 @@ impl vmod_priv {
     ///
     /// SAFETY: `priv_` must reference a valid `T` object pointer or `NULL`
     pub unsafe fn take<T>(&mut self) -> Option<Box<T>> {
+        // methods does not need to be dropped because `put` always sets it to a static reference
         self.methods = null();
         get_owned_bbox(&mut self.priv_)
     }

--- a/varnish-sys/src/vcl/convert.rs
+++ b/varnish-sys/src/vcl/convert.rs
@@ -157,7 +157,7 @@ impl From<Duration> for VCL_DURATION {
 //
 impl From<vtim_dur> for Duration {
     fn from(value: vtim_dur) -> Self {
-        Duration::from_secs_f64(value.0)
+        Self::from_secs_f64(value.0)
     }
 }
 impl From<Duration> for vtim_dur {

--- a/varnish-sys/src/vcl/ctx.rs
+++ b/varnish-sys/src/vcl/ctx.rs
@@ -135,7 +135,7 @@ pub struct TestCtx {
 impl TestCtx {
     /// Instantiate a [`vrt_ctx`], as well as the workspace (of size `sz`) it links to.
     pub fn new(sz: usize) -> Self {
-        let mut test_ctx = TestCtx {
+        let mut test_ctx = Self {
             vrt_ctx: vrt_ctx {
                 magic: VRT_CTX_MAGIC,
                 ..vrt_ctx::default()

--- a/varnish-sys/src/vcl/processor.rs
+++ b/varnish-sys/src/vcl/processor.rs
@@ -8,7 +8,7 @@
 use std::ffi::{c_int, c_void, CStr};
 use std::ptr;
 
-use crate::ffi::{vdp_ctx, vfp_ctx, vfp_entry, VdpAction, VfpStatus};
+use crate::ffi::{vdp_ctx, vfp_ctx, vfp_entry, vrt_ctx, VdpAction, VfpStatus};
 use crate::vcl::{Ctx, VclError};
 use crate::{ffi, validate_vfp_ctx, validate_vfp_entry};
 
@@ -56,7 +56,7 @@ pub trait DeliveryProcessor: Sized {
 }
 
 pub unsafe extern "C" fn gen_vdp_init<T: DeliveryProcessor>(
-    vrt_ctx: *const ffi::vrt_ctx,
+    vrt_ctx: *const vrt_ctx,
     ctx_raw: *mut vdp_ctx,
     priv_: *mut *mut c_void,
     #[cfg(feature = "_objcore_in_init")] _oc: *mut ffi::objcore,
@@ -173,7 +173,7 @@ pub trait FetchProcessor: Sized {
 }
 
 unsafe extern "C" fn wrap_vfp_init<T: FetchProcessor>(
-    vrt_ctx: *const ffi::vrt_ctx,
+    vrt_ctx: *const vrt_ctx,
     ctxp: *mut vfp_ctx,
     vfep: *mut vfp_entry,
 ) -> VfpStatus {

--- a/varnish/snapshots/docs_types@code.snap
+++ b/varnish/snapshots/docs_types@code.snap
@@ -163,7 +163,7 @@ mod types {
     impl DocStruct {
         /// doctest for `new`
         pub fn new(cap: Option<i64>) -> Self {
-            DocStruct
+            Self
         }
         /// doctest for the object function
         #[rustfmt::skip]

--- a/varnish/snapshots/object_obj@code.snap
+++ b/varnish/snapshots/object_obj@code.snap
@@ -306,7 +306,7 @@ mod obj {
     use varnish::vcl::Ctx;
     impl kv1 {
         pub fn new(cap: Option<i64>) -> Self {
-            kv1
+            Self
         }
         pub fn set(&self, key: &str, value: &str) {}
         pub fn get(&self, key: &str) -> String {
@@ -315,13 +315,13 @@ mod obj {
     }
     impl kv2 {
         pub fn new(cap: Option<i64>, name: &str) -> Self {
-            kv2
+            Self
         }
         pub fn set(&self, key: &str, value: Option<&str>) {}
     }
     impl kv3 {
         pub fn new(ctx: &mut Ctx, cap: Option<i64>, name: &str) -> Self {
-            kv3
+            Self
         }
         pub fn set(&self, ctx: &mut Ctx, key: &str, value: Option<&str>) {}
     }

--- a/varnish/snapshots/shared1_task@code.snap
+++ b/varnish/snapshots/shared1_task@code.snap
@@ -282,7 +282,7 @@ mod task {
     pub fn per_vcl_opt(vcl: Option<&PerVcl>, op: Option<i64>) {}
     impl PerVcl {
         pub fn new(vcl: &mut Option<Box<PerVcl>>) -> Self {
-            PerVcl
+            Self
         }
         pub fn both(&self, tsk: &mut Option<Box<PerTask>>, vcl: Option<&PerVcl>) {}
         pub fn both_pos(

--- a/varnish/tests/fail/error_event.stderr
+++ b/varnish/tests/fail/error_event.stderr
@@ -1,5 +1,5 @@
-error: Only one event handler is allowed
- --> tests/fail/error_event.rs:7:12
+error: More than one event handler found. Only one event handler is allowed
+ --> tests/fail/error_event.rs:2:1
   |
-7 |     pub fn event_fn2() {}
-  |            ^^^^^^^^^
+2 | mod event_dup {
+  | ^^^

--- a/varnish/tests/fail/error_fn.stderr
+++ b/varnish/tests/fail/error_fn.stderr
@@ -1,8 +1,10 @@
 error: No functions or objects found in this module
- --> tests/fail/error_fn.rs:2:5
+ --> tests/fail/error_fn.rs:1:1
   |
-2 | mod empty {}
-  |     ^^^^^
+1 | #[varnish::vmod]
+  | ^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `varnish::vmod` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: Only public functions and impl blocks are allowed inside a `mod` tagged with `#[varnish::vmod]`. Add `pub` or move this function outside of this mod.
  --> tests/fail/error_fn.rs:6:5
@@ -23,7 +25,9 @@ error: unsafe functions are not supported
   |         ^^^^^^
 
 error: No functions or objects found in this module
- --> tests/fail/error_fn.rs:5:5
+ --> tests/fail/error_fn.rs:4:1
   |
-5 | mod err_fn {
-  |     ^^^^^^
+4 | #[varnish::vmod]
+  | ^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `varnish::vmod` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/varnish/tests/fail/error_obj.stderr
+++ b/varnish/tests/fail/error_obj.stderr
@@ -71,7 +71,9 @@ error: Object must have a constructor called `new`
    |          ^^^^^^^^^^^^^
 
 error: No functions or objects found in this module
- --> tests/fail/error_obj.rs:9:5
+ --> tests/fail/error_obj.rs:8:1
   |
-9 | mod err {
-  |     ^^^
+8 | #[varnish::vmod]
+  | ^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `varnish::vmod` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/varnish/tests/fail/error_obj_no_ctor.stderr
+++ b/varnish/tests/fail/error_obj_no_ctor.stderr
@@ -5,7 +5,9 @@ error: Object must have a constructor called `new`
   |          ^^^^^^^^^
 
 error: No functions or objects found in this module
- --> tests/fail/error_obj_no_ctor.rs:4:5
+ --> tests/fail/error_obj_no_ctor.rs:3:1
   |
-4 | mod err {
-  |     ^^^
+3 | #[varnish::vmod]
+  | ^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `varnish::vmod` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/varnish/tests/pass/docs.rs
+++ b/varnish/tests/pass/docs.rs
@@ -60,7 +60,7 @@ mod types {
             /// doc comment for `cap`
             cap: Option<i64>,
         ) -> Self {
-            DocStruct
+            Self
         }
         /// doctest for the object function
         #[rustfmt::skip]

--- a/varnish/tests/pass/object.rs
+++ b/varnish/tests/pass/object.rs
@@ -16,7 +16,7 @@ mod obj {
 
     impl kv1 {
         pub fn new(cap: Option<i64>) -> Self {
-            kv1
+            Self
         }
         pub fn set(&self, key: &str, value: &str) {}
         pub fn get(&self, key: &str) -> String {
@@ -26,14 +26,14 @@ mod obj {
 
     impl kv2 {
         pub fn new(cap: Option<i64>, #[vcl_name] name: &str) -> Self {
-            kv2
+            Self
         }
         pub fn set(&self, key: &str, value: Option<&str>) {}
     }
 
     impl kv3 {
         pub fn new(ctx: &mut Ctx, cap: Option<i64>, #[vcl_name] name: &str) -> Self {
-            kv3
+            Self
         }
         pub fn set(&self, ctx: &mut Ctx, key: &str, value: Option<&str>) {}
     }

--- a/varnish/tests/pass/shared1.rs
+++ b/varnish/tests/pass/shared1.rs
@@ -26,7 +26,7 @@ mod task {
 
     impl PerVcl {
         pub fn new(#[shared_per_vcl] vcl: &mut Option<Box<PerVcl>>) -> Self {
-            PerVcl
+            Self
         }
 
         pub fn both(


### PR DESCRIPTION
Getting ready for the per_vcl filter registry, and cleaning up some unrelated code.  Simplified global parser validation with a dedicated function - easier to scan the entire parsed model to see if any conditions are invalid, e.g. multiple event functions, etc