### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.6.0...varnish-sys-v0.6.1) - 2026-03-25
+
+### Other
+
+- [internal] cleanup version_after_v6 blocks ([#262](https://github.com/varnish-rs/varnish-rs/pull/262))
+
 ## [0.6.0](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.5.5...varnish-sys-v0.6.0) - 2026-03-23
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.6.0...varnish-sys-v0.7.0) - 2026-06-11
+
+### Fixed
+
+- NativeBackendBuilder::tls() now returns self ([#284](https://github.com/varnish-rs/varnish-rs/pull/284))
+
+### Other
+
+- Doc update ([#299](https://github.com/varnish-rs/varnish-rs/pull/299))
+- introduce the SubRoutine to call VCL routines from vmods ([#298](https://github.com/varnish-rs/varnish-rs/pull/298))
+- Introduce NativeBackendBuilder::build_with_vcl() ([#264](https://github.com/varnish-rs/varnish-rs/pull/264))
+- remove impl IntoVCL<VCL_STRING> for &[u8] ([#291](https://github.com/varnish-rs/varnish-rs/pull/291))
+- [convert] Add internal write_ip_to_buf() ([#272](https://github.com/varnish-rs/varnish-rs/pull/272))
+- implement the $Restrict equivalent of the C world ([#278](https://github.com/varnish-rs/varnish-rs/pull/278))
+- Add hash_always_miss and hash_ignore_* functions/ ([#261](https://github.com/varnish-rs/varnish-rs/pull/261))
+- implement weaken_etag() ([#281](https://github.com/varnish-rs/varnish-rs/pull/281))
+- remove all unwrap() calls ([#282](https://github.com/varnish-rs/varnish-rs/pull/282))
+- Fix/267 tls enable flag ([#288](https://github.com/varnish-rs/varnish-rs/pull/288))
+- use #[allow(non_snake_case)]  ([#287](https://github.com/varnish-rs/varnish-rs/pull/287))
+- Add local_socket support to the VCL context ([#285](https://github.com/varnish-rs/varnish-rs/pull/285))
+- add test for blob_copy ([#279](https://github.com/varnish-rs/varnish-rs/pull/279))
+- [internal] cleanup version_after_v6 blocks ([#262](https://github.com/varnish-rs/varnish-rs/pull/262))
+
 ## [0.6.0](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.5.5...varnish-sys-v0.6.0) - 2026-03-23
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["varnish", "varnish-macros", "varnish-sys", "varnish/tests/vmod_test"
 
 [workspace.package]
 # These fields are used by multiple crates, so it's defined here.
-version = "0.6.0"
+version = "0.6.1"
 repository = "https://github.com/varnish-rs/varnish-rs"
 edition = "2021"
 rust-version = "1.90.0"
@@ -17,9 +17,9 @@ readme = "README.md"
 
 [workspace.dependencies]
 # These versions should match the package.version above, and will be updated by release-plz.
-varnish = { path = "./varnish", version = "0.6.0" }
-varnish-macros = { path = "./varnish-macros", version = "0.6.0" }
-varnish-sys = { path = "./varnish-sys", version = "0.6.0" }
+varnish = { path = "./varnish", version = "0.6.1" }
+varnish-macros = { path = "./varnish-macros", version = "0.6.1" }
+varnish-sys = { path = "./varnish-sys", version = "0.6.1" }
 #
 # These dependencies are used by one or more crates, and easier to maintain in one place.
 bindgen_helpers = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["varnish", "varnish-macros", "varnish-sys", "varnish/tests/vmod_test"
 
 [workspace.package]
 # These fields are used by multiple crates, so it's defined here.
-version = "0.6.0"
+version = "0.7.0"
 repository = "https://github.com/varnish-rs/varnish-rs"
 edition = "2021"
 rust-version = "1.90.0"
@@ -17,9 +17,9 @@ readme = "README.md"
 
 [workspace.dependencies]
 # These versions should match the package.version above, and will be updated by release-plz.
-varnish = { path = "./varnish", version = "0.6.0" }
-varnish-macros = { path = "./varnish-macros", version = "0.6.0" }
-varnish-sys = { path = "./varnish-sys", version = "0.6.0" }
+varnish = { path = "./varnish", version = "0.7.0" }
+varnish-macros = { path = "./varnish-macros", version = "0.7.0" }
+varnish-sys = { path = "./varnish-sys", version = "0.7.0" }
 #
 # These dependencies are used by one or more crates, and easier to maintain in one place.
 bindgen_helpers = "0.6.1"


### PR DESCRIPTION



## 🤖 New release

* `varnish-sys`: 0.6.0 -> 0.7.0 (⚠ API breaking changes)
* `varnish-macros`: 0.6.0 -> 0.7.0
* `varnish`: 0.6.0 -> 0.7.0 (⚠ API breaking changes)

### ⚠ `varnish-sys` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type VCL_conf is no longer Send, in /tmp/.tmpE0r5TH/varnish-rs/target/semver-checks/local-varnish_sys-0_6_0-x86_64_unknown_linux_gnu-d86aa6e83e9a1f7c/target/debug/build/varnish-sys-ee2ed63872edca17/out/bindings.rs:13433
  type VCL_conf is no longer Sync, in /tmp/.tmpE0r5TH/varnish-rs/target/semver-checks/local-varnish_sys-0_6_0-x86_64_unknown_linux_gnu-d86aa6e83e9a1f7c/target/debug/build/varnish-sys-ee2ed63872edca17/out/bindings.rs:13433

--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field Ctx.req in /tmp/.tmpE0r5TH/varnish-rs/varnish-sys/src/vcl/ctx.rs:42

--- failure method_receiver_mut_ref_became_owned: method receiver changed from mutable reference to owned value ---

Description:
A method's receiver changed from a mutable reference to an owned value. Ownership is transferred as part of the call, which is a breaking change.
        ref: https://doc.rust-lang.org/reference/items/associated-items.html#methods
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_receiver_mut_ref_became_owned.ron

Failed in:
  varnish_sys::vcl::NativeBackendBuilder::proxy_v1 now takes Self, not &mut Self, in /tmp/.tmpE0r5TH/varnish-rs/varnish-sys/src/vcl/backend/backend_main.rs:482
  varnish_sys::vcl::NativeBackendBuilder::proxy_v2 now takes Self, not &mut Self, in /tmp/.tmpE0r5TH/varnish-rs/varnish-sys/src/vcl/backend/backend_main.rs:489
```

### ⚠ `varnish` breaking changes

```text
--- failure declarative_macro_missing: macro_rules declaration removed or renamed ---

Description:
A `macro_rules!` declarative macro cannot be invoked by its prior name. The macro may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/reference/macros-by-example.html#path-based-scope
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/declarative_macro_missing.ron

Failed in:
  macro run_vtc_tests, previously in file /tmp/.tmp0noYSb/varnish/src/lib.rs:130
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `varnish-sys`

<blockquote>

## [0.7.0](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.6.0...varnish-sys-v0.7.0) - 2026-06-11

### Fixed

- NativeBackendBuilder::tls() now returns self ([#284](https://github.com/varnish-rs/varnish-rs/pull/284))

### Other

- Doc update ([#299](https://github.com/varnish-rs/varnish-rs/pull/299))
- introduce the SubRoutine to call VCL routines from vmods ([#298](https://github.com/varnish-rs/varnish-rs/pull/298))
- Introduce NativeBackendBuilder::build_with_vcl() ([#264](https://github.com/varnish-rs/varnish-rs/pull/264))
- remove impl IntoVCL<VCL_STRING> for &[u8] ([#291](https://github.com/varnish-rs/varnish-rs/pull/291))
- [convert] Add internal write_ip_to_buf() ([#272](https://github.com/varnish-rs/varnish-rs/pull/272))
- implement the $Restrict equivalent of the C world ([#278](https://github.com/varnish-rs/varnish-rs/pull/278))
- Add hash_always_miss and hash_ignore_* functions/ ([#261](https://github.com/varnish-rs/varnish-rs/pull/261))
- implement weaken_etag() ([#281](https://github.com/varnish-rs/varnish-rs/pull/281))
- remove all unwrap() calls ([#282](https://github.com/varnish-rs/varnish-rs/pull/282))
- Fix/267 tls enable flag ([#288](https://github.com/varnish-rs/varnish-rs/pull/288))
- use #[allow(non_snake_case)]  ([#287](https://github.com/varnish-rs/varnish-rs/pull/287))
- Add local_socket support to the VCL context ([#285](https://github.com/varnish-rs/varnish-rs/pull/285))
- add test for blob_copy ([#279](https://github.com/varnish-rs/varnish-rs/pull/279))
- [internal] cleanup version_after_v6 blocks ([#262](https://github.com/varnish-rs/varnish-rs/pull/262))
</blockquote>

## `varnish-macros`

<blockquote>

## [0.7.0](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.6.0...varnish-sys-v0.7.0) - 2026-06-11

### Fixed

- NativeBackendBuilder::tls() now returns self ([#284](https://github.com/varnish-rs/varnish-rs/pull/284))

### Other

- Doc update ([#299](https://github.com/varnish-rs/varnish-rs/pull/299))
- introduce the SubRoutine to call VCL routines from vmods ([#298](https://github.com/varnish-rs/varnish-rs/pull/298))
- Introduce NativeBackendBuilder::build_with_vcl() ([#264](https://github.com/varnish-rs/varnish-rs/pull/264))
- remove impl IntoVCL<VCL_STRING> for &[u8] ([#291](https://github.com/varnish-rs/varnish-rs/pull/291))
- [convert] Add internal write_ip_to_buf() ([#272](https://github.com/varnish-rs/varnish-rs/pull/272))
- implement the $Restrict equivalent of the C world ([#278](https://github.com/varnish-rs/varnish-rs/pull/278))
- Add hash_always_miss and hash_ignore_* functions/ ([#261](https://github.com/varnish-rs/varnish-rs/pull/261))
- implement weaken_etag() ([#281](https://github.com/varnish-rs/varnish-rs/pull/281))
- remove all unwrap() calls ([#282](https://github.com/varnish-rs/varnish-rs/pull/282))
- Fix/267 tls enable flag ([#288](https://github.com/varnish-rs/varnish-rs/pull/288))
- use #[allow(non_snake_case)]  ([#287](https://github.com/varnish-rs/varnish-rs/pull/287))
- Add local_socket support to the VCL context ([#285](https://github.com/varnish-rs/varnish-rs/pull/285))
- add test for blob_copy ([#279](https://github.com/varnish-rs/varnish-rs/pull/279))
- [internal] cleanup version_after_v6 blocks ([#262](https://github.com/varnish-rs/varnish-rs/pull/262))
</blockquote>

## `varnish`

<blockquote>

## [0.7.0](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.6.0...varnish-sys-v0.7.0) - 2026-06-11

### Fixed

- NativeBackendBuilder::tls() now returns self ([#284](https://github.com/varnish-rs/varnish-rs/pull/284))

### Other

- Doc update ([#299](https://github.com/varnish-rs/varnish-rs/pull/299))
- introduce the SubRoutine to call VCL routines from vmods ([#298](https://github.com/varnish-rs/varnish-rs/pull/298))
- Introduce NativeBackendBuilder::build_with_vcl() ([#264](https://github.com/varnish-rs/varnish-rs/pull/264))
- remove impl IntoVCL<VCL_STRING> for &[u8] ([#291](https://github.com/varnish-rs/varnish-rs/pull/291))
- [convert] Add internal write_ip_to_buf() ([#272](https://github.com/varnish-rs/varnish-rs/pull/272))
- implement the $Restrict equivalent of the C world ([#278](https://github.com/varnish-rs/varnish-rs/pull/278))
- Add hash_always_miss and hash_ignore_* functions/ ([#261](https://github.com/varnish-rs/varnish-rs/pull/261))
- implement weaken_etag() ([#281](https://github.com/varnish-rs/varnish-rs/pull/281))
- remove all unwrap() calls ([#282](https://github.com/varnish-rs/varnish-rs/pull/282))
- Fix/267 tls enable flag ([#288](https://github.com/varnish-rs/varnish-rs/pull/288))
- use #[allow(non_snake_case)]  ([#287](https://github.com/varnish-rs/varnish-rs/pull/287))
- Add local_socket support to the VCL context ([#285](https://github.com/varnish-rs/varnish-rs/pull/285))
- add test for blob_copy ([#279](https://github.com/varnish-rs/varnish-rs/pull/279))
- [internal] cleanup version_after_v6 blocks ([#262](https://github.com/varnish-rs/varnish-rs/pull/262))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).