### PR TITLE
Use `vmod_data`, varnishapi installation

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,8 +37,13 @@ jobs:
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
       - name: install varnish-dev
         run: |
-          curl -s https://packagecloud.io/install/repositories/varnishcache/${{ matrix.setup }}/script.deb.sh | sudo bash
-          sudo apt-get install -y varnish-dev
+          # These steps should be the same as in the Dockerfile
+          set -ex
+          curl -sSf "https://packagecloud.io/install/repositories/varnishcache/${{ matrix.setup }}/script.deb.sh" | sudo bash
+          echo 'echo '\''Package: varnish varnish-dev\nPin: origin "packagecloud.io"\nPin-Priority: 1001'\'' > /etc/apt/preferences.d/varnish' | sudo bash
+          cat /etc/apt/preferences.d/varnish
+          sudo apt-cache policy varnish
+          sudo apt-get install -y varnish varnish-dev
       - run: just -v ci-test
       - name: Check semver
         if: matrix.type == 'latest'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,8 +17,13 @@ RUN    apt-get update \
 
 # Pass in the VARNISH_VERSION build arg to specify the version of Varnish to install
 ARG VARNISH_VERSION=76
-RUN curl -sSf "https://packagecloud.io/install/repositories/varnishcache/varnish${VARNISH_VERSION}/script.deb.sh" | sudo bash \
-    && (sudo apt-get install -y varnish-dev || sudo apt-get install -y libvarnishapi-dev)
+# These steps should be the same as in the CI workflow
+RUN set -ex; \
+    curl -sSf "https://packagecloud.io/install/repositories/varnishcache/varnish${VARNISH_VERSION}/script.deb.sh" | sudo bash; \
+    echo 'Package: varnish varnish-dev\nPin: origin "packagecloud.io"\nPin-Priority: 1001' > /etc/apt/preferences.d/varnish; \
+    cat /etc/apt/preferences.d/varnish; \
+    apt-cache policy varnish; \
+    sudo apt-get install -y varnish varnish-dev;
 
 ARG USERNAME=user
 ARG USER_UID=1000

--- a/justfile
+++ b/justfile
@@ -118,7 +118,7 @@ check-if-published:
 
 [private]
 docker-build-ver VERSION:
-    docker build -t varnish-img-{{VERSION}} --build-arg VARNISH_VERSION={{VERSION}} --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) -f docker/Dockerfile docker
+    docker build --progress=plain -t varnish-img-{{VERSION}} --build-arg VARNISH_VERSION={{VERSION}} --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) -f docker/Dockerfile docker
 
 [private]
 docker-run-ver VERSION *ARGS:

