### PR TITLE
add multi-version docker support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,3 +28,7 @@ cargo expand -p varnish --test compile --tests try_to_build > varnish/tests/pass
 ```
 
 Delete the top 2 lines with `mod try_to_build {` and the last `}`,  and reformat `object.expanded.rs`  before comparing it with `object.rs` to see the resulting code.  Now, modify the `path` in the `compiler.rs` to point to the expanded file, and you should be able to run `cargo check --tests` to see the errors. 
+
+# Using Docker
+
+Docker allows multiple Varnish versions on the same machine.  To use it, run `just docker-run-76` or any other version (run `just` to see a list).  On the first run, it will build the image, install needed dependencies, and then it will start the container.  The container will have the git root directory mounted as `/app`, so you can run `cargo build` and `cargo test` as usual. All work is preserved in the `docker/.cache/<version>`, so restarting container would not need re-install everything.

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,4 @@
+# Make sure empty file is not ignored
+.cache/*
+!.cache/
+!.cache/empty_file

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,50 @@
+FROM ubuntu:22.04
+
+RUN    apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        apt-transport-https \
+        bash-completion \
+        build-essential \
+        clang \
+        cmake \
+        curl \
+        git \
+        gnupg \
+        llvm \
+        pkg-config \
+        sudo `# allows dev to install more packages without switching to root or rebuilding container` \
+    && : # end of the RUN cmd - easier to keep a colon at the end of the list, than to keep the backslashes in check
+
+# Pass in the VARNISH_VERSION build arg to specify the version of Varnish to install
+ARG VARNISH_VERSION=76
+RUN curl -sSf "https://packagecloud.io/install/repositories/varnishcache/varnish${VARNISH_VERSION}/script.deb.sh" | sudo bash \
+    && (sudo apt-get install -y varnish-dev || sudo apt-get install -y libvarnishapi-dev)
+
+ARG USERNAME=user
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Create docker user wuth sudo rights as passed in by the build command
+# This was modeled on https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user
+# On a Mac, USER_GID might already exist, so ignore it if it fails (--force)
+RUN groupadd --force --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# This allows users to `docker run` without specifying -u and -g
+USER $USERNAME
+
+ENV RUSTUP_HOME=/home/$USERNAME/.cache/.rustup \
+    CARGO_HOME=/home/$USERNAME/.cache/.cargo \
+    PATH=/home/$USERNAME/.cache/.cargo/bin:$PATH
+
+# As the very last step, copy the startup script
+USER root
+COPY startup.sh /usr/local/bin/startup.sh
+RUN chmod +x /usr/local/bin/startup.sh
+USER $USERNAME
+
+WORKDIR /app
+ENTRYPOINT ["/usr/local/bin/startup.sh"]
+CMD ["bash"]

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+if [ ! -d /app/.github ] || [ ! -d ~/.cache ]; then
+    echo " "
+    echo "ERROR: Docker container was not started properly."
+    echo "       Use   just docker-run-76  or another version."
+    exit 1
+fi
+
+export PATH="$PATH:~/.local/bin/"
+
+export CARGO_TARGET_DIR=~/.cache/target
+if [ ! -f "$CARGO_HOME/env" ]; then
+    echo "Downloading and installing Rust..."
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+fi
+. "$CARGO_HOME/env"
+
+if ! command -v cargo-binstall; then
+  echo "cargo-binstall is not found. Installing..." >&2
+  curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+fi
+
+cargo binstall --no-confirm just ripgrep
+
+exec "$@"

--- a/justfile
+++ b/justfile
@@ -115,3 +115,22 @@ check-if-published:
     else
         echo "The current crate version has not yet been published."
     fi
+
+[private]
+docker-build-ver VERSION:
+    docker build -t varnish-img-{{VERSION}} --build-arg VARNISH_VERSION={{VERSION}} --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) -f docker/Dockerfile docker
+
+[private]
+docker-run-ver VERSION *ARGS:
+    mkdir -p docker/.cache/{{VERSION}}
+    touch docker/.cache/{{VERSION}}/.bash_history
+    docker run --rm -it \
+        -v "$PWD:/app/" \
+        -v "$PWD/docker/.cache/{{VERSION}}:/home/user/.cache" \
+        -v "$PWD/docker/.cache/{{VERSION}}/.bash_history:/home/user/.bash_history" \
+        varnish-img-{{VERSION}} {{ARGS}}
+
+docker-run-76 *ARGS: (docker-build-ver "76") (docker-run-ver "76" ARGS)
+docker-run-75 *ARGS: (docker-build-ver "75") (docker-run-ver "75" ARGS)
+docker-run-74 *ARGS: (docker-build-ver "74") (docker-run-ver "74" ARGS)
+docker-run-60 *ARGS: (docker-build-ver "60") (docker-run-ver "60" ARGS)


### PR DESCRIPTION
Docker allows multiple Varnish versions on the same machine.  To use it, run `just docker-run-76` or any other version (run `just` to see a list).  On the first run, it will build the image, install needed dependencies, and then it will start the container.  The container will have the git root directory mounted as `/app`, so you can run `cargo build` and `cargo test` as usual. All work is preserved in the `docker/.cache/<version>`, so restarting container would not need re-install everything.

This will allow simpler #141 implementation