### PR TITLE
Fix Clippy 1.85 lints + minor fix

### DIFF
--- a/varnish-macros/src/parser.rs
+++ b/varnish-macros/src/parser.rs
@@ -16,7 +16,7 @@ use crate::parser_args::FuncStatus;
 use crate::{parser_utils, ProcResult};
 
 pub fn tokens_to_model(args: TokenStream, item_mod: &mut ItemMod) -> ProcResult<VmodInfo> {
-    let args = NestedMeta::parse_meta_list(args).map_err(syn::Error::from)?;
+    let args = NestedMeta::parse_meta_list(args)?;
     let args = VmodParams::from_list(&args)?;
     let info = VmodInfo::parse(args, item_mod)?;
     Ok(info)

--- a/varnish-sys/src/vcl/backend.rs
+++ b/varnish-sys/src/vcl/backend.rs
@@ -524,12 +524,14 @@ unsafe extern "C" fn wrap_finish<S: Serve<T>, T: Transfer>(
     let bo = ctx.bo.as_mut().unwrap();
 
     // drop the Transfer
-    // FIXME: can htc be null? We do set it to null later...
-    let htc = bo.htc.as_ref().unwrap();
-    if let Some(old) = htc.priv_.cast::<T>().as_mut().take() {
-        drop(Box::from_raw(old));
+    if let Some(htc) = ptr::replace(&mut bo.htc, null_mut()).as_mut() {
+        if let Some(val) = ptr::replace(&mut htc.priv_, null_mut())
+            .cast::<T>()
+            .as_mut()
+        {
+            drop(Box::from_raw(val));
+        }
     }
-    bo.htc = null_mut();
 
     // FIXME?: should _prev be set to NULL?
     prev_backend.finish(&mut Ctx::from_ptr(ctx));


### PR DESCRIPTION
I modified the logic of the `wrap_finish` a bit - now it will properly handle if `htc` is null already, and won't crash.