### PR TITLE
no more 7.4 in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,7 +20,6 @@ jobs:
           - setup: varnish76
             type: latest
           - setup: varnish75
-          - setup: varnish74
           - setup: varnish60lts
 
     env:


### PR DESCRIPTION
`github actions` moved to `ubuntu:noble` and `varnish:7.4` isn't packaged for it, on top of being EOL