### PR TITLE
chore: release v0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.5](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.5.4...varnish-sys-v0.5.5) - 2025-09-18
+
+### Other
+
+- upgrade to be compatible with 8.0 ([#231](https://github.com/varnish-rs/varnish-rs/pull/231))
+- be clearer about lifetime elisions ([#226](https://github.com/varnish-rs/varnish-rs/pull/226))
+- fix readme vmod example links ([#224](https://github.com/varnish-rs/varnish-rs/pull/224))
+- CI fixes
+
 ## [0.5.4](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.5.3...varnish-sys-v0.5.4) - 2025-07-06
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["varnish", "varnish-macros", "varnish-sys", "varnish/tests/vmod_test"
 
 [workspace.package]
 # These fields are used by multiple crates, so it's defined here.
-version = "0.5.4"
+version = "0.5.5"
 repository = "https://github.com/varnish-rs/varnish-rs"
 edition = "2021"
 rust-version = "1.82.0"
@@ -17,9 +17,9 @@ readme = "README.md"
 
 [workspace.dependencies]
 # These versions should match the package.version above, and will be updated by release-plz.
-varnish = { path = "./varnish", version = "0.5.4" }
-varnish-macros = { path = "./varnish-macros", version = "0.5.4" }
-varnish-sys = { path = "./varnish-sys", version = "0.5.4" }
+varnish = { path = "./varnish", version = "0.5.5" }
+varnish-macros = { path = "./varnish-macros", version = "0.5.5" }
+varnish-sys = { path = "./varnish-sys", version = "0.5.5" }
 #
 # These dependencies are used by one or more crates, and easier to maintain in one place.
 bindgen_helpers = "0.5.0"


### PR DESCRIPTION



## 🤖 New release

* `varnish-sys`: 0.5.4 -> 0.5.5 (✓ API compatible changes)
* `varnish-macros`: 0.5.4 -> 0.5.5
* `varnish`: 0.5.4 -> 0.5.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `varnish-sys`

<blockquote>

## [0.5.5](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.5.4...varnish-sys-v0.5.5) - 2025-09-18

### Other

- upgrade to be compatible with 8.0 ([#231](https://github.com/varnish-rs/varnish-rs/pull/231))
- be clearer about lifetime elisions ([#226](https://github.com/varnish-rs/varnish-rs/pull/226))
- fix readme vmod example links ([#224](https://github.com/varnish-rs/varnish-rs/pull/224))
- CI fixes
</blockquote>

## `varnish-macros`

<blockquote>

## [0.5.5](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.5.4...varnish-sys-v0.5.5) - 2025-09-18

### Other

- upgrade to be compatible with 8.0 ([#231](https://github.com/varnish-rs/varnish-rs/pull/231))
- be clearer about lifetime elisions ([#226](https://github.com/varnish-rs/varnish-rs/pull/226))
- fix readme vmod example links ([#224](https://github.com/varnish-rs/varnish-rs/pull/224))
- CI fixes
</blockquote>

## `varnish`

<blockquote>

## [0.5.5](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.5.4...varnish-sys-v0.5.5) - 2025-09-18

### Other

- upgrade to be compatible with 8.0 ([#231](https://github.com/varnish-rs/varnish-rs/pull/231))
- be clearer about lifetime elisions ([#226](https://github.com/varnish-rs/varnish-rs/pull/226))
- fix readme vmod example links ([#224](https://github.com/varnish-rs/varnish-rs/pull/224))
- CI fixes
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).