### PR TITLE
lots of lints

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,12 +49,11 @@ jobs:
       - name: Test for latest Varnish version
         if: matrix.type == 'latest'
         run: just ci-test-extras
-# Comment out until after v0.3.0 is published
-#      - name: Check semver
-#        if: matrix.type == 'latest'
-#        uses: obi1kenobi/cargo-semver-checks-action@v2
-#        with:
-#          exclude: varnish-sys  # GitHub CI has somehow generates a different output
+      - name: Check semver
+        if: matrix.type == 'latest'
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          exclude: varnish-sys  # GitHub CI has somehow generates a different output
       - name: Test packaging for publish
         if: matrix.type == 'latest'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unpublished
+- In probe support, renamed `Request::URL` to `Request::Url`
 
 # 0.3.0 (2024-12-12)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = ["varnish", "varnish-macros", "varnish-sys", "varnish/tests/vmod_test"
 #
 #
 # ! STOP !  Update the version in dependencies below!!!
-version = "0.3.0"  ## <<<----- ! STOP !!!
+version = "0.4.0"  ## <<<----- ! STOP !!!
 # ! STOP !  Update the version in dependencies below!!!
 #
 #
@@ -24,9 +24,9 @@ readme = "README.md"
 
 [workspace.dependencies]
 # These versions must match the one in the [workspace.package] section above
-varnish = { path = "./varnish", version = "0.3.0" }
-varnish-macros = { path = "./varnish-macros", version = "0.3.0" }
-varnish-sys = { path = "./varnish-sys", version = "0.3.0" }
+varnish = { path = "./varnish", version = "0.4.0" }
+varnish-macros = { path = "./varnish-macros", version = "0.4.0" }
+varnish-sys = { path = "./varnish-sys", version = "0.4.0" }
 #
 # These dependencies are used by one or more crates, and easier to maintain in one place.
 bindgen_helpers = "0.3.0"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+avoid-breaking-exported-api = false

