### PR TITLE
unsafe `VCL_*` returning functions, v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unpublished
 
-- ...
+- Support for Varnish v6.0 LTS, but without filters, and without `vmod_be`, `vmod_vfp`, `vmod_vdp` examples
+- Require all user functions that return `VCL_*` types to be `unsafe` 
 
 # 0.2.0 (2024-11-19)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,11 @@ members = ["varnish", "varnish-macros", "varnish-sys", "varnish/tests/vmod_test"
 # These fields are used by multiple crates, so it's defined here.
 # Version must also be updated in the `varnish-macros` dependency below.
 #
+#
 # ! STOP !  Update the version in dependencies below!!!
-version = "0.2.3"  ## <<<----- ! STOP !!!
+version = "0.3.0"  ## <<<----- ! STOP !!!
 # ! STOP !  Update the version in dependencies below!!!
+#
 #
 repository = "https://github.com/gquintard/varnish-rs"
 edition = "2021"
@@ -22,9 +24,9 @@ readme = "README.md"
 
 [workspace.dependencies]
 # These versions must match the one in the [workspace.package] section above
-varnish = { path = "./varnish", version = "0.2.3" }
-varnish-macros = { path = "./varnish-macros", version = "0.2.3" }
-varnish-sys = { path = "./varnish-sys", version = "0.2.3" }
+varnish = { path = "./varnish", version = "0.3.0" }
+varnish-macros = { path = "./varnish-macros", version = "0.3.0" }
+varnish-sys = { path = "./varnish-sys", version = "0.3.0" }
 #
 # These dependencies are used by one or more crates, and easier to maintain in one place.
 bindgen = "0.70.1"

--- a/examples/vmod_be/src/lib.rs
+++ b/examples/vmod_be/src/lib.rs
@@ -43,7 +43,7 @@ mod be {
             Ok(parrot { backend })
         }
 
-        pub fn backend(&self) -> VCL_BACKEND {
+        pub unsafe fn backend(&self) -> VCL_BACKEND {
             self.backend.vcl_ptr()
         }
     }

--- a/justfile
+++ b/justfile
@@ -82,7 +82,7 @@ test-publish:
 
 # Run tests, and accept their results. Requires insta to be installed.
 bless:
-    TRYBUILD=overwrite cargo insta test -p varnish-macros -p varnish --accept --unreferenced=delete
+    TRYBUILD=overwrite cargo insta test -p varnish-macros -p varnish --accept
 
 # Test documentation
 test-doc:

--- a/varnish-macros/src/errors.rs
+++ b/varnish-macros/src/errors.rs
@@ -19,6 +19,10 @@ impl Errors {
         Self { errors: None }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.errors.is_none()
+    }
+
     pub fn on_err<T>(&mut self, result: ProcResult<T>) -> Option<T> {
         match result {
             Ok(val) => Some(val),

--- a/varnish-sys/src/vcl/backend.rs
+++ b/varnish-sys/src/vcl/backend.rs
@@ -84,7 +84,8 @@ use crate::{
 
 /// Fat wrapper around [`VCL_BACKEND`].
 ///
-/// It will handle almost all the necessary boilerplate needed to create a vmod. Most importantly, it destroys/unregisters the backend as part of it's `Drop` implementation, and
+/// It will handle almost all the necessary boilerplate needed to create a vmod. Most importantly,
+/// it destroys/unregisters the backend as part of it's `Drop` implementation, and
 /// will convert the C methods to something more idiomatic.
 ///
 /// Once created, a [`Backend`]'s sole purpose is to exist as a C reference for the VCL. As a

--- a/varnish/snapshots/function_types@code.snap
+++ b/varnish/snapshots/function_types@code.snap
@@ -1003,10 +1003,10 @@ mod types {
     pub fn to_res_ip() -> Result<SocketAddr, &'static str> {
         Err("")
     }
-    pub fn to_vcl_string() -> VCL_STRING {
+    pub unsafe fn to_vcl_string() -> VCL_STRING {
         VCL_STRING::default()
     }
-    pub fn to_res_vcl_string() -> Result<VCL_STRING, &'static str> {
+    pub unsafe fn to_res_vcl_string() -> Result<VCL_STRING, &'static str> {
         Err("")
     }
     pub fn opt_i64_opt_i64(a1: i64, a2: Option<i64>, a3: i64) -> String {

--- a/varnish/snapshots/vcl_returns_vcl_returns@code.snap
+++ b/varnish/snapshots/vcl_returns_vcl_returns@code.snap
@@ -491,133 +491,133 @@ mod vcl_returns {
         VCL_REAL, VCL_REGEX, VCL_STEVEDORE, VCL_STRANDS, VCL_STRING, VCL_SUB, VCL_TIME,
         VCL_VCL,
     };
-    pub fn val_acl() -> VCL_ACL {
+    pub unsafe fn val_acl() -> VCL_ACL {
         VCL_ACL::default()
     }
-    pub fn res_acl() -> Result<VCL_ACL, &'static str> {
+    pub unsafe fn res_acl() -> Result<VCL_ACL, &'static str> {
         Err("")
     }
-    pub fn val_backend() -> VCL_BACKEND {
+    pub unsafe fn val_backend() -> VCL_BACKEND {
         VCL_BACKEND::default()
     }
-    pub fn res_backend() -> Result<VCL_BACKEND, &'static str> {
+    pub unsafe fn res_backend() -> Result<VCL_BACKEND, &'static str> {
         Err("")
     }
-    pub fn val_blob() -> VCL_BLOB {
+    pub unsafe fn val_blob() -> VCL_BLOB {
         VCL_BLOB::default()
     }
-    pub fn res_blob() -> Result<VCL_BLOB, &'static str> {
+    pub unsafe fn res_blob() -> Result<VCL_BLOB, &'static str> {
         Err("")
     }
-    pub fn val_body() -> VCL_BODY {
+    pub unsafe fn val_body() -> VCL_BODY {
         VCL_BODY::default()
     }
-    pub fn res_body() -> Result<VCL_BODY, &'static str> {
+    pub unsafe fn res_body() -> Result<VCL_BODY, &'static str> {
         Err("")
     }
-    pub fn val_bool() -> VCL_BOOL {
+    pub unsafe fn val_bool() -> VCL_BOOL {
         VCL_BOOL::default()
     }
-    pub fn res_bool() -> Result<VCL_BOOL, &'static str> {
+    pub unsafe fn res_bool() -> Result<VCL_BOOL, &'static str> {
         Err("")
     }
-    pub fn val_bytes() -> VCL_BYTES {
+    pub unsafe fn val_bytes() -> VCL_BYTES {
         VCL_BYTES::default()
     }
-    pub fn res_bytes() -> Result<VCL_BYTES, &'static str> {
+    pub unsafe fn res_bytes() -> Result<VCL_BYTES, &'static str> {
         Err("")
     }
-    pub fn val_duration() -> VCL_DURATION {
+    pub unsafe fn val_duration() -> VCL_DURATION {
         VCL_DURATION::default()
     }
-    pub fn res_duration() -> Result<VCL_DURATION, &'static str> {
+    pub unsafe fn res_duration() -> Result<VCL_DURATION, &'static str> {
         Err("")
     }
-    pub fn val_enum() -> VCL_ENUM {
+    pub unsafe fn val_enum() -> VCL_ENUM {
         VCL_ENUM::default()
     }
-    pub fn res_enum() -> Result<VCL_ENUM, &'static str> {
+    pub unsafe fn res_enum() -> Result<VCL_ENUM, &'static str> {
         Err("")
     }
-    pub fn val_header() -> VCL_HEADER {
+    pub unsafe fn val_header() -> VCL_HEADER {
         VCL_HEADER::default()
     }
-    pub fn res_header() -> Result<VCL_HEADER, &'static str> {
+    pub unsafe fn res_header() -> Result<VCL_HEADER, &'static str> {
         Err("")
     }
-    pub fn val_http() -> VCL_HTTP {
+    pub unsafe fn val_http() -> VCL_HTTP {
         VCL_HTTP::default()
     }
-    pub fn res_http() -> Result<VCL_HTTP, &'static str> {
+    pub unsafe fn res_http() -> Result<VCL_HTTP, &'static str> {
         Err("")
     }
-    pub fn val_instance() -> VCL_INSTANCE {
+    pub unsafe fn val_instance() -> VCL_INSTANCE {
         panic!()
     }
-    pub fn val_int() -> VCL_INT {
+    pub unsafe fn val_int() -> VCL_INT {
         VCL_INT::default()
     }
-    pub fn res_int() -> Result<VCL_INT, &'static str> {
+    pub unsafe fn res_int() -> Result<VCL_INT, &'static str> {
         Err("")
     }
-    pub fn val_ip() -> VCL_IP {
+    pub unsafe fn val_ip() -> VCL_IP {
         VCL_IP::default()
     }
-    pub fn res_ip() -> Result<VCL_IP, &'static str> {
+    pub unsafe fn res_ip() -> Result<VCL_IP, &'static str> {
         Err("")
     }
-    pub fn val_probe() -> VCL_PROBE {
+    pub unsafe fn val_probe() -> VCL_PROBE {
         VCL_PROBE::default()
     }
-    pub fn res_probe() -> Result<VCL_PROBE, &'static str> {
+    pub unsafe fn res_probe() -> Result<VCL_PROBE, &'static str> {
         Err("")
     }
-    pub fn val_real() -> VCL_REAL {
+    pub unsafe fn val_real() -> VCL_REAL {
         VCL_REAL::default()
     }
-    pub fn res_real() -> Result<VCL_REAL, &'static str> {
+    pub unsafe fn res_real() -> Result<VCL_REAL, &'static str> {
         Err("")
     }
-    pub fn val_regex() -> VCL_REGEX {
+    pub unsafe fn val_regex() -> VCL_REGEX {
         VCL_REGEX::default()
     }
-    pub fn res_regex() -> Result<VCL_REGEX, &'static str> {
+    pub unsafe fn res_regex() -> Result<VCL_REGEX, &'static str> {
         Err("")
     }
-    pub fn val_stevedore() -> VCL_STEVEDORE {
+    pub unsafe fn val_stevedore() -> VCL_STEVEDORE {
         VCL_STEVEDORE::default()
     }
-    pub fn res_stevedore() -> Result<VCL_STEVEDORE, &'static str> {
+    pub unsafe fn res_stevedore() -> Result<VCL_STEVEDORE, &'static str> {
         Err("")
     }
-    pub fn val_strands() -> VCL_STRANDS {
+    pub unsafe fn val_strands() -> VCL_STRANDS {
         VCL_STRANDS::default()
     }
-    pub fn res_strands() -> Result<VCL_STRANDS, &'static str> {
+    pub unsafe fn res_strands() -> Result<VCL_STRANDS, &'static str> {
         Err("")
     }
-    pub fn val_string() -> VCL_STRING {
+    pub unsafe fn val_string() -> VCL_STRING {
         VCL_STRING::default()
     }
-    pub fn res_string() -> Result<VCL_STRING, &'static str> {
+    pub unsafe fn res_string() -> Result<VCL_STRING, &'static str> {
         Err("")
     }
-    pub fn val_sub() -> VCL_SUB {
+    pub unsafe fn val_sub() -> VCL_SUB {
         VCL_SUB::default()
     }
-    pub fn res_sub() -> Result<VCL_SUB, &'static str> {
+    pub unsafe fn res_sub() -> Result<VCL_SUB, &'static str> {
         Err("")
     }
-    pub fn val_time() -> VCL_TIME {
+    pub unsafe fn val_time() -> VCL_TIME {
         VCL_TIME::default()
     }
-    pub fn res_time() -> Result<VCL_TIME, &'static str> {
+    pub unsafe fn res_time() -> Result<VCL_TIME, &'static str> {
         Err("")
     }
-    pub fn val_vcl() -> VCL_VCL {
+    pub unsafe fn val_vcl() -> VCL_VCL {
         VCL_VCL::default()
     }
-    pub fn res_vcl() -> Result<VCL_VCL, &'static str> {
+    pub unsafe fn res_vcl() -> Result<VCL_VCL, &'static str> {
         Err("")
     }
 }

--- a/varnish/snapshots_v6/function_types@code.snap
+++ b/varnish/snapshots_v6/function_types@code.snap
@@ -1003,10 +1003,10 @@ mod types {
     pub fn to_res_ip() -> Result<SocketAddr, &'static str> {
         Err("")
     }
-    pub fn to_vcl_string() -> VCL_STRING {
+    pub unsafe fn to_vcl_string() -> VCL_STRING {
         VCL_STRING::default()
     }
-    pub fn to_res_vcl_string() -> Result<VCL_STRING, &'static str> {
+    pub unsafe fn to_res_vcl_string() -> Result<VCL_STRING, &'static str> {
         Err("")
     }
     pub fn opt_i64_opt_i64(a1: i64, a2: Option<i64>, a3: i64) -> String {

--- a/varnish/snapshots_v6/vcl_returns_vcl_returns@code.snap
+++ b/varnish/snapshots_v6/vcl_returns_vcl_returns@code.snap
@@ -491,133 +491,133 @@ mod vcl_returns {
         VCL_REAL, VCL_REGEX, VCL_STEVEDORE, VCL_STRANDS, VCL_STRING, VCL_SUB, VCL_TIME,
         VCL_VCL,
     };
-    pub fn val_acl() -> VCL_ACL {
+    pub unsafe fn val_acl() -> VCL_ACL {
         VCL_ACL::default()
     }
-    pub fn res_acl() -> Result<VCL_ACL, &'static str> {
+    pub unsafe fn res_acl() -> Result<VCL_ACL, &'static str> {
         Err("")
     }
-    pub fn val_backend() -> VCL_BACKEND {
+    pub unsafe fn val_backend() -> VCL_BACKEND {
         VCL_BACKEND::default()
     }
-    pub fn res_backend() -> Result<VCL_BACKEND, &'static str> {
+    pub unsafe fn res_backend() -> Result<VCL_BACKEND, &'static str> {
         Err("")
     }
-    pub fn val_blob() -> VCL_BLOB {
+    pub unsafe fn val_blob() -> VCL_BLOB {
         VCL_BLOB::default()
     }
-    pub fn res_blob() -> Result<VCL_BLOB, &'static str> {
+    pub unsafe fn res_blob() -> Result<VCL_BLOB, &'static str> {
         Err("")
     }
-    pub fn val_body() -> VCL_BODY {
+    pub unsafe fn val_body() -> VCL_BODY {
         VCL_BODY::default()
     }
-    pub fn res_body() -> Result<VCL_BODY, &'static str> {
+    pub unsafe fn res_body() -> Result<VCL_BODY, &'static str> {
         Err("")
     }
-    pub fn val_bool() -> VCL_BOOL {
+    pub unsafe fn val_bool() -> VCL_BOOL {
         VCL_BOOL::default()
     }
-    pub fn res_bool() -> Result<VCL_BOOL, &'static str> {
+    pub unsafe fn res_bool() -> Result<VCL_BOOL, &'static str> {
         Err("")
     }
-    pub fn val_bytes() -> VCL_BYTES {
+    pub unsafe fn val_bytes() -> VCL_BYTES {
         VCL_BYTES::default()
     }
-    pub fn res_bytes() -> Result<VCL_BYTES, &'static str> {
+    pub unsafe fn res_bytes() -> Result<VCL_BYTES, &'static str> {
         Err("")
     }
-    pub fn val_duration() -> VCL_DURATION {
+    pub unsafe fn val_duration() -> VCL_DURATION {
         VCL_DURATION::default()
     }
-    pub fn res_duration() -> Result<VCL_DURATION, &'static str> {
+    pub unsafe fn res_duration() -> Result<VCL_DURATION, &'static str> {
         Err("")
     }
-    pub fn val_enum() -> VCL_ENUM {
+    pub unsafe fn val_enum() -> VCL_ENUM {
         VCL_ENUM::default()
     }
-    pub fn res_enum() -> Result<VCL_ENUM, &'static str> {
+    pub unsafe fn res_enum() -> Result<VCL_ENUM, &'static str> {
         Err("")
     }
-    pub fn val_header() -> VCL_HEADER {
+    pub unsafe fn val_header() -> VCL_HEADER {
         VCL_HEADER::default()
     }
-    pub fn res_header() -> Result<VCL_HEADER, &'static str> {
+    pub unsafe fn res_header() -> Result<VCL_HEADER, &'static str> {
         Err("")
     }
-    pub fn val_http() -> VCL_HTTP {
+    pub unsafe fn val_http() -> VCL_HTTP {
         VCL_HTTP::default()
     }
-    pub fn res_http() -> Result<VCL_HTTP, &'static str> {
+    pub unsafe fn res_http() -> Result<VCL_HTTP, &'static str> {
         Err("")
     }
-    pub fn val_instance() -> VCL_INSTANCE {
+    pub unsafe fn val_instance() -> VCL_INSTANCE {
         panic!()
     }
-    pub fn val_int() -> VCL_INT {
+    pub unsafe fn val_int() -> VCL_INT {
         VCL_INT::default()
     }
-    pub fn res_int() -> Result<VCL_INT, &'static str> {
+    pub unsafe fn res_int() -> Result<VCL_INT, &'static str> {
         Err("")
     }
-    pub fn val_ip() -> VCL_IP {
+    pub unsafe fn val_ip() -> VCL_IP {
         VCL_IP::default()
     }
-    pub fn res_ip() -> Result<VCL_IP, &'static str> {
+    pub unsafe fn res_ip() -> Result<VCL_IP, &'static str> {
         Err("")
     }
-    pub fn val_probe() -> VCL_PROBE {
+    pub unsafe fn val_probe() -> VCL_PROBE {
         VCL_PROBE::default()
     }
-    pub fn res_probe() -> Result<VCL_PROBE, &'static str> {
+    pub unsafe fn res_probe() -> Result<VCL_PROBE, &'static str> {
         Err("")
     }
-    pub fn val_real() -> VCL_REAL {
+    pub unsafe fn val_real() -> VCL_REAL {
         VCL_REAL::default()
     }
-    pub fn res_real() -> Result<VCL_REAL, &'static str> {
+    pub unsafe fn res_real() -> Result<VCL_REAL, &'static str> {
         Err("")
     }
-    pub fn val_regex() -> VCL_REGEX {
+    pub unsafe fn val_regex() -> VCL_REGEX {
         VCL_REGEX::default()
     }
-    pub fn res_regex() -> Result<VCL_REGEX, &'static str> {
+    pub unsafe fn res_regex() -> Result<VCL_REGEX, &'static str> {
         Err("")
     }
-    pub fn val_stevedore() -> VCL_STEVEDORE {
+    pub unsafe fn val_stevedore() -> VCL_STEVEDORE {
         VCL_STEVEDORE::default()
     }
-    pub fn res_stevedore() -> Result<VCL_STEVEDORE, &'static str> {
+    pub unsafe fn res_stevedore() -> Result<VCL_STEVEDORE, &'static str> {
         Err("")
     }
-    pub fn val_strands() -> VCL_STRANDS {
+    pub unsafe fn val_strands() -> VCL_STRANDS {
         VCL_STRANDS::default()
     }
-    pub fn res_strands() -> Result<VCL_STRANDS, &'static str> {
+    pub unsafe fn res_strands() -> Result<VCL_STRANDS, &'static str> {
         Err("")
     }
-    pub fn val_string() -> VCL_STRING {
+    pub unsafe fn val_string() -> VCL_STRING {
         VCL_STRING::default()
     }
-    pub fn res_string() -> Result<VCL_STRING, &'static str> {
+    pub unsafe fn res_string() -> Result<VCL_STRING, &'static str> {
         Err("")
     }
-    pub fn val_sub() -> VCL_SUB {
+    pub unsafe fn val_sub() -> VCL_SUB {
         VCL_SUB::default()
     }
-    pub fn res_sub() -> Result<VCL_SUB, &'static str> {
+    pub unsafe fn res_sub() -> Result<VCL_SUB, &'static str> {
         Err("")
     }
-    pub fn val_time() -> VCL_TIME {
+    pub unsafe fn val_time() -> VCL_TIME {
         VCL_TIME::default()
     }
-    pub fn res_time() -> Result<VCL_TIME, &'static str> {
+    pub unsafe fn res_time() -> Result<VCL_TIME, &'static str> {
         Err("")
     }
-    pub fn val_vcl() -> VCL_VCL {
+    pub unsafe fn val_vcl() -> VCL_VCL {
         VCL_VCL::default()
     }
-    pub fn res_vcl() -> Result<VCL_VCL, &'static str> {
+    pub unsafe fn res_vcl() -> Result<VCL_VCL, &'static str> {
         Err("")
     }
 }

--- a/varnish/tests/fail/error_fn.rs
+++ b/varnish/tests/fail/error_fn.rs
@@ -6,6 +6,9 @@ mod err_fn {
     fn non_public() {}
     pub async fn async_fn() {}
     pub unsafe fn unsafe_fn() {}
+    pub fn ret_vcl() -> Result<VCL_STRING, &'static str> {
+        Err("error")
+    }
 }
 
 fn main() {}

--- a/varnish/tests/fail/error_fn.stderr
+++ b/varnish/tests/fail/error_fn.stderr
@@ -18,16 +18,14 @@ error: async functions are not supported
 7 |     pub async fn async_fn() {}
   |         ^^^^^
 
-error: unsafe functions are not supported
+error: functions and methods must not be tagged as `unsafe` unless they return a VCL_* type
  --> tests/fail/error_fn.rs:8:9
   |
 8 |     pub unsafe fn unsafe_fn() {}
   |         ^^^^^^
 
-error: No functions or objects found in this module
- --> tests/fail/error_fn.rs:4:1
+error: functions and methods that return a VCL_* type must be tagged as `unsafe`
+ --> tests/fail/error_fn.rs:9:9
   |
-4 | #[varnish::vmod]
-  | ^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in the attribute macro `varnish::vmod` (in Nightly builds, run with -Z macro-backtrace for more info)
+9 |     pub fn ret_vcl() -> Result<VCL_STRING, &'static str> {
+  |         ^^

--- a/varnish/tests/fail/error_fn_args_dups.rs
+++ b/varnish/tests/fail/error_fn_args_dups.rs
@@ -1,6 +1,5 @@
 #[varnish::vmod]
 mod err_fn_args_dups {
-    pub fn good(i: i64) {}
     pub fn dup_ctx(ctx: &Ctx, i: i64, ctx2: &Ctx) {}
     pub fn dup_ctx2(ctx: &Ctx, i: i64, ctx2: &mut Ctx) {}
     pub fn dup_shared_vcl(#[shared_per_vcl] a: Option<&i64>, #[shared_per_vcl] b: Option<&i64>) {}

--- a/varnish/tests/fail/error_fn_args_dups.stderr
+++ b/varnish/tests/fail/error_fn_args_dups.stderr
@@ -1,35 +1,35 @@
 error: Context or Workspace param is allowed only once in a function args list
- --> tests/fail/error_fn_args_dups.rs:4:39
+ --> tests/fail/error_fn_args_dups.rs:3:39
   |
-4 |     pub fn dup_ctx(ctx: &Ctx, i: i64, ctx2: &Ctx) {}
+3 |     pub fn dup_ctx(ctx: &Ctx, i: i64, ctx2: &Ctx) {}
   |                                       ^^^^
 
 error: Context or Workspace param is allowed only once in a function args list
- --> tests/fail/error_fn_args_dups.rs:5:40
+ --> tests/fail/error_fn_args_dups.rs:4:40
   |
-5 |     pub fn dup_ctx2(ctx: &Ctx, i: i64, ctx2: &mut Ctx) {}
+4 |     pub fn dup_ctx2(ctx: &Ctx, i: i64, ctx2: &mut Ctx) {}
   |                                        ^^^^
 
 error: #[shared_per_vcl] param is allowed only once in a function args list
- --> tests/fail/error_fn_args_dups.rs:6:80
+ --> tests/fail/error_fn_args_dups.rs:5:80
   |
-6 |     pub fn dup_shared_vcl(#[shared_per_vcl] a: Option<&i64>, #[shared_per_vcl] b: Option<&i64>) {}
+5 |     pub fn dup_shared_vcl(#[shared_per_vcl] a: Option<&i64>, #[shared_per_vcl] b: Option<&i64>) {}
   |                                                                                ^
+
+error: This params must be declared as `&mut Option<Box<...>>`
+ --> tests/fail/error_fn_args_dups.rs:7:31
+  |
+7 |         #[shared_per_task] a: Option<Box<i64>>,
+  |                               ^^^^^^
 
 error: This params must be declared as `&mut Option<Box<...>>`
  --> tests/fail/error_fn_args_dups.rs:8:31
   |
-8 |         #[shared_per_task] a: Option<Box<i64>>,
-  |                               ^^^^^^
-
-error: This params must be declared as `&mut Option<Box<...>>`
- --> tests/fail/error_fn_args_dups.rs:9:31
-  |
-9 |         #[shared_per_task] b: Option<Box<i64>>,
+8 |         #[shared_per_task] b: Option<Box<i64>>,
   |                               ^^^^^^
 
 error: Event param is allowed only once in a function args list
-  --> tests/fail/error_fn_args_dups.rs:13:32
+  --> tests/fail/error_fn_args_dups.rs:12:32
    |
-13 |     pub fn dup_event(a: Event, b: Event) {}
+12 |     pub fn dup_event(a: Event, b: Event) {}
    |                                ^

--- a/varnish/tests/fail/error_fn_args_logic.rs
+++ b/varnish/tests/fail/error_fn_args_logic.rs
@@ -1,6 +1,5 @@
 #[varnish::vmod]
 mod err_fn_args_logic {
-    pub fn good(i: i64) {}
     pub fn string(s: String) {}
     pub fn task_arg_non_mut(#[shared_per_task] a: Option<i64>) {}
     pub fn task_arg_non_mut2(#[shared_per_task] a: Option<&i64>) {}

--- a/varnish/tests/fail/error_fn_args_logic.stderr
+++ b/varnish/tests/fail/error_fn_args_logic.stderr
@@ -1,59 +1,59 @@
 error: unsupported argument type
- --> tests/fail/error_fn_args_logic.rs:4:19
+ --> tests/fail/error_fn_args_logic.rs:3:19
   |
-4 |     pub fn string(s: String) {}
+3 |     pub fn string(s: String) {}
   |                   ^
 
 error: This params must be declared as `&mut Option<Box<...>>`
- --> tests/fail/error_fn_args_logic.rs:5:51
+ --> tests/fail/error_fn_args_logic.rs:4:51
   |
-5 |     pub fn task_arg_non_mut(#[shared_per_task] a: Option<i64>) {}
+4 |     pub fn task_arg_non_mut(#[shared_per_task] a: Option<i64>) {}
   |                                                   ^^^^^^
 
 error: This params must be declared as `&mut Option<Box<...>>`
- --> tests/fail/error_fn_args_logic.rs:6:52
+ --> tests/fail/error_fn_args_logic.rs:5:52
   |
-6 |     pub fn task_arg_non_mut2(#[shared_per_task] a: Option<&i64>) {}
+5 |     pub fn task_arg_non_mut2(#[shared_per_task] a: Option<&i64>) {}
   |                                                    ^^^^^^
 
 error: This params must be declared as `Option<&...>`
- --> tests/fail/error_fn_args_logic.rs:7:49
+ --> tests/fail/error_fn_args_logic.rs:6:49
   |
-7 |     pub fn vcl_arg_non_ref(#[shared_per_vcl] a: Option<i64>) {}
+6 |     pub fn vcl_arg_non_ref(#[shared_per_vcl] a: Option<i64>) {}
   |                                                 ^^^^^^
 
 error: Event parameters are only allowed in event handlers. Try adding `#[event]` to this function.
- --> tests/fail/error_fn_args_logic.rs:8:25
+ --> tests/fail/error_fn_args_logic.rs:7:25
   |
-8 |     pub fn on_non_event(a: Event) {}
+7 |     pub fn on_non_event(a: Event) {}
   |                         ^
 
 error: Event functions can only have `Ctx`, `#[event] Event`, and `#[shared_per_vcl] &mut Option<Box<T>>` arguments.
-  --> tests/fail/error_fn_args_logic.rs:10:25
-   |
-10 |     pub fn on_event_arg(a: i64) {}
-   |                         ^
+ --> tests/fail/error_fn_args_logic.rs:9:25
+  |
+9 |     pub fn on_event_arg(a: i64) {}
+  |                         ^
 
 error: This params must be declared as `&mut Option<Box<...>>`
-  --> tests/fail/error_fn_args_logic.rs:12:52
+  --> tests/fail/error_fn_args_logic.rs:11:52
    |
-12 |     pub fn on_event_arg_task(#[shared_per_task] a: Option<Box<i64>>) {}
+11 |     pub fn on_event_arg_task(#[shared_per_task] a: Option<Box<i64>>) {}
    |                                                    ^^^^^^
 
 error: This params must be declared as `&mut Option<Box<...>>`
-  --> tests/fail/error_fn_args_logic.rs:14:50
+  --> tests/fail/error_fn_args_logic.rs:13:50
    |
-14 |     pub fn on_event_arg_vcl(#[shared_per_vcl] a: Option<&i64>) {}
+13 |     pub fn on_event_arg_vcl(#[shared_per_vcl] a: Option<&i64>) {}
    |                                                  ^^^^^^
 
 error: This type of argument must be declared as optional with `Option<...>`
-  --> tests/fail/error_fn_args_logic.rs:15:32
+  --> tests/fail/error_fn_args_logic.rs:14:32
    |
-15 |     pub fn socket_addr_non_opt(_v: SocketAddr) {}
+14 |     pub fn socket_addr_non_opt(_v: SocketAddr) {}
    |                                ^^
 
 error: #[vcl_name] params are only allowed in object constructors
-  --> tests/fail/error_fn_args_logic.rs:17:33
+  --> tests/fail/error_fn_args_logic.rs:16:33
    |
-17 |     pub fn vcl_name(#[vcl_name] a: &str) {}
+16 |     pub fn vcl_name(#[vcl_name] a: &str) {}
    |                                 ^

--- a/varnish/tests/fail/error_obj.stderr
+++ b/varnish/tests/fail/error_obj.stderr
@@ -69,11 +69,3 @@ error: Object must have a constructor called `new`
    |
 28 |     impl ObjVclNameDup {
    |          ^^^^^^^^^^^^^
-
-error: No functions or objects found in this module
- --> tests/fail/error_obj.rs:8:1
-  |
-8 | #[varnish::vmod]
-  | ^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in the attribute macro `varnish::vmod` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/varnish/tests/fail/error_obj_no_ctor.stderr
+++ b/varnish/tests/fail/error_obj_no_ctor.stderr
@@ -3,11 +3,3 @@ error: Object must have a constructor called `new`
   |
 6 |     impl ObjNoCtor {
   |          ^^^^^^^^^
-
-error: No functions or objects found in this module
- --> tests/fail/error_obj_no_ctor.rs:3:1
-  |
-3 | #[varnish::vmod]
-  | ^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in the attribute macro `varnish::vmod` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/varnish/tests/pass/function.rs
+++ b/varnish/tests/pass/function.rs
@@ -149,10 +149,10 @@ mod types {
     }
 
     // VCL_STRING
-    pub fn to_vcl_string() -> VCL_STRING {
+    pub unsafe fn to_vcl_string() -> VCL_STRING {
         VCL_STRING::default()
     }
-    pub fn to_res_vcl_string() -> Result<VCL_STRING, &'static str> {
+    pub unsafe fn to_res_vcl_string() -> Result<VCL_STRING, &'static str> {
         Err("")
     }
 

--- a/varnish/tests/pass_ffi/vcl_returns.rs
+++ b/varnish/tests/pass_ffi/vcl_returns.rs
@@ -14,136 +14,136 @@ mod vcl_returns {
         VCL_STEVEDORE, VCL_STRANDS, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VCL,
     };
 
-    pub fn val_acl() -> VCL_ACL {
+    pub unsafe fn val_acl() -> VCL_ACL {
         VCL_ACL::default()
     }
-    pub fn res_acl() -> Result<VCL_ACL, &'static str> {
+    pub unsafe fn res_acl() -> Result<VCL_ACL, &'static str> {
         Err("")
     }
-    pub fn val_backend() -> VCL_BACKEND {
+    pub unsafe fn val_backend() -> VCL_BACKEND {
         VCL_BACKEND::default()
     }
-    pub fn res_backend() -> Result<VCL_BACKEND, &'static str> {
+    pub unsafe fn res_backend() -> Result<VCL_BACKEND, &'static str> {
         Err("")
     }
-    pub fn val_blob() -> VCL_BLOB {
+    pub unsafe fn val_blob() -> VCL_BLOB {
         VCL_BLOB::default()
     }
-    pub fn res_blob() -> Result<VCL_BLOB, &'static str> {
+    pub unsafe fn res_blob() -> Result<VCL_BLOB, &'static str> {
         Err("")
     }
-    pub fn val_body() -> VCL_BODY {
+    pub unsafe fn val_body() -> VCL_BODY {
         VCL_BODY::default()
     }
-    pub fn res_body() -> Result<VCL_BODY, &'static str> {
+    pub unsafe fn res_body() -> Result<VCL_BODY, &'static str> {
         Err("")
     }
-    pub fn val_bool() -> VCL_BOOL {
+    pub unsafe fn val_bool() -> VCL_BOOL {
         VCL_BOOL::default()
     }
-    pub fn res_bool() -> Result<VCL_BOOL, &'static str> {
+    pub unsafe fn res_bool() -> Result<VCL_BOOL, &'static str> {
         Err("")
     }
-    pub fn val_bytes() -> VCL_BYTES {
+    pub unsafe fn val_bytes() -> VCL_BYTES {
         VCL_BYTES::default()
     }
-    pub fn res_bytes() -> Result<VCL_BYTES, &'static str> {
+    pub unsafe fn res_bytes() -> Result<VCL_BYTES, &'static str> {
         Err("")
     }
-    pub fn val_duration() -> VCL_DURATION {
+    pub unsafe fn val_duration() -> VCL_DURATION {
         VCL_DURATION::default()
     }
-    pub fn res_duration() -> Result<VCL_DURATION, &'static str> {
+    pub unsafe fn res_duration() -> Result<VCL_DURATION, &'static str> {
         Err("")
     }
-    pub fn val_enum() -> VCL_ENUM {
+    pub unsafe fn val_enum() -> VCL_ENUM {
         VCL_ENUM::default()
     }
-    pub fn res_enum() -> Result<VCL_ENUM, &'static str> {
+    pub unsafe fn res_enum() -> Result<VCL_ENUM, &'static str> {
         Err("")
     }
-    pub fn val_header() -> VCL_HEADER {
+    pub unsafe fn val_header() -> VCL_HEADER {
         VCL_HEADER::default()
     }
-    pub fn res_header() -> Result<VCL_HEADER, &'static str> {
+    pub unsafe fn res_header() -> Result<VCL_HEADER, &'static str> {
         Err("")
     }
-    pub fn val_http() -> VCL_HTTP {
+    pub unsafe fn val_http() -> VCL_HTTP {
         VCL_HTTP::default()
     }
-    pub fn res_http() -> Result<VCL_HTTP, &'static str> {
+    pub unsafe fn res_http() -> Result<VCL_HTTP, &'static str> {
         Err("")
     }
-    pub fn val_instance() -> VCL_INSTANCE {
+    pub unsafe fn val_instance() -> VCL_INSTANCE {
         panic!()
     }
-    // pub fn res_instance() -> Result<VCL_INSTANCE, &'static str> {
+    // pub unsafe fn res_instance() -> Result<VCL_INSTANCE, &'static str> {
     //     Err("")
     // }
-    pub fn val_int() -> VCL_INT {
+    pub unsafe fn val_int() -> VCL_INT {
         VCL_INT::default()
     }
-    pub fn res_int() -> Result<VCL_INT, &'static str> {
+    pub unsafe fn res_int() -> Result<VCL_INT, &'static str> {
         Err("")
     }
-    pub fn val_ip() -> VCL_IP {
+    pub unsafe fn val_ip() -> VCL_IP {
         VCL_IP::default()
     }
-    pub fn res_ip() -> Result<VCL_IP, &'static str> {
+    pub unsafe fn res_ip() -> Result<VCL_IP, &'static str> {
         Err("")
     }
-    pub fn val_probe() -> VCL_PROBE {
+    pub unsafe fn val_probe() -> VCL_PROBE {
         VCL_PROBE::default()
     }
-    pub fn res_probe() -> Result<VCL_PROBE, &'static str> {
+    pub unsafe fn res_probe() -> Result<VCL_PROBE, &'static str> {
         Err("")
     }
-    pub fn val_real() -> VCL_REAL {
+    pub unsafe fn val_real() -> VCL_REAL {
         VCL_REAL::default()
     }
-    pub fn res_real() -> Result<VCL_REAL, &'static str> {
+    pub unsafe fn res_real() -> Result<VCL_REAL, &'static str> {
         Err("")
     }
-    pub fn val_regex() -> VCL_REGEX {
+    pub unsafe fn val_regex() -> VCL_REGEX {
         VCL_REGEX::default()
     }
-    pub fn res_regex() -> Result<VCL_REGEX, &'static str> {
+    pub unsafe fn res_regex() -> Result<VCL_REGEX, &'static str> {
         Err("")
     }
-    pub fn val_stevedore() -> VCL_STEVEDORE {
+    pub unsafe fn val_stevedore() -> VCL_STEVEDORE {
         VCL_STEVEDORE::default()
     }
-    pub fn res_stevedore() -> Result<VCL_STEVEDORE, &'static str> {
+    pub unsafe fn res_stevedore() -> Result<VCL_STEVEDORE, &'static str> {
         Err("")
     }
-    pub fn val_strands() -> VCL_STRANDS {
+    pub unsafe fn val_strands() -> VCL_STRANDS {
         VCL_STRANDS::default()
     }
-    pub fn res_strands() -> Result<VCL_STRANDS, &'static str> {
+    pub unsafe fn res_strands() -> Result<VCL_STRANDS, &'static str> {
         Err("")
     }
-    pub fn val_string() -> VCL_STRING {
+    pub unsafe fn val_string() -> VCL_STRING {
         VCL_STRING::default()
     }
-    pub fn res_string() -> Result<VCL_STRING, &'static str> {
+    pub unsafe fn res_string() -> Result<VCL_STRING, &'static str> {
         Err("")
     }
-    pub fn val_sub() -> VCL_SUB {
+    pub unsafe fn val_sub() -> VCL_SUB {
         VCL_SUB::default()
     }
-    pub fn res_sub() -> Result<VCL_SUB, &'static str> {
+    pub unsafe fn res_sub() -> Result<VCL_SUB, &'static str> {
         Err("")
     }
-    pub fn val_time() -> VCL_TIME {
+    pub unsafe fn val_time() -> VCL_TIME {
         VCL_TIME::default()
     }
-    pub fn res_time() -> Result<VCL_TIME, &'static str> {
+    pub unsafe fn res_time() -> Result<VCL_TIME, &'static str> {
         Err("")
     }
-    pub fn val_vcl() -> VCL_VCL {
+    pub unsafe fn val_vcl() -> VCL_VCL {
         VCL_VCL::default()
     }
-    pub fn res_vcl() -> Result<VCL_VCL, &'static str> {
+    pub unsafe fn res_vcl() -> Result<VCL_VCL, &'static str> {
         Err("")
     }
 }

--- a/varnish/tests/vmod_test/src/lib.rs
+++ b/varnish/tests/vmod_test/src/lib.rs
@@ -36,7 +36,7 @@ mod rustest {
         }
     }
 
-    pub fn ws_reserve(ws: &mut Workspace, s: &str) -> Result<VCL_STRING, &'static str> {
+    pub unsafe fn ws_reserve(ws: &mut Workspace, s: &str) -> Result<VCL_STRING, &'static str> {
         let mut rbuf = ws.reserve();
         match write!(rbuf.buf, "{s} {s} {s}\0") {
             Ok(()) => {
@@ -102,7 +102,7 @@ mod rustest {
 
     // this is a pretty terrible idea, the request body is probably big, and your workspace is tiny,
     // but hey, it's a test function
-    pub fn req_body(ctx: &mut Ctx) -> Result<VCL_STRING, VclError> {
+    pub unsafe fn req_body(ctx: &mut Ctx) -> Result<VCL_STRING, VclError> {
         let mut body_chunks = ctx.cached_req_body()?;
         // make sure the body will be null-terminated
         body_chunks.push(b"\0");


### PR DESCRIPTION
* Require all user functions that return `VCL_*` types to be `unsafe`
* updated changelog
* bump to v0.3.0
* do not report an error that no functions found if other errors were found too

Fixes #151 