### PR TITLE
[internal] cleanup version_after_v6 blocks

### DIFF
--- a/varnish-sys/src/extensions.rs
+++ b/varnish-sys/src/extensions.rs
@@ -1,7 +1,8 @@
 use std::ffi::c_void;
 use std::ptr;
 
-use crate::ffi::{vmod_data, vmod_priv};
+use crate::ffi::{vmod_data, vmod_priv, vmod_priv_methods, vrt_ctx};
+use crate::validate_vrt_ctx;
 use crate::vcl::PerVclState;
 
 /// SAFETY: ensured by Varnish itself
@@ -52,51 +53,42 @@ impl vmod_priv {
     }
 }
 
-mod version_after_v6 {
-    use std::ffi::c_void;
+/// SAFETY: ensured by Varnish itself
+unsafe impl Sync for vmod_priv_methods {}
 
-    use super::get_owned_bbox;
-    use crate::ffi::{vmod_priv, vmod_priv_methods, vrt_ctx};
-    use crate::validate_vrt_ctx;
-    use crate::vcl::PerVclState;
+impl vmod_priv {
+    /// Set the object and methods for the `vmod_priv`, and the corresponding static methods.
+    ///
+    /// SAFETY: The type of `obj` must match the type of the function pointers in `methods`.
+    pub unsafe fn put<T>(&mut self, obj: Box<T>, methods: &'static vmod_priv_methods) {
+        self.priv_ = Box::into_raw(obj).cast();
+        self.methods = methods;
+    }
 
-    /// SAFETY: ensured by Varnish itself
-    unsafe impl Sync for vmod_priv_methods {}
+    /// A Varnish callback function to free a `vmod_priv` object.
+    /// Here we take the ownership and immediately drop the object of type `T`.
+    /// Note that here we get `*priv_` directly, not the `*vmod_priv`
+    ///
+    /// SAFETY: `priv_` must be a valid pointer to a `T` object or `NULL`.
+    pub unsafe extern "C" fn on_fini<T>(_ctx: *const vrt_ctx, mut priv_: *mut c_void) {
+        drop(get_owned_bbox::<T>(&mut priv_));
+    }
 
-    impl vmod_priv {
-        /// Set the object and methods for the `vmod_priv`, and the corresponding static methods.
-        ///
-        /// SAFETY: The type of `obj` must match the type of the function pointers in `methods`.
-        pub unsafe fn put<T>(&mut self, obj: Box<T>, methods: &'static vmod_priv_methods) {
-            self.priv_ = Box::into_raw(obj).cast();
-            self.methods = methods;
-        }
-
-        /// A Varnish callback function to free a `vmod_priv` object.
-        /// Here we take the ownership and immediately drop the object of type `T`.
-        /// Note that here we get `*priv_` directly, not the `*vmod_priv`
-        ///
-        /// SAFETY: `priv_` must be a valid pointer to a `T` object or `NULL`.
-        pub unsafe extern "C" fn on_fini<T>(_ctx: *const vrt_ctx, mut priv_: *mut c_void) {
-            drop(get_owned_bbox::<T>(&mut priv_));
-        }
-
-        /// A Varnish callback function to clean up the `PerVclState` object.
-        /// Similar to `on_fini`, but also unregisters filters.
-        ///
-        /// SAFETY: `priv_` must be a valid pointer to a `T` object or `NULL`.
-        pub unsafe extern "C" fn on_fini_per_vcl<T>(ctx: *const vrt_ctx, mut priv_: *mut c_void) {
-            if let Some(obj) = get_owned_bbox::<PerVclState<T>>(&mut priv_) {
-                let PerVclState {
-                    mut fetch_filters,
-                    mut delivery_filters,
-                    user_data,
-                } = *obj;
-                let ctx = validate_vrt_ctx(ctx);
-                ctx.fetch_filters(&mut fetch_filters).unregister_all();
-                ctx.delivery_filters(&mut delivery_filters).unregister_all();
-                drop(user_data);
-            }
+    /// A Varnish callback function to clean up the `PerVclState` object.
+    /// Similar to `on_fini`, but also unregisters filters.
+    ///
+    /// SAFETY: `priv_` must be a valid pointer to a `T` object or `NULL`.
+    pub unsafe extern "C" fn on_fini_per_vcl<T>(ctx: *const vrt_ctx, mut priv_: *mut c_void) {
+        if let Some(obj) = get_owned_bbox::<PerVclState<T>>(&mut priv_) {
+            let PerVclState {
+                mut fetch_filters,
+                mut delivery_filters,
+                user_data,
+            } = *obj;
+            let ctx = validate_vrt_ctx(ctx);
+            ctx.fetch_filters(&mut fetch_filters).unregister_all();
+            ctx.delivery_filters(&mut delivery_filters).unregister_all();
+            drop(user_data);
         }
     }
 }

--- a/varnish-sys/src/validate.rs
+++ b/varnish-sys/src/validate.rs
@@ -1,7 +1,8 @@
 use crate::ffi::{
-    director, req, sess, vrt_ctx, ws, DIRECTOR_MAGIC, REQ_MAGIC, SESS_MAGIC, VCL_BACKEND,
-    VRT_CTX_MAGIC, WS_MAGIC,
+    self, director, req, sess, vcldir, vfp_ctx, vfp_entry, vrt_ctx, ws, DIRECTOR_MAGIC, REQ_MAGIC,
+    SESS_MAGIC, VCLDIR_MAGIC, VCL_BACKEND, VFP_CTX_MAGIC, VFP_ENTRY_MAGIC, VRT_CTX_MAGIC, WS_MAGIC,
 };
+use crate::vcl::{DeliveryFilters, FetchFilters};
 
 pub unsafe fn validate_vrt_ctx(ctxp: *const vrt_ctx) -> &'static vrt_ctx {
     let val = ctxp.as_ref().unwrap();
@@ -37,48 +38,38 @@ impl req {
     }
 }
 
-pub use version_after_v6::*;
+pub unsafe fn validate_vfp_ctx(ctxp: *mut vfp_ctx) -> &'static mut vfp_ctx {
+    let val = ctxp.as_mut().unwrap();
+    assert_eq!(val.magic, VFP_CTX_MAGIC);
+    val
+}
 
-mod version_after_v6 {
-    use crate::ffi::{
-        self, director, vcldir, vfp_ctx, vfp_entry, vrt_ctx, VCLDIR_MAGIC, VFP_CTX_MAGIC,
-        VFP_ENTRY_MAGIC,
-    };
-    use crate::vcl::{DeliveryFilters, FetchFilters};
+pub unsafe fn validate_vfp_entry(vfep: *mut vfp_entry) -> &'static mut vfp_entry {
+    let val = vfep.as_mut().unwrap();
+    assert_eq!(val.magic, VFP_ENTRY_MAGIC);
+    val
+}
 
-    pub unsafe fn validate_vfp_ctx(ctxp: *mut vfp_ctx) -> &'static mut vfp_ctx {
-        let val = ctxp.as_mut().unwrap();
-        assert_eq!(val.magic, VFP_CTX_MAGIC);
-        val
+pub unsafe fn validate_vdir(be: &director) -> &'static mut vcldir {
+    let val = be.vdir.as_mut().unwrap();
+    assert_eq!(val.magic, VCLDIR_MAGIC);
+    val
+}
+
+impl vrt_ctx {
+    #[expect(clippy::vec_box)] // FIXME: we may want to rethink this
+    pub fn fetch_filters<'c, 'f>(
+        &'c self,
+        filters: &'f mut Vec<Box<ffi::vfp>>,
+    ) -> FetchFilters<'c, 'f> {
+        FetchFilters::<'c, 'f>::new(self, filters)
     }
 
-    pub unsafe fn validate_vfp_entry(vfep: *mut vfp_entry) -> &'static mut vfp_entry {
-        let val = vfep.as_mut().unwrap();
-        assert_eq!(val.magic, VFP_ENTRY_MAGIC);
-        val
-    }
-
-    pub unsafe fn validate_vdir(be: &director) -> &'static mut vcldir {
-        let val = be.vdir.as_mut().unwrap();
-        assert_eq!(val.magic, VCLDIR_MAGIC);
-        val
-    }
-
-    impl vrt_ctx {
-        #[expect(clippy::vec_box)] // FIXME: we may want to rethink this
-        pub fn fetch_filters<'c, 'f>(
-            &'c self,
-            filters: &'f mut Vec<Box<ffi::vfp>>,
-        ) -> FetchFilters<'c, 'f> {
-            FetchFilters::<'c, 'f>::new(self, filters)
-        }
-
-        #[expect(clippy::vec_box)] // FIXME: we may want to rethink this
-        pub fn delivery_filters<'c, 'f>(
-            &'c self,
-            filters: &'f mut Vec<Box<ffi::vdp>>,
-        ) -> DeliveryFilters<'c, 'f> {
-            DeliveryFilters::<'c, 'f>::new(self, filters)
-        }
+    #[expect(clippy::vec_box)] // FIXME: we may want to rethink this
+    pub fn delivery_filters<'c, 'f>(
+        &'c self,
+        filters: &'f mut Vec<Box<ffi::vdp>>,
+    ) -> DeliveryFilters<'c, 'f> {
+        DeliveryFilters::<'c, 'f>::new(self, filters)
     }
 }