--- a/varnish-macros/src/generator.rs
+++ b/varnish-macros/src/generator.rs
@@ -176,7 +176,7 @@ impl Generator {
         let export_decls: Vec<_> = self.iter_all_funcs().map(|f| &f.export_decl).collect();
         let export_inits: Vec<_> = self.iter_all_funcs().map(|f| &f.export_init).collect();
 
-        // This list must match the list in varnish-macros/src/lib.rs
+        // WARNING: This list must match the list in varnish-macros/src/lib.rs
         let use_ffi_items = quote![
             VCL_BACKEND,
             VCL_BOOL,
@@ -190,10 +190,12 @@ impl Generator {
             VMOD_ABI_Version,
             VMOD_PRIV_METHODS_MAGIC,
             VclEvent,
+            vmod_data,
             vmod_priv,
             vmod_priv_methods,
             vrt_ctx,
         ];
+        // WARNING: This list must match the list in varnish-macros/src/lib.rs
 
         quote!(
             #[allow(
@@ -224,26 +226,10 @@ impl Generator {
                     #(#export_inits,)*
                 };
 
-                #[repr(C)]
-                pub struct VmodData {
-                    vrt_major: c_uint,
-                    vrt_minor: c_uint,
-                    file_id: *const c_char,
-                    name: *const c_char,
-                    func_name: *const c_char,
-                    func: *const c_void,
-                    func_len: c_int,
-                    proto: *const c_char,
-                    json: *const c_char,
-                    abi: *const c_char,
-                }
-
-                unsafe impl Sync for VmodData {}
-
                 // This name must be in the format `Vmod_{modulename}_Data`.
                 #[allow(non_upper_case_globals)]
                 #[no_mangle]
-                pub static #vmod_name_data: VmodData = VmodData {
+                pub static #vmod_name_data: vmod_data = vmod_data {
                     vrt_major: 0,
                     vrt_minor: 0,
                     file_id: #file_id.as_ptr(),

--- a/varnish-sys/src/extensions.rs
+++ b/varnish-sys/src/extensions.rs
@@ -2,9 +2,12 @@ use std::ffi::c_void;
 use std::ptr;
 use std::ptr::null;
 
-use crate::ffi::{vmod_priv, vmod_priv_methods, vrt_ctx};
+use crate::ffi::{vmod_data, vmod_priv, vmod_priv_methods, vrt_ctx};
 use crate::validate_vrt_ctx;
 use crate::vcl::PerVclState;
+
+/// SAFETY: ensured by Varnish itself
+unsafe impl Sync for vmod_data {}
 
 /// SAFETY: ensured by Varnish itself
 unsafe impl Sync for vmod_priv_methods {}

--- a/varnish/snapshots/docs_types@code.snap
+++ b/varnish/snapshots/docs_types@code.snap
@@ -20,7 +20,7 @@ mod types {
         use varnish::ffi::{
             VCL_BACKEND, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL,
             VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, VclEvent,
-            vmod_priv, vmod_priv_methods, vrt_ctx,
+            vmod_data, vmod_priv, vmod_priv_methods, vrt_ctx,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;
@@ -116,23 +116,9 @@ mod types {
             vmod_c_DocStruct__fini: Some(vmod_c_DocStruct__fini),
             vmod_c_DocStruct_function: Some(vmod_c_DocStruct_function),
         };
-        #[repr(C)]
-        pub struct VmodData {
-            vrt_major: c_uint,
-            vrt_minor: c_uint,
-            file_id: *const c_char,
-            name: *const c_char,
-            func_name: *const c_char,
-            func: *const c_void,
-            func_len: c_int,
-            proto: *const c_char,
-            json: *const c_char,
-            abi: *const c_char,
-        }
-        unsafe impl Sync for VmodData {}
         #[allow(non_upper_case_globals)]
         #[no_mangle]
-        pub static Vmod_types_Data: VmodData = VmodData {
+        pub static Vmod_types_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
             file_id: c"84444b833e86e8a67f59228fa2634183f81f58c50e684ec4152fd478ab9875fe"

--- a/varnish/snapshots/event1_event@code.snap
+++ b/varnish/snapshots/event1_event@code.snap
@@ -11,7 +11,7 @@ mod event {
         use varnish::ffi::{
             VCL_BACKEND, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL,
             VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, VclEvent,
-            vmod_priv, vmod_priv_methods, vrt_ctx,
+            vmod_data, vmod_priv, vmod_priv_methods, vrt_ctx,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;
@@ -36,23 +36,9 @@ mod event {
         pub static VMOD_EXPORTS: VmodExports = VmodExports {
             vmod_c_on_event: Some(vmod_c_on_event),
         };
-        #[repr(C)]
-        pub struct VmodData {
-            vrt_major: c_uint,
-            vrt_minor: c_uint,
-            file_id: *const c_char,
-            name: *const c_char,
-            func_name: *const c_char,
-            func: *const c_void,
-            func_len: c_int,
-            proto: *const c_char,
-            json: *const c_char,
-            abi: *const c_char,
-        }
-        unsafe impl Sync for VmodData {}
         #[allow(non_upper_case_globals)]
         #[no_mangle]
-        pub static Vmod_event_Data: VmodData = VmodData {
+        pub static Vmod_event_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
             file_id: c"4d1200f410ef454f543f699d77aaa0ff7e3c4d4fdc8395b6771c294c71d409a2"

--- a/varnish/snapshots/event2_event2@code.snap
+++ b/varnish/snapshots/event2_event2@code.snap
@@ -11,7 +11,7 @@ mod event2 {
         use varnish::ffi::{
             VCL_BACKEND, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL,
             VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, VclEvent,
-            vmod_priv, vmod_priv_methods, vrt_ctx,
+            vmod_data, vmod_priv, vmod_priv_methods, vrt_ctx,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;
@@ -44,23 +44,9 @@ mod event2 {
         pub static VMOD_EXPORTS: VmodExports = VmodExports {
             vmod_c_on_event: Some(vmod_c_on_event),
         };
-        #[repr(C)]
-        pub struct VmodData {
-            vrt_major: c_uint,
-            vrt_minor: c_uint,
-            file_id: *const c_char,
-            name: *const c_char,
-            func_name: *const c_char,
-            func: *const c_void,
-            func_len: c_int,
-            proto: *const c_char,
-            json: *const c_char,
-            abi: *const c_char,
-        }
-        unsafe impl Sync for VmodData {}
         #[allow(non_upper_case_globals)]
         #[no_mangle]
-        pub static Vmod_event2_Data: VmodData = VmodData {
+        pub static Vmod_event2_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
             file_id: c"12c0145150bdb078f1e8f5f2186f8beaf799d5163796db1e68583cf35e74472e"

--- a/varnish/snapshots/event3_event3@code.snap
+++ b/varnish/snapshots/event3_event3@code.snap
@@ -11,7 +11,7 @@ mod event3 {
         use varnish::ffi::{
             VCL_BACKEND, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL,
             VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, VclEvent,
-            vmod_priv, vmod_priv_methods, vrt_ctx,
+            vmod_data, vmod_priv, vmod_priv_methods, vrt_ctx,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;
@@ -160,23 +160,9 @@ mod event3 {
             vmod_c_Obj2__fini: Some(vmod_c_Obj2__fini),
             vmod_c_Obj2_obj_access: Some(vmod_c_Obj2_obj_access),
         };
-        #[repr(C)]
-        pub struct VmodData {
-            vrt_major: c_uint,
-            vrt_minor: c_uint,
-            file_id: *const c_char,
-            name: *const c_char,
-            func_name: *const c_char,
-            func: *const c_void,
-            func_len: c_int,
-            proto: *const c_char,
-            json: *const c_char,
-            abi: *const c_char,
-        }
-        unsafe impl Sync for VmodData {}
         #[allow(non_upper_case_globals)]
         #[no_mangle]
-        pub static Vmod_event3_Data: VmodData = VmodData {
+        pub static Vmod_event3_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
             file_id: c"65b49085a4dba9c1b453b7e82d61d20a705b516d4ab88c0875ecb5eb7807fbb6"

--- a/varnish/snapshots/event4_event4@code.snap
+++ b/varnish/snapshots/event4_event4@code.snap
@@ -11,7 +11,7 @@ mod event4 {
         use varnish::ffi::{
             VCL_BACKEND, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL,
             VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, VclEvent,
-            vmod_priv, vmod_priv_methods, vrt_ctx,
+            vmod_data, vmod_priv, vmod_priv_methods, vrt_ctx,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;
@@ -47,23 +47,9 @@ mod event4 {
         pub static VMOD_EXPORTS: VmodExports = VmodExports {
             vmod_c_on_event: Some(vmod_c_on_event),
         };
-        #[repr(C)]
-        pub struct VmodData {
-            vrt_major: c_uint,
-            vrt_minor: c_uint,
-            file_id: *const c_char,
-            name: *const c_char,
-            func_name: *const c_char,
-            func: *const c_void,
-            func_len: c_int,
-            proto: *const c_char,
-            json: *const c_char,
-            abi: *const c_char,
-        }
-        unsafe impl Sync for VmodData {}
         #[allow(non_upper_case_globals)]
         #[no_mangle]
-        pub static Vmod_event4_Data: VmodData = VmodData {
+        pub static Vmod_event4_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
             file_id: c"884770a967ac851537a1caf26f304aed02fb682067f9b5bfc63423ef05cb4e02"

--- a/varnish/snapshots/function_types@code.snap
+++ b/varnish/snapshots/function_types@code.snap
@@ -11,7 +11,7 @@ mod types {
         use varnish::ffi::{
             VCL_BACKEND, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL,
             VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, VclEvent,
-            vmod_priv, vmod_priv_methods, vrt_ctx,
+            vmod_data, vmod_priv, vmod_priv_methods, vrt_ctx,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;
@@ -869,23 +869,9 @@ mod types {
             vmod_c_get_ws_mut: Some(vmod_c_get_ws_mut),
             vmod_c_get_ws_ref: Some(vmod_c_get_ws_ref),
         };
-        #[repr(C)]
-        pub struct VmodData {
-            vrt_major: c_uint,
-            vrt_minor: c_uint,
-            file_id: *const c_char,
-            name: *const c_char,
-            func_name: *const c_char,
-            func: *const c_void,
-            func_len: c_int,
-            proto: *const c_char,
-            json: *const c_char,
-            abi: *const c_char,
-        }
-        unsafe impl Sync for VmodData {}
         #[allow(non_upper_case_globals)]
         #[no_mangle]
-        pub static Vmod_types_Data: VmodData = VmodData {
+        pub static Vmod_types_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
             file_id: c"52017119c74321c7fb095e6e0334165ad142d83cfb72627ad44b471f228c1652"

--- a/varnish/snapshots/object2_obj2@code.snap
+++ b/varnish/snapshots/object2_obj2@code.snap
@@ -11,7 +11,7 @@ mod obj2 {
         use varnish::ffi::{
             VCL_BACKEND, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL,
             VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, VclEvent,
-            vmod_priv, vmod_priv_methods, vrt_ctx,
+            vmod_data, vmod_priv, vmod_priv_methods, vrt_ctx,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;
@@ -164,23 +164,9 @@ mod obj2 {
             vmod_c_Obj4__init: Some(vmod_c_Obj4__init),
             vmod_c_Obj4__fini: Some(vmod_c_Obj4__fini),
         };
-        #[repr(C)]
-        pub struct VmodData {
-            vrt_major: c_uint,
-            vrt_minor: c_uint,
-            file_id: *const c_char,
-            name: *const c_char,
-            func_name: *const c_char,
-            func: *const c_void,
-            func_len: c_int,
-            proto: *const c_char,
-            json: *const c_char,
-            abi: *const c_char,
-        }
-        unsafe impl Sync for VmodData {}
         #[allow(non_upper_case_globals)]
         #[no_mangle]
-        pub static Vmod_obj2_Data: VmodData = VmodData {
+        pub static Vmod_obj2_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
             file_id: c"0cd5a7608f16067dbb42bb21d157e185290d63e1a33e73c3715eee45ee3fc2b6"

--- a/varnish/snapshots/object_obj@code.snap
+++ b/varnish/snapshots/object_obj@code.snap
@@ -11,7 +11,7 @@ mod obj {
         use varnish::ffi::{
             VCL_BACKEND, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL,
             VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, VclEvent,
-            vmod_priv, vmod_priv_methods, vrt_ctx,
+            vmod_data, vmod_priv, vmod_priv_methods, vrt_ctx,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;
@@ -271,23 +271,9 @@ mod obj {
             vmod_c_kv3__fini: Some(vmod_c_kv3__fini),
             vmod_c_kv3_set: Some(vmod_c_kv3_set),
         };
-        #[repr(C)]
-        pub struct VmodData {
-            vrt_major: c_uint,
-            vrt_minor: c_uint,
-            file_id: *const c_char,
-            name: *const c_char,
-            func_name: *const c_char,
-            func: *const c_void,
-            func_len: c_int,
-            proto: *const c_char,
-            json: *const c_char,
-            abi: *const c_char,
-        }
-        unsafe impl Sync for VmodData {}
         #[allow(non_upper_case_globals)]
         #[no_mangle]
-        pub static Vmod_obj_Data: VmodData = VmodData {
+        pub static Vmod_obj_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
             file_id: c"e4dde1367a8785e0bb9e3b32a6a53880156eb4050d20f22573df4b5ea5f44461"

--- a/varnish/snapshots/shared1_task@code.snap
+++ b/varnish/snapshots/shared1_task@code.snap
@@ -11,7 +11,7 @@ mod task {
         use varnish::ffi::{
             VCL_BACKEND, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL,
             VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, VclEvent,
-            vmod_priv, vmod_priv_methods, vrt_ctx,
+            vmod_data, vmod_priv, vmod_priv_methods, vrt_ctx,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;
@@ -262,23 +262,9 @@ mod task {
             vmod_c_PerVcl_both_pos: Some(vmod_c_PerVcl_both_pos),
             vmod_c_PerVcl_both_opt: Some(vmod_c_PerVcl_both_opt),
         };
-        #[repr(C)]
-        pub struct VmodData {
-            vrt_major: c_uint,
-            vrt_minor: c_uint,
-            file_id: *const c_char,
-            name: *const c_char,
-            func_name: *const c_char,
-            func: *const c_void,
-            func_len: c_int,
-            proto: *const c_char,
-            json: *const c_char,
-            abi: *const c_char,
-        }
-        unsafe impl Sync for VmodData {}
         #[allow(non_upper_case_globals)]
         #[no_mangle]
-        pub static Vmod_task_Data: VmodData = VmodData {
+        pub static Vmod_task_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
             file_id: c"d3254ccf9860c2c9a8db4e739800906db26805bc168f4b8f497e3685770707e1"

--- a/varnish/snapshots/shared2_tuple@code.snap
+++ b/varnish/snapshots/shared2_tuple@code.snap
@@ -11,7 +11,7 @@ mod tuple {
         use varnish::ffi::{
             VCL_BACKEND, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL,
             VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, VclEvent,
-            vmod_priv, vmod_priv_methods, vrt_ctx,
+            vmod_data, vmod_priv, vmod_priv_methods, vrt_ctx,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;
@@ -75,23 +75,9 @@ mod tuple {
             vmod_c_on_event: Some(vmod_c_on_event),
             vmod_c_per_tsk_val: Some(vmod_c_per_tsk_val),
         };
-        #[repr(C)]
-        pub struct VmodData {
-            vrt_major: c_uint,
-            vrt_minor: c_uint,
-            file_id: *const c_char,
-            name: *const c_char,
-            func_name: *const c_char,
-            func: *const c_void,
-            func_len: c_int,
-            proto: *const c_char,
-            json: *const c_char,
-            abi: *const c_char,
-        }
-        unsafe impl Sync for VmodData {}
         #[allow(non_upper_case_globals)]
         #[no_mangle]
-        pub static Vmod_tuple_Data: VmodData = VmodData {
+        pub static Vmod_tuple_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
             file_id: c"41c8f93b128c17e6327da85165e29dc663acf100bf5bfb80ffce76925121d6fe"

--- a/varnish/snapshots/shared3_tuple@code.snap
+++ b/varnish/snapshots/shared3_tuple@code.snap
@@ -11,7 +11,7 @@ mod tuple {
         use varnish::ffi::{
             VCL_BACKEND, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL,
             VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, VclEvent,
-            vmod_priv, vmod_priv_methods, vrt_ctx,
+            vmod_data, vmod_priv, vmod_priv_methods, vrt_ctx,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;
@@ -54,23 +54,9 @@ mod tuple {
         pub static VMOD_EXPORTS: VmodExports = VmodExports {
             vmod_c_ref_to_slice_lifetime: Some(vmod_c_ref_to_slice_lifetime),
         };
-        #[repr(C)]
-        pub struct VmodData {
-            vrt_major: c_uint,
-            vrt_minor: c_uint,
-            file_id: *const c_char,
-            name: *const c_char,
-            func_name: *const c_char,
-            func: *const c_void,
-            func_len: c_int,
-            proto: *const c_char,
-            json: *const c_char,
-            abi: *const c_char,
-        }
-        unsafe impl Sync for VmodData {}
         #[allow(non_upper_case_globals)]
         #[no_mangle]
-        pub static Vmod_tuple_Data: VmodData = VmodData {
+        pub static Vmod_tuple_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
             file_id: c"fd153c857e1a4787114cd9261faa83d258aa10401348fb167822ff1c1467c4f1"

--- a/varnish/snapshots/vcl_returns_vcl_returns@code.snap
+++ b/varnish/snapshots/vcl_returns_vcl_returns@code.snap
@@ -11,7 +11,7 @@ mod vcl_returns {
         use varnish::ffi::{
             VCL_BACKEND, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL,
             VCL_STRING, VCL_VOID, VMOD_ABI_Version, VMOD_PRIV_METHODS_MAGIC, VclEvent,
-            vmod_priv, vmod_priv_methods, vrt_ctx,
+            vmod_data, vmod_priv, vmod_priv_methods, vrt_ctx,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;
@@ -469,23 +469,9 @@ mod vcl_returns {
             vmod_c_val_vcl: Some(vmod_c_val_vcl),
             vmod_c_res_vcl: Some(vmod_c_res_vcl),
         };
-        #[repr(C)]
-        pub struct VmodData {
-            vrt_major: c_uint,
-            vrt_minor: c_uint,
-            file_id: *const c_char,
-            name: *const c_char,
-            func_name: *const c_char,
-            func: *const c_void,
-            func_len: c_int,
-            proto: *const c_char,
-            json: *const c_char,
-            abi: *const c_char,
-        }
-        unsafe impl Sync for VmodData {}
         #[allow(non_upper_case_globals)]
         #[no_mangle]
-        pub static Vmod_vcl_returns_Data: VmodData = VmodData {
+        pub static Vmod_vcl_returns_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
             file_id: c"a6876b707a04e5bc7badd29339d22abb0b7ae46d62d946fbfbc5882f6d37eeed"

--- a/varnish/src/lib.rs
+++ b/varnish/src/lib.rs
@@ -82,11 +82,12 @@
 pub use varnish_sys::vcl;
 
 #[cfg(not(feature = "ffi"))]
+#[doc(hidden)]
 pub mod ffi {
     // This list must match the `use_ffi_items` in generator.rs
     pub use varnish_sys::ffi::{
-        vmod_priv, vmod_priv_methods, vrt_ctx, VMOD_ABI_Version, VclEvent, VCL_BACKEND, VCL_BOOL,
-        VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL, VCL_STRING, VCL_VOID,
+        vmod_data, vmod_priv, vmod_priv_methods, vrt_ctx, VMOD_ABI_Version, VclEvent, VCL_BACKEND,
+        VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL, VCL_STRING, VCL_VOID,
         VMOD_PRIV_METHODS_MAGIC,
     };
 }


### PR DESCRIPTION
Get rid of the duplicate generated `VmodData`, move a few minor things from LTS 6.0 PR

Also, hides documentation of the ffi re-export structs as this is a "hidden" macro-support