### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.5.5...varnish-sys-v0.6.0) - 2026-03-23
+
+### Other
+
+- Remove old version support and clean up ([#257](https://github.com/varnish-rs/varnish-rs/pull/257))
+- Drop 7.x versions ([#256](https://github.com/varnish-rs/varnish-rs/pull/256))
+- Introduce new Backend types ([#246](https://github.com/varnish-rs/varnish-rs/pull/246))
+- Support VCL_TIME as vmod arguments and returns ([#242](https://github.com/varnish-rs/varnish-rs/pull/242))
+- [clippy] reference as raw pointer ([#255](https://github.com/varnish-rs/varnish-rs/pull/255))
+- Update doc bindings ([#254](https://github.com/varnish-rs/varnish-rs/pull/254))
+- Trunk support ([#253](https://github.com/varnish-rs/varnish-rs/pull/253))
+- Add set_url() method to HttpHeaders ([#250](https://github.com/varnish-rs/varnish-rs/pull/250))
+- allow VCL_BLOB arguments as &[u8] ([#239](https://github.com/varnish-rs/varnish-rs/pull/239))
+
 ## [0.5.5](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.5.4...varnish-sys-v0.5.5) - 2025-09-18
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["varnish", "varnish-macros", "varnish-sys", "varnish/tests/vmod_test"
 
 [workspace.package]
 # These fields are used by multiple crates, so it's defined here.
-version = "0.5.5"
+version = "0.6.0"
 repository = "https://github.com/varnish-rs/varnish-rs"
 edition = "2021"
 rust-version = "1.90.0"
@@ -17,9 +17,9 @@ readme = "README.md"
 
 [workspace.dependencies]
 # These versions should match the package.version above, and will be updated by release-plz.
-varnish = { path = "./varnish", version = "0.5.5" }
-varnish-macros = { path = "./varnish-macros", version = "0.5.5" }
-varnish-sys = { path = "./varnish-sys", version = "0.5.5" }
+varnish = { path = "./varnish", version = "0.6.0" }
+varnish-macros = { path = "./varnish-macros", version = "0.6.0" }
+varnish-sys = { path = "./varnish-sys", version = "0.6.0" }
 #
 # These dependencies are used by one or more crates, and easier to maintain in one place.
 bindgen_helpers = "0.5.0"


### PR DESCRIPTION



## 🤖 New release

* `varnish-sys`: 0.5.5 -> 0.6.0 (⚠ API breaking changes)
* `varnish-macros`: 0.5.5 -> 0.6.0
* `varnish`: 0.5.5 -> 0.6.0 (✓ API compatible changes)

### ⚠ `varnish-sys` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type req_step is no longer Send, in /tmp/.tmpCyQhA4/varnish-rs/target/semver-checks/local-varnish_sys-0_5_5-default-01666ec060466c14/target/debug/build/varnish-sys-6e12d260e290572d/out/bindings.rs:10319
  type req_step is no longer Sync, in /tmp/.tmpCyQhA4/varnish-rs/target/semver-checks/local-varnish_sys-0_5_5-default-01666ec060466c14/target/debug/build/varnish-sys-6e12d260e290572d/out/bindings.rs:10319
  type worker_priv is no longer Send, in /tmp/.tmpCyQhA4/varnish-rs/target/semver-checks/local-varnish_sys-0_5_5-default-01666ec060466c14/target/debug/build/varnish-sys-6e12d260e290572d/out/bindings.rs:10360
  type worker_priv is no longer Sync, in /tmp/.tmpCyQhA4/varnish-rs/target/semver-checks/local-varnish_sys-0_5_5-default-01666ec060466c14/target/debug/build/varnish-sys-6e12d260e290572d/out/bindings.rs:10360
  type vcf is no longer Send, in /tmp/.tmpCyQhA4/varnish-rs/target/semver-checks/local-varnish_sys-0_5_5-default-01666ec060466c14/target/debug/build/varnish-sys-6e12d260e290572d/out/bindings.rs:10512
  type vcf is no longer Sync, in /tmp/.tmpCyQhA4/varnish-rs/target/semver-checks/local-varnish_sys-0_5_5-default-01666ec060466c14/target/debug/build/varnish-sys-6e12d260e290572d/out/bindings.rs:10512

--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field http_conn.pipeline_snap in /tmp/.tmpCyQhA4/varnish-rs/target/semver-checks/local-varnish_sys-0_5_5-default-01666ec060466c14/target/debug/build/varnish-sys-6e12d260e290572d/out/bindings.rs:10409
  field http_conn.oper in /tmp/.tmpCyQhA4/varnish-rs/target/semver-checks/local-varnish_sys-0_5_5-default-01666ec060466c14/target/debug/build/varnish-sys-6e12d260e290572d/out/bindings.rs:10412
  field http_conn.oper_priv in /tmp/.tmpCyQhA4/varnish-rs/target/semver-checks/local-varnish_sys-0_5_5-default-01666ec060466c14/target/debug/build/varnish-sys-6e12d260e290572d/out/bindings.rs:10413

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function varnish_sys::ffi::VRT_VSC_AllocVariadic, previously in file /tmp/.tmpbh9lKr/varnish-sys/target/semver-checks/local-varnish_sys-0_5_5-default-01666ec060466c14/target/debug/build/varnish-sys-fe367e2712d58abd/out/bindings.rs:9778

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  Backend::vcl_ptr, previously in file /tmp/.tmpbh9lKr/varnish-sys/src/vcl/backend.rs:113

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_method_missing.ron

Failed in:
  method healthy of trait VclBackend, previously in file /tmp/.tmpbh9lKr/varnish-sys/src/vcl/backend.rs:193
  method list_without_probe of trait VclBackend, previously in file /tmp/.tmpbh9lKr/varnish-sys/src/vcl/backend.rs:215
  method list of trait VclBackend, previously in file /tmp/.tmpbh9lKr/varnish-sys/src/vcl/backend.rs:236

--- warning repr_c_plain_struct_fields_reordered: struct fields reordered in repr(C) struct ---

Description:
A public repr(C) struct had its fields reordered. This can change the struct's memory layout, possibly breaking FFI use cases that depend on field position and order.
        ref: https://doc.rust-lang.org/reference/type-layout.html#reprc-structs
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/repr_c_plain_struct_fields_reordered.ron

Failed in:
  http_conn.content_length moved from position 10 to 11, in /tmp/.tmpCyQhA4/varnish-rs/target/semver-checks/local-varnish_sys-0_5_5-default-01666ec060466c14/target/debug/build/varnish-sys-6e12d260e290572d/out/bindings.rs:10410
  http_conn.priv_ moved from position 11 to 12, in /tmp/.tmpCyQhA4/varnish-rs/target/semver-checks/local-varnish_sys-0_5_5-default-01666ec060466c14/target/debug/build/varnish-sys-6e12d260e290572d/out/bindings.rs:10411
  http_conn.first_byte_timeout moved from position 12 to 15, in /tmp/.tmpCyQhA4/varnish-rs/target/semver-checks/local-varnish_sys-0_5_5-default-01666ec060466c14/target/debug/build/varnish-sys-6e12d260e290572d/out/bindings.rs:10414
  http_conn.between_bytes_timeout moved from position 13 to 16, in /tmp/.tmpCyQhA4/varnish-rs/target/semver-checks/local-varnish_sys-0_5_5-default-01666ec060466c14/target/debug/build/varnish-sys-6e12d260e290572d/out/bindings.rs:10415
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `varnish-sys`

<blockquote>

## [0.6.0](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.5.5...varnish-sys-v0.6.0) - 2026-03-23

### Other

- Remove old version support and clean up ([#257](https://github.com/varnish-rs/varnish-rs/pull/257))
- Drop 7.x versions ([#256](https://github.com/varnish-rs/varnish-rs/pull/256))
- Introduce new Backend types ([#246](https://github.com/varnish-rs/varnish-rs/pull/246))
- Support VCL_TIME as vmod arguments and returns ([#242](https://github.com/varnish-rs/varnish-rs/pull/242))
- [clippy] reference as raw pointer ([#255](https://github.com/varnish-rs/varnish-rs/pull/255))
- Update doc bindings ([#254](https://github.com/varnish-rs/varnish-rs/pull/254))
- Trunk support ([#253](https://github.com/varnish-rs/varnish-rs/pull/253))
- Add set_url() method to HttpHeaders ([#250](https://github.com/varnish-rs/varnish-rs/pull/250))
- allow VCL_BLOB arguments as &[u8] ([#239](https://github.com/varnish-rs/varnish-rs/pull/239))
</blockquote>

## `varnish-macros`

<blockquote>

## [0.6.0](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.5.5...varnish-sys-v0.6.0) - 2026-03-23

### Other

- Remove old version support and clean up ([#257](https://github.com/varnish-rs/varnish-rs/pull/257))
- Drop 7.x versions ([#256](https://github.com/varnish-rs/varnish-rs/pull/256))
- Introduce new Backend types ([#246](https://github.com/varnish-rs/varnish-rs/pull/246))
- Support VCL_TIME as vmod arguments and returns ([#242](https://github.com/varnish-rs/varnish-rs/pull/242))
- [clippy] reference as raw pointer ([#255](https://github.com/varnish-rs/varnish-rs/pull/255))
- Update doc bindings ([#254](https://github.com/varnish-rs/varnish-rs/pull/254))
- Trunk support ([#253](https://github.com/varnish-rs/varnish-rs/pull/253))
- Add set_url() method to HttpHeaders ([#250](https://github.com/varnish-rs/varnish-rs/pull/250))
- allow VCL_BLOB arguments as &[u8] ([#239](https://github.com/varnish-rs/varnish-rs/pull/239))
</blockquote>

## `varnish`

<blockquote>

## [0.6.0](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.5.5...varnish-sys-v0.6.0) - 2026-03-23

### Other

- Remove old version support and clean up ([#257](https://github.com/varnish-rs/varnish-rs/pull/257))
- Drop 7.x versions ([#256](https://github.com/varnish-rs/varnish-rs/pull/256))
- Introduce new Backend types ([#246](https://github.com/varnish-rs/varnish-rs/pull/246))
- Support VCL_TIME as vmod arguments and returns ([#242](https://github.com/varnish-rs/varnish-rs/pull/242))
- [clippy] reference as raw pointer ([#255](https://github.com/varnish-rs/varnish-rs/pull/255))
- Update doc bindings ([#254](https://github.com/varnish-rs/varnish-rs/pull/254))
- Trunk support ([#253](https://github.com/varnish-rs/varnish-rs/pull/253))
- Add set_url() method to HttpHeaders ([#250](https://github.com/varnish-rs/varnish-rs/pull/250))
- allow VCL_BLOB arguments as &[u8] ([#239](https://github.com/varnish-rs/varnish-rs/pull/239))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).