--- a/varnish-sys/src/vcl/convert.rs
+++ b/varnish-sys/src/vcl/convert.rs
@@ -52,11 +52,15 @@ use std::ptr::{null, null_mut};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::ffi::{
-    http, vtim_dur, vtim_real, VSA_GetPtr, VSA_Port, PF_INET, PF_INET6, VCL_ACL, VCL_BACKEND,
-    VCL_BLOB, VCL_BODY, VCL_BOOL, VCL_DURATION, VCL_ENUM, VCL_HEADER, VCL_HTTP, VCL_INT, VCL_IP,
-    VCL_PROBE, VCL_REAL, VCL_STEVEDORE, VCL_STRANDS, VCL_STRING, VCL_TIME, VCL_VCL,
+    http, sa_family_t, vsa_suckaddr_len, vtim_dur, vtim_real, VSA_BuildFAP, VSA_GetPtr, VSA_Port,
+    PF_INET, PF_INET6, VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BODY, VCL_BOOL, VCL_DURATION, VCL_ENUM,
+    VCL_HEADER, VCL_HTTP, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL, VCL_REGEX, VCL_STEVEDORE,
+    VCL_STRANDS, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VCL,
 };
-use crate::vcl::{from_vcl_probe, into_vcl_probe, CowProbe, Probe, VclError, Workspace};
+
+use crate::vcl::{
+    from_vcl_probe, into_vcl_probe, BackendRef, CowProbe, Probe, VclError, Workspace,
+};
 
 /// Convert a Rust type into a VCL one
 ///
