### PR TITLE
Turn Rust panics into Varnish panics

### DIFF
--- a/varnish-macros/src/model.rs
+++ b/varnish-macros/src/model.rs
@@ -91,6 +91,7 @@ pub enum FuncType {
     Destructor,
     Method,
     Event,
+    FallbackEvent,
 }
 
 impl FuncType {
@@ -100,7 +101,7 @@ impl FuncType {
             Self::Constructor => "$INIT",
             Self::Destructor => "$FINI",
             Self::Method => "$METHOD",
-            Self::Event => "$EVENT",
+            Self::Event | Self::FallbackEvent => "$EVENT",
         }
     }
 }

--- a/varnish-macros/src/parser.rs
+++ b/varnish-macros/src/parser.rs
@@ -106,7 +106,7 @@ impl VmodInfo {
                 }
             }
         }
-        let info = Self {
+        let mut info = Self {
             params,
             ident: item.ident.to_string(),
             docs: parser_utils::parse_doc_str(&item.attrs),
@@ -116,6 +116,19 @@ impl VmodInfo {
         };
         info.validate(item, &mut errors);
         errors.into_result()?;
+
+        if info.count_funcs(|v| matches!(v.func_type, FuncType::Event)) == 0 {
+            info.funcs.push(FuncInfo {
+                func_type: FuncType::FallbackEvent,
+                ident: "_event".to_string(),
+                docs: String::new(),
+                has_optional_args: false,
+                args: Vec::<ParamTypeInfo>::new(),
+                output_ty: OutputTy::VclType("VCL_INT".to_string()),
+                out_result: false,
+            });
+        }
+
         Ok(info)
     }
 

--- a/varnish-sys/src/lib.rs
+++ b/varnish-sys/src/lib.rs
@@ -15,6 +15,8 @@ pub mod ffi {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 
+pub mod panic;
+
 mod extensions;
 mod txt;
 #[cfg(not(varnishsys_6))]

--- a/varnish-sys/src/panic.rs
+++ b/varnish-sys/src/panic.rs
@@ -1,0 +1,23 @@
+use crate::ffi::{VAS_Fail, Vas};
+use std::panic;
+use std::sync::Once;
+
+static SET_HOOK: Once = Once::new();
+
+pub fn set_vas_hook_once() {
+    SET_HOOK.call_once(|| panic::set_hook(Box::new(vas_hook)));
+}
+
+fn vas_hook(info: &panic::PanicHookInfo<'_>) {
+    let loc = info.location();
+    let line = loc.map_or(-1, |l| l.line().try_into().unwrap_or(-1));
+    unsafe {
+        VAS_Fail(
+            c"???".as_ptr(), // XXX: extract fn name as &Cstr?
+            c"???".as_ptr(), // XXX: ideally, should be file name
+            line,
+            c"rust panic".as_ptr(), // XXX: extract message as &Cstr?
+            Vas::Wrong,
+        )
+    }
+}

--- a/varnish/src/lib.rs
+++ b/varnish/src/lib.rs
@@ -95,6 +95,8 @@ pub mod ffi {
 #[cfg(feature = "ffi")]
 pub use varnish_sys::ffi;
 
+pub use varnish_sys::panic;
+
 pub mod varnishtest;
 
 mod metrics_reader;

--- a/varnish/tests/vmod_test/README.md
+++ b/varnish/tests/vmod_test/README.md
@@ -57,4 +57,6 @@ import rustest from "path/to/librustest.so";
 
 ### Function `STRING rustest.merge_all_names()`
 
+### Function `VOID rustest.panic(STRING msg)`
+
 ### Function `VOID rustest.ws_tests()`

--- a/varnish/tests/vmod_test/src/lib.rs
+++ b/varnish/tests/vmod_test/src/lib.rs
@@ -154,6 +154,10 @@ mod rustest {
         s
     }
 
+    pub fn panic(msg: &str) {
+        panic!("{}", msg);
+    }
+
     pub fn ws_tests(ctx: &mut Ctx) {
         //external buffer, 0-length -> new ptr
         let buf = b"";

--- a/varnish/tests/vmod_test/tests/test09.vtc
+++ b/varnish/tests/vmod_test/tests/test09.vtc
@@ -1,0 +1,22 @@
+varnishtest "vmod panic"
+
+varnish v1 -cliok "param.set feature +no_coredump"
+varnish v1 -expectexit 0x40
+
+varnish v1 -vcl {
+    import rustest from "${vmod}";
+
+    backend be none;
+
+    sub vcl_recv {
+        rustest.panic("what is this rust thing?");
+    }
+} -start
+
+client c1 {
+    txreq
+    expect_close
+} -run
+
+varnish v1 -cliexpect "Wrong turn at " panic.show
+varnish v1 -cliok panic.clear

--- a/varnish/tests/vmod_test/tests/test09.vtc
+++ b/varnish/tests/vmod_test/tests/test09.vtc
@@ -19,4 +19,5 @@ client c1 {
 } -run
 
 varnish v1 -cliexpect "Wrong turn at " panic.show
+varnish v1 -cliexpect "rust panic" panic.show
 varnish v1 -cliok panic.clear


### PR DESCRIPTION
This sets the VAS panic hook from the event function, regardless of the actual event (meaning at least twice per VMOD life cycle).

It is safe to do this unilaterally because events all occur from the same cache-main thread, and even if that was not the case, the hook is only set up once.

The panic hook is global, so it may be overridden by a dependency, though I suspect having a random crate set a panic hook under the program's feet is probably frowned upon.

I suspect but haven't verified that two distinct Rust VMODs will not share this global hook as they will each have their own copy of the Rust std runtime code supporting panics and other language constructs.

The hook itself must not panic, so it is not desirable to turn Rust strings into C strings. If the Rust panic was caused by a failed allocation, chances are we won't be able to make null-terminated copies of the function name, file name and panic message.

This could be solved with a VAS_FailTxt() function in Varnish Cache, replacing `const char *` arguments with `txt` arguments instead.

An empty event function is injected when the VMOD does not declare one.