--- a/justfile
+++ b/justfile
@@ -78,8 +78,13 @@ publish:
     cargo publish -p varnish-macros
     cargo publish -p varnish
     LOCAL_VERSION="$(grep '^version =' Cargo.toml | sed -E 's/version = "([^"]*)".*/\1/')"
-    echo "Detected crate version:  $LOCAL_VERSION"
-    git tag -a "v$LOCAL_VERSION"
+    git tag -a "v$LOCAL_VERSION" -m "Release v$LOCAL_VERSION"
+    echo "A new tag v$LOCAL_VERSION has been created.  Please push it to the repository:"
+    if git remote get-url upstream > /dev/null 2> /dev/null ; then
+        echo "   git push upstream tag v$LOCAL_VERSION"
+    else
+        echo "   git push origin tag v$LOCAL_VERSION"
+    fi
 
 # Use the experimental workspace publishing with --dry-run. Requires nightly Rust.
 test-publish:

--- a/varnish-macros/src/gen_func.rs
+++ b/varnish-macros/src/gen_func.rs
@@ -206,7 +206,7 @@ impl FuncProcessor {
         (format!("  {td_name} *{};\n", self.names.f_fn_name()), decl)
     }
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn do_fn_param(&mut self, func_info: &FuncInfo, arg_info: &ParamTypeInfo) {
         let arg_name_ident = arg_info.ident.to_ident();
         let arg_value = Self::get_arg_value(func_info, &arg_name_ident);

--- a/varnish-macros/src/generator.rs
+++ b/varnish-macros/src/generator.rs
@@ -178,7 +178,6 @@ impl Generator {
         cproto
     }
 
-    #[allow(clippy::too_many_lines)]
     fn render_generated_mod(&self, vmod: &VmodInfo) -> TokenStream {
         let cproto = self.generate_proto().force_cstr();
         let vmod_name_data = self.names.data_struct_name().to_ident();

--- a/varnish-macros/src/parser.rs
+++ b/varnish-macros/src/parser.rs
@@ -24,7 +24,6 @@ pub fn tokens_to_model(args: TokenStream, item_mod: &mut ItemMod) -> ProcResult<
 
 impl VmodInfo {
     /// Parse the `mod` item and generate the model of everything
-    #[allow(clippy::too_many_lines)]
     fn parse(params: VmodParams, item: &mut ItemMod) -> ProcResult<Self> {
         let mut errors = Errors::new();
         let mut funcs = Vec::<FuncInfo>::new();

--- a/varnish-macros/src/parser_args.rs
+++ b/varnish-macros/src/parser_args.rs
@@ -16,7 +16,7 @@ use crate::ProcResult;
 
 /// Parser state for a function parser. This is not part of the model, but helps with error detection.
 #[derive(Debug, Default)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub struct FuncStatus {
     func_type: FuncType,
     has_ctx_or_ws: bool,
@@ -87,7 +87,7 @@ impl ParamTypeInfo {
 
 impl ParamType {
     /// Parse an argument type, including the magical types like shared types and context.
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn parse(
         shared_types: &mut SharedTypes,
         pat_ty: &mut PatType,

--- a/varnish-sys/src/extensions.rs
+++ b/varnish-sys/src/extensions.rs
@@ -33,6 +33,7 @@ impl vmod_priv {
         get_owned_bbox(&mut self.priv_)
     }
 
+    #[expect(clippy::unnecessary_box_returns)]
     pub unsafe fn take_per_vcl<T>(&mut self) -> Box<PerVclState<T>> {
         if let Some(v) = self.take::<PerVclState<T>>() {
             v

--- a/varnish-sys/src/lib.rs
+++ b/varnish-sys/src/lib.rs
@@ -1,15 +1,13 @@
 extern crate core;
 
-#[allow(
+#[expect(
     improper_ctypes,
     non_camel_case_types,
-    non_snake_case,
     non_upper_case_globals,
     unused_qualifications
 )]
-#[allow(
+#[expect(
     clippy::approx_constant,
-    clippy::manual_c_str_literals,
     clippy::pedantic,
     clippy::ptr_offset_with_cast,
     clippy::too_many_arguments,

--- a/varnish-sys/src/txt.rs
+++ b/varnish-sys/src/txt.rs
@@ -17,7 +17,7 @@ impl txt {
     /// FIXME: This method is only used when calling [`crate::ffi::VSLbt`],
     /// and current implementation creates a string without a null terminator to pass it in.
     /// Going forward, we should probably refactor it to avoid extra string allocation.
-    #[allow(clippy::should_implement_trait)]
+    #[expect(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
         Self::from_bytes(s.as_bytes())
     }
@@ -28,6 +28,7 @@ impl txt {
 
     /// Convert the `txt` struct to a `&[u8]`.
     /// We want to explicitly differentiate between empty (`None`) and null (`Some([])`) strings.
+    #[expect(clippy::wrong_self_convention)] // TODO: drop Copy trait for txt?
     pub fn to_slice<'a>(&self) -> Option<&'a [u8]> {
         if self.b.is_null() {
             None
@@ -45,6 +46,7 @@ impl txt {
     }
 
     /// Convert the `txt` struct to a `&str`.  Will panic if the string is not valid UTF-8.
+    #[expect(clippy::wrong_self_convention)] // TODO: drop Copy trait for txt?
     pub fn to_str<'a>(&self) -> Option<&'a str> {
         self.to_slice().map(|s| from_utf8(s).unwrap())
     }

--- a/varnish-sys/src/validate.rs
+++ b/varnish-sys/src/validate.rs
@@ -67,6 +67,7 @@ mod version_after_v6 {
     }
 
     impl vrt_ctx {
+        #[expect(clippy::vec_box)] // FIXME: we may want to rethink this
         pub fn fetch_filters<'c, 'f>(
             &'c self,
             filters: &'f mut Vec<Box<ffi::vfp>>,
@@ -74,6 +75,7 @@ mod version_after_v6 {
             FetchFilters::<'c, 'f>::new(self, filters)
         }
 
+        #[expect(clippy::vec_box)] // FIXME: we may want to rethink this
         pub fn delivery_filters<'c, 'f>(
             &'c self,
             filters: &'f mut Vec<Box<ffi::vdp>>,

--- a/varnish-sys/src/vcl/backend.rs
+++ b/varnish-sys/src/vcl/backend.rs
@@ -95,10 +95,10 @@ use crate::{
 #[derive(Debug)]
 pub struct Backend<S: Serve<T>, T: Transfer> {
     bep: VCL_BACKEND,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     methods: Box<ffi::vdi_methods>,
     inner: Box<S>,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     type_: CString,
     phantom: PhantomData<T>,
 }
@@ -247,7 +247,7 @@ pub trait Serve<T: Transfer> {
 /// - `Ok(None)`: headers are set, but the response as no content body.
 /// - `Ok(Some(Transfer))`: headers are set, and Varnish will use the `Transfer` object to build
 ///   the response body.
-#[allow(clippy::len_without_is_empty)] // FIXME: should there be an is_empty() method?
+#[expect(clippy::len_without_is_empty)] // FIXME: should there be an is_empty() method?
 pub trait Transfer {
     /// The only mandatory method, it will be called repeated so that the `Transfer` object can
     /// fill `buf`. The transfer will stop if any of its calls returns an error, and it will
@@ -351,7 +351,6 @@ unsafe extern "C" fn wrap_pipe<S: Serve<T>, T: Transfer>(
     sc_to_ptr(backend.pipe(&mut ctx, tcp_stream))
 }
 
-#[allow(clippy::too_many_lines)] // fixme
 unsafe extern "C" fn wrap_gethdrs<S: Serve<T>, T: Transfer>(
     ctxp: *const ffi::vrt_ctx,
     be: VCL_BACKEND,

--- a/varnish-sys/src/vcl/ctx.rs
+++ b/varnish-sys/src/vcl/ctx.rs
@@ -50,7 +50,7 @@ impl<'a> Ctx<'a> {
     }
 
     /// Instantiate from a mutable reference to a [`vrt_ctx`].
-    #[allow(clippy::useless_conversion)] // Varnish v6 has a different struct, requiring .into()
+    #[cfg_attr(not(varnishsys_6), expect(clippy::useless_conversion))] // Varnish v6 has a different struct, requiring .into()
     pub fn from_ref(raw: &'a mut vrt_ctx) -> Self {
         assert_eq!(raw.magic, VRT_CTX_MAGIC);
         Self {
@@ -184,8 +184,10 @@ mod tests {
 #[derive(Debug)]
 pub struct PerVclState<T> {
     #[cfg(not(varnishsys_6))]
+    #[expect(clippy::vec_box)] // FIXME: we may want to rethink this
     pub fetch_filters: Vec<Box<ffi::vfp>>,
     #[cfg(not(varnishsys_6))]
+    #[expect(clippy::vec_box)] // FIXME: we may want to rethink this
     pub delivery_filters: Vec<Box<ffi::vdp>>,
     pub user_data: Option<Box<T>>,
 }

--- a/varnish-sys/src/vcl/http.rs
+++ b/varnish-sys/src/vcl/http.rs
@@ -11,7 +11,6 @@
 //! the case. Future work needs to sanitize the headers to make this safer to use. It is tracked in
 //! this [issue](https://github.com/gquintard/varnish-rs/issues/4).
 
-#![allow(clippy::not_unsafe_ptr_arg_deref)]
 use std::mem::transmute;
 use std::slice::from_raw_parts_mut;
 

--- a/varnish-sys/src/vcl/probe.rs
+++ b/varnish-sys/src/vcl/probe.rs
@@ -9,7 +9,7 @@ use crate::vcl::{IntoVCL, VclError, Workspace};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum Request<T> {
-    URL(T),
+    Url(T),
     Text(T),
 }
 
@@ -30,7 +30,7 @@ impl CowProbe<'_> {
     pub fn to_owned(&self) -> Probe {
         Probe {
             request: match &self.request {
-                Request::URL(cow) => Request::URL(cow.to_string()),
+                Request::Url(cow) => Request::Url(cow.to_string()),
                 Request::Text(cow) => Request::Text(cow.to_string()),
             },
             timeout: self.timeout,
@@ -59,7 +59,7 @@ pub(crate) fn into_vcl_probe<T: AsRef<str>>(
     })?;
 
     match src.request {
-        Request::URL(s) => {
+        Request::Url(s) => {
             probe.url = s.as_ref().into_vcl(ws)?.0;
         }
         Request::Text(s) => {
@@ -80,7 +80,7 @@ pub(crate) fn from_vcl_probe<'a, T: From<Cow<'a, str>>>(value: VCL_PROBE) -> Opt
         request: if pr.url.is_null() {
             Request::Text(from_str(pr.request).into())
         } else {
-            Request::URL(from_str(pr.url).into())
+            Request::Url(from_str(pr.url).into())
         },
         timeout: VCL_DURATION(pr.timeout).into(),
         interval: VCL_DURATION(pr.interval).into(),

--- a/varnish-sys/src/vcl/processor.rs
+++ b/varnish-sys/src/vcl/processor.rs
@@ -280,7 +280,7 @@ impl FetchProcCtx<'_> {
             VfpStatus::Null => panic!("VFP_Suck() was never supposed to return VFP_NULL!"),
             // In the future, there might be more enum values, so we should ensure it continues
             // to compile, but we do want a warning when developing locally to add the new one.
-            #[allow(unreachable_patterns)]
+            #[expect(unreachable_patterns)]
             n => panic!("unknown VfpStatus {n:?}"),
         }
     }
@@ -291,12 +291,12 @@ pub struct FetchFilters<'c, 'f> {
     ctx: &'c vrt_ctx,
     // The pointer to the box content must be stable.
     // Storing values directly in the vector might be moved when the vector grows.
-    #[allow(clippy::vec_box)]
+    #[expect(clippy::vec_box)]
     filters: &'f mut Vec<Box<ffi::vfp>>,
 }
 
 impl<'c, 'f> FetchFilters<'c, 'f> {
-    #[allow(clippy::vec_box)]
+    #[expect(clippy::vec_box)]
     pub(crate) fn new(ctx: &'c vrt_ctx, filters: &'f mut Vec<Box<ffi::vfp>>) -> Self {
         Self { ctx, filters }
     }
@@ -343,12 +343,12 @@ pub struct DeliveryFilters<'c, 'f> {
     ctx: &'c vrt_ctx,
     // The pointer to the box content must be stable.
     // Storing values directly in the vector might be moved when the vector grows.
-    #[allow(clippy::vec_box)]
+    #[expect(clippy::vec_box)]
     filters: &'f mut Vec<Box<ffi::vdp>>,
 }
 
 impl<'c, 'f> DeliveryFilters<'c, 'f> {
-    #[allow(clippy::vec_box)]
+    #[expect(clippy::vec_box)]
     pub(crate) fn new(ctx: &'c vrt_ctx, filters: &'f mut Vec<Box<ffi::vdp>>) -> Self {
         Self { ctx, filters }
     }

--- a/varnish-sys/src/vcl/vsb.rs
+++ b/varnish-sys/src/vcl/vsb.rs
@@ -11,7 +11,7 @@ pub struct Buffer<'a> {
 
 impl Buffer<'_> {
     /// Create a `Vsb` from a C pointer
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    #[expect(clippy::not_unsafe_ptr_arg_deref)]
     pub fn from_ptr(raw: *mut ffi::vsb) -> Self {
         let raw = unsafe { raw.as_mut().unwrap() };
         assert_eq!(raw.magic, ffi::VSB_MAGIC);
@@ -19,7 +19,7 @@ impl Buffer<'_> {
     }
 
     /// Push a buffer into the buffer
-    #[allow(clippy::result_unit_err)] // FIXME: what should the error be? VclError?
+    #[expect(clippy::result_unit_err)] // FIXME: what should the error be? VclError?
     pub fn write<T: AsRef<[u8]>>(&mut self, src: &T) -> Result<(), ()> {
         let buf = src.as_ref().as_ptr().cast::<c_void>();
         let l = src.as_ref().len();

--- a/varnish-sys/src/vcl/ws.rs
+++ b/varnish-sys/src/vcl/ws.rs
@@ -218,7 +218,7 @@ fn maybe_uninit(value: &[u8]) -> &[MaybeUninit<u8>] {
     // SAFETY: &[T] and &[MaybeUninit<T>] have the same layout
     // This was copied from MaybeUninit::copy_from_slice, ignoring clippy lints
     unsafe {
-        #[allow(clippy::transmute_ptr_to_ptr)]
+        #[expect(clippy::transmute_ptr_to_ptr)]
         transmute(value)
     }
 }
@@ -227,7 +227,7 @@ fn maybe_uninit(value: &[u8]) -> &[MaybeUninit<u8>] {
 unsafe fn slice_assume_init_mut(value: &mut [MaybeUninit<u8>]) -> &mut [u8] {
     // SAFETY: Valid elements have just been copied into `this` so it is initialized
     // This was copied from MaybeUninit::slice_assume_init_mut, ignoring clippy lints
-    #[allow(clippy::ref_as_ptr)]
+    #[expect(clippy::ref_as_ptr)]
     &mut *(value as *mut [MaybeUninit<u8>] as *mut [u8])
 }
 
@@ -323,7 +323,7 @@ impl Drop for ReservedBuf<'_> {
 #[derive(Debug)]
 pub struct TestWS {
     c_ws: ffi::ws,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     space: Vec<c_char>,
 }
 

--- a/varnish/src/vsc.rs
+++ b/varnish/src/vsc.rs
@@ -39,7 +39,7 @@ pub struct StatsBuilder<'a> {
 
 impl<'a> StatsBuilder<'a> {
     /// Create a new `VSCBuilder`
-    #[allow(clippy::new_without_default)] // TODO: consider implementing
+    #[expect(clippy::new_without_default)] // TODO: consider implementing
     pub fn new() -> Self {
         unsafe {
             let vsm = ffi::VSM_New();

--- a/varnish/tests/pass/docs.rs
+++ b/varnish/tests/pass/docs.rs
@@ -1,4 +1,4 @@
-#![allow(unused_variables)]
+#![expect(unused_variables)]
 
 use varnish::vmod;
 

--- a/varnish/tests/pass/event1.rs
+++ b/varnish/tests/pass/event1.rs
@@ -1,4 +1,4 @@
-#![allow(unused_variables)]
+#![expect(unused_variables)]
 
 use varnish::vmod;
 

--- a/varnish/tests/pass/event2.rs
+++ b/varnish/tests/pass/event2.rs
@@ -1,4 +1,4 @@
-#![allow(unused_variables)]
+#![expect(unused_variables)]
 
 use varnish::vmod;
 

--- a/varnish/tests/pass/event3.rs
+++ b/varnish/tests/pass/event3.rs
@@ -1,4 +1,4 @@
-#![allow(unused_variables)]
+#![expect(unused_variables)]
 
 use varnish::vmod;
 

--- a/varnish/tests/pass/event4.rs
+++ b/varnish/tests/pass/event4.rs
@@ -1,4 +1,4 @@
-#![allow(unused_variables)]
+#![expect(unused_variables)]
 
 use varnish::vmod;
 

--- a/varnish/tests/pass/function.rs
+++ b/varnish/tests/pass/function.rs
@@ -1,4 +1,4 @@
-#![allow(unused_variables)]
+#![expect(unused_variables)]
 
 use varnish::vmod;
 

--- a/varnish/tests/pass/object.rs
+++ b/varnish/tests/pass/object.rs
@@ -1,5 +1,5 @@
-#![allow(unused_variables)]
-#![allow(non_camel_case_types)]
+#![expect(unused_variables)]
+#![expect(non_camel_case_types)]
 
 use varnish::vmod;
 

--- a/varnish/tests/pass/object2.rs
+++ b/varnish/tests/pass/object2.rs
@@ -1,4 +1,4 @@
-#![allow(unused_variables)]
+#![expect(unused_variables)]
 
 use varnish::vmod;
 

--- a/varnish/tests/pass/shared1.rs
+++ b/varnish/tests/pass/shared1.rs
@@ -1,4 +1,4 @@
-#![allow(unused_variables)]
+#![expect(unused_variables)]
 
 use varnish::vmod;
 

--- a/varnish/tests/pass/shared2.rs
+++ b/varnish/tests/pass/shared2.rs
@@ -1,4 +1,4 @@
-#![allow(unused_variables)]
+#![expect(unused_variables)]
 
 use varnish::vmod;
 

--- a/varnish/tests/pass/shared3.rs
+++ b/varnish/tests/pass/shared3.rs
@@ -1,4 +1,4 @@
-#![allow(unused_variables)]
+#![expect(unused_variables)]
 
 use varnish::vmod;
 

--- a/varnish/tests/pass_ffi/vcl_returns.rs
+++ b/varnish/tests/pass_ffi/vcl_returns.rs
@@ -1,4 +1,4 @@
-#![allow(unused_variables)]
+#![expect(unused_variables)]
 
 use varnish::vmod;
 

--- a/varnish/tests/vmod_test/src/lib.rs
+++ b/varnish/tests/vmod_test/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::unnecessary_wraps)]
+#![expect(clippy::unnecessary_wraps)]
 
 use std::ffi::CStr;
 
@@ -119,21 +119,7 @@ mod rustest {
     }
 
     pub fn cowprobe_prop(probe: Option<CowProbe<'_>>) -> String {
-        match probe {
-            Some(probe) => format!(
-                "{}-{}-{}-{}-{}-{}",
-                match probe.request {
-                    Request::URL(url) => format!("url:{url}"),
-                    Request::Text(text) => format!("text:{text}"),
-                },
-                probe.threshold,
-                probe.timeout.as_secs(),
-                probe.interval.as_secs(),
-                probe.initial,
-                probe.window
-            ),
-            None => "no probe".to_string(),
-        }
+        probe_prop(probe.map(|v| v.to_owned()))
     }
 
     pub fn probe_prop(probe: Option<Probe>) -> String {
@@ -141,7 +127,7 @@ mod rustest {
             Some(probe) => format!(
                 "{}-{}-{}-{}-{}-{}",
                 match probe.request {
-                    Request::URL(url) => format!("url:{url}"),
+                    Request::Url(url) => format!("url:{url}"),
                     Request::Text(text) => format!("text:{text}"),
                 },
                 probe.threshold,


### PR DESCRIPTION
* re-enable semver check in CI
* in just publish, suggest better git push command
* Due to MSRV bump, we can now use `#[expect]`, which also showed that a few of them can be removed
* make clippy warn even if that changes public API, and allow a few of the newly found ones
* rename a few `Probe::URL -> Url`