### PR TITLE
Easier build config reuse

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ pedantic = { level = "warn", priority = -1 }
 cast_possible_truncation = "allow"
 cast_possible_wrap = "allow"
 cast_sign_loss = "allow"
+manual_range_contains = "allow"
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"
 module_name_repetitions = "allow"

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -16,11 +16,20 @@ if [ ! -f "$CARGO_HOME/env" ]; then
 fi
 . "$CARGO_HOME/env"
 
+if ! command -v cargo-insta; then
+  echo "cargo-insta is not found. Installing..." >&2
+  curl -LsSf https://insta.rs/install.sh | sh
+fi
+
 if ! command -v cargo-binstall; then
   echo "cargo-binstall is not found. Installing..." >&2
   curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 fi
 
-cargo binstall --no-confirm just ripgrep
+cargo binstall --no-confirm just ripgrep cargo-expand
 
+echo "##################################################"
+echo "##  Welcome to the Varnish development container"
+echo "##  Use 'just' to see the available commands."
+echo "##################################################"
 exec "$@"

--- a/varnish-sys/Cargo.toml
+++ b/varnish-sys/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "varnish-sys"
 authors = ["Guillaume Quintard <guillaume.quintard@gmail.com>", "Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
+links = "varnishapi"
 description.workspace = true
 keywords.workspace = true
 categories.workspace = true
@@ -10,13 +11,6 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 readme.workspace = true
-
-[features]
-default = []
-#
-# These features are used to match the lib to the various Varnish API versions.
-# They are set in the build.rs file and should not be used directly by the user.
-_objcore_in_init = []  # <=7.5 passed *objcore in vdp_init_f as the 4th param
 
 [lib]
 name = "varnish_sys"

--- a/varnish-sys/src/vcl/processor.rs
+++ b/varnish-sys/src/vcl/processor.rs
@@ -59,7 +59,7 @@ pub unsafe extern "C" fn gen_vdp_init<T: DeliveryProcessor>(
     vrt_ctx: *const vrt_ctx,
     ctx_raw: *mut vdp_ctx,
     priv_: *mut *mut c_void,
-    #[cfg(feature = "_objcore_in_init")] _oc: *mut ffi::objcore,
+    #[cfg(varnishsys_objcore_in_init)] _oc: *mut ffi::objcore,
 ) -> c_int {
     assert_ne!(priv_, ptr::null_mut());
     assert_eq!(*priv_, ptr::null_mut());


### PR DESCRIPTION
* Use `links` manifest key (see [docs](https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key)) - this exports all metadata fields to all dependants.

With this change, any crate that depends on `varnish-sys` will have `DEP_VARNISHAPI_VERSION_NUMBER=6.0.13` env var set during the build, accessible from that crate's `build.rs`.  We can re-parse it, or better yet - add some more metadata values relevant to specific usecases.

* Do not declare hidden features in `Cargo.toml` - turns out there is a [special command](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-check-cfg) for that.
* Added a few tools to the docker