@@ -410,78 +414,67 @@ default_null_ptr!(mut VCL_VCL);
 // VCL_BACKEND
 default_null_ptr!(VCL_BACKEND);
 
-mod version_after_v6 {
-    use std::ffi::c_void;
-    use std::net::SocketAddr;
-    use std::num::NonZeroUsize;
-    use std::ptr;
-    use std::ptr::null;
+use std::ffi::c_void;
+use std::num::NonZeroUsize;
+use std::ptr;
 
-    use super::IntoVCL;
-    use crate::ffi::{
-        sa_family_t, vsa_suckaddr_len, VSA_BuildFAP, PF_INET, PF_INET6, VCL_BACKEND, VCL_IP,
-        VCL_REGEX, VCL_SUB,
-    };
-    use crate::vcl::{BackendRef, VclError, Workspace};
-
-    impl IntoVCL<VCL_BACKEND> for BackendRef {
-        fn into_vcl(self, _: &mut Workspace) -> Result<VCL_BACKEND, VclError> {
-            unsafe { Ok(self.vcl_ptr()) }
-        }
+impl IntoVCL<VCL_BACKEND> for BackendRef {
+    fn into_vcl(self, _: &mut Workspace) -> Result<VCL_BACKEND, VclError> {
+        unsafe { Ok(self.vcl_ptr()) }
     }
+}
 
-    impl IntoVCL<VCL_BACKEND> for Option<BackendRef> {
-        fn into_vcl(self, _: &mut Workspace) -> Result<VCL_BACKEND, VclError> {
-            unsafe { Ok(self.map_or(VCL_BACKEND(null()), |b: BackendRef| b.vcl_ptr())) }
-        }
+impl IntoVCL<VCL_BACKEND> for Option<BackendRef> {
+    fn into_vcl(self, _: &mut Workspace) -> Result<VCL_BACKEND, VclError> {
+        unsafe { Ok(self.map_or(VCL_BACKEND(null()), |b: BackendRef| b.vcl_ptr())) }
     }
+}
 
-    impl From<VCL_BACKEND> for Option<BackendRef> {
-        fn from(value: VCL_BACKEND) -> Self {
-            unsafe { BackendRef::new(value) }
-        }
+impl From<VCL_BACKEND> for Option<BackendRef> {
+    fn from(value: VCL_BACKEND) -> Self {
+        unsafe { BackendRef::new(value) }
     }
+}
 
-    default_null_ptr!(VCL_SUB);
+default_null_ptr!(VCL_SUB);
 
-    default_null_ptr!(VCL_REGEX);
+default_null_ptr!(VCL_REGEX);
 
-    impl IntoVCL<VCL_IP> for SocketAddr {
-        fn into_vcl(self, ws: &mut Workspace) -> Result<VCL_IP, VclError> {
-            unsafe {
-                // We cannot use sizeof::<suckaddr>() because suckaddr is a zero-sized
-                // struct from Rust's perspective
-                let size = NonZeroUsize::new(vsa_suckaddr_len).unwrap();
-                let p = ws.alloc(size);
-                if p.is_null() {
-                    Err(VclError::WsOutOfMemory(size))?;
-                }
-                match self {
-                    SocketAddr::V4(sa) => {
-                        assert!(!VSA_BuildFAP(
-                            p,
-                            PF_INET as sa_family_t,
-                            sa.ip().octets().as_slice().as_ptr().cast::<c_void>(),
-                            4,
-                            ptr::from_ref::<u16>(&sa.port().to_be()).cast::<c_void>(),
-                            2
-                        )
-                        .is_null());
-                    }
-                    SocketAddr::V6(sa) => {
-                        assert!(!VSA_BuildFAP(
-                            p,
-                            PF_INET6 as sa_family_t,
-                            sa.ip().octets().as_slice().as_ptr().cast::<c_void>(),
-                            16,
-                            ptr::from_ref::<u16>(&sa.port().to_be()).cast::<c_void>(),
-                            2
-                        )
-                        .is_null());
-                    }
-                }
-                Ok(VCL_IP(p.cast()))
+impl IntoVCL<VCL_IP> for SocketAddr {
+    fn into_vcl(self, ws: &mut Workspace) -> Result<VCL_IP, VclError> {
+        unsafe {
+            // We cannot use sizeof::<suckaddr>() because suckaddr is a zero-sized
+            // struct from Rust's perspective
+            let size = NonZeroUsize::new(vsa_suckaddr_len).unwrap();
+            let p = ws.alloc(size);
+            if p.is_null() {
+                Err(VclError::WsOutOfMemory(size))?;
             }
+            match self {
+                SocketAddr::V4(sa) => {
+                    assert!(!VSA_BuildFAP(
+                        p,
+                        PF_INET as sa_family_t,
+                        sa.ip().octets().as_slice().as_ptr().cast::<c_void>(),
+                        4,
+                        ptr::from_ref::<u16>(&sa.port().to_be()).cast::<c_void>(),
+                        2
+                    )
+                    .is_null());
+                }
+                SocketAddr::V6(sa) => {
+                    assert!(!VSA_BuildFAP(
+                        p,
+                        PF_INET6 as sa_family_t,
+                        sa.ip().octets().as_slice().as_ptr().cast::<c_void>(),
+                        16,
+                        ptr::from_ref::<u16>(&sa.port().to_be()).cast::<c_void>(),
+                        2
+                    )
+                    .is_null());
+                }
+            }
+            Ok(VCL_IP(p.cast()))
         }
     }
 }


### PR DESCRIPTION
we can remove one level of nesting now that conditional support for older versions is gone