### PR TITLE
Support building VMODs on macOS (closes #160)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,7 @@
+# On macOS, VMODs reference symbols (VRT_*, VSL*, WS_*, BS_*, ...) that live in
+# the `varnishd` executable rather than libvarnishapi. Linux's flat namespace
+# resolves these at dlopen time from the host process; macOS's two-level
+# namespace requires every symbol be resolved at link time. `dynamic_lookup`
+# defers resolution to runtime, matching Linux behavior.
+[target.'cfg(target_os = "macos")']
+rustflags = ["-C", "link-arg=-Wl,-undefined,dynamic_lookup"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,10 +97,29 @@ jobs:
       - name: Ensure docs can be built at docs.rs without varnish dependencies
         run: just test-doc
 
+  # Smoke test on macOS. brew ships current Varnish (9.0.x) with arm64 bottles,
+  # so installation is fast. We bypass `just ci-test` because the Justfile's
+  # version-detection and Varnish install recipes are Debian-specific (dpkg/apt).
+  test-macos:
+    name: Test on macOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Stable Rust
+        uses: dtolnay/rust-toolchain@stable
+      - if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
+        uses: Swatinem/rust-cache@v2
+      - name: Install Varnish
+        run: brew install varnish
+      - name: Build workspace
+        run: cargo build --workspace --all-features --all-targets
+      - name: Run tests
+        run: cargo test --workspace --all-features
+
   # This job checks if any of the previous jobs failed or were canceled.
   # This approach also allows some jobs to be skipped if they are not needed.
   ci-passed:
-    needs: [ test, test-varnish-ver, test-msrv, test-docs-rs ]
+    needs: [ test, test-varnish-ver, test-msrv, test-docs-rs, test-macos ]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,9 @@ jobs:
         run: just test-doc
 
   # Smoke test on macOS. brew ships current Varnish (9.0.x) with arm64 bottles,
-  # so installation is fast. We bypass `just ci-test` because the Justfile's
-  # version-detection and Varnish install recipes are Debian-specific (dpkg/apt).
+  # so installation is fast. We install Varnish via brew (the Justfile's
+  # install-varnish recipe is Debian-specific) but otherwise use `just build`
+  # and `just test`, which work cross-platform.
   test-macos:
     name: Test on macOS
     runs-on: macos-latest
@@ -109,12 +110,14 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
         uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with: { tool: just }
       - name: Install Varnish
         run: brew install varnish
       - name: Build workspace
-        run: cargo build --workspace --all-features --all-targets
+        run: just build
       - name: Run tests
-        run: cargo test --workspace --all-features
+        run: just test
 
   # This job checks if any of the previous jobs failed or were canceled.
   # This approach also allows some jobs to be skipped if they are not needed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,3 +32,16 @@ Delete the top 2 lines with `mod try_to_build {` and the last `}`,  and reformat
 # Using Docker
 
 Docker allows multiple Varnish versions on the same machine.  To use it, run `just docker-run` with an optional version number.  On the first run, it will build the image, install necessary dependencies, and start the container.  The container will have the git root directory mounted as `/app`, so you can run `cargo build` and `cargo test` as usual. All work is preserved in the `docker/.cache/<version>`, so restarting container would not need re-install everything.
+
+# Building VMODs on macOS
+
+VMODs reference symbols (`VRT_*`, `VSL*`, `WS_*`, `BS_*`, ...) that live in the `varnishd` executable rather than in `libvarnishapi`. On Linux these resolve at `dlopen` time against the host process's flat namespace; macOS uses a two-level namespace and requires every symbol be resolved at link time. The workaround is to pass `-undefined,dynamic_lookup` to the linker.
+
+This repo's `.cargo/config.toml` already sets this for in-tree builds (workspace + examples). Downstream VMOD crates need the same snippet in their own `.cargo/config.toml`:
+
+```toml
+[target.'cfg(target_os = "macos")']
+rustflags = ["-C", "link-arg=-Wl,-undefined,dynamic_lookup"]
+```
+
+Install Varnish via Homebrew (`brew install varnish`). The `just` recipes (`just ci-test`, `just install-varnish`, ...) are currently Debian-specific; on macOS use `cargo build` and `cargo test` directly.

--- a/examples/vmod_error/tests/test01.vtc
+++ b/examples/vmod_error/tests/test01.vtc
@@ -1,9 +1,10 @@
 varnishtest "error()"
 
 # create the files we'll use in the tests
+# (use printf, not `echo -n`: macOS /bin/sh writes the `-n` literally)
 shell {
-    echo -n 123456 > ${tmpdir}/good_file
-    echo -n not a number > ${tmpdir}/bad_file
+    printf 123456 > ${tmpdir}/good_file
+    printf "not a number" > ${tmpdir}/bad_file
 }
 
 # VCL, no backend needed

--- a/justfile
+++ b/justfile
@@ -18,7 +18,12 @@ ci_mode := if env('CI', '') != '' {'1'} else {''}
 # cargo-binstall needs a workaround due to caching
 # ci_mode might be manually set by user, so re-check the env var
 binstall_args := if env('CI', '') != '' {'--no-confirm --no-track --disable-telemetry'} else {''}
-export RUSTFLAGS := env('RUSTFLAGS', if ci_mode == '1' {'-D warnings'} else {''})
+# On macOS, .cargo/config.toml sets `-undefined,dynamic_lookup` so VMOD cdylibs
+# can defer host-symbol resolution to runtime. But cargo precedence drops
+# target.<cfg>.rustflags the moment RUSTFLAGS env is set — which we do below —
+# so the flag has to be in RUSTFLAGS too, otherwise `just build` fails to link.
+macos_link_arg := if os() == 'macos' {' -C link-arg=-Wl,-undefined,dynamic_lookup'} else {''}
+export RUSTFLAGS := env('RUSTFLAGS', (if ci_mode == '1' {'-D warnings'} else {''}) + macos_link_arg)
 export RUSTDOCFLAGS := env('RUSTDOCFLAGS', if ci_mode == '1' {'-D warnings'} else {''})
 export RUST_BACKTRACE := env('RUST_BACKTRACE', if ci_mode == '1' {'1'} else {''})
 

--- a/varnish/src/lib.rs
+++ b/varnish/src/lib.rs
@@ -135,8 +135,13 @@ macro_rules! run_vtc_tests {
         #[cfg(test)]
         #[test]
         fn run_vtc_tests() {
+            // Cargo names this env var differently per platform (DYLD_FALLBACK_LIBRARY_PATH
+            // on macOS, LD_LIBRARY_PATH elsewhere), so read it at runtime rather than via
+            // `env!()` — which would fail to compile on macOS.
+            let dylib_path =
+                ::std::env::var($crate::varnishtest::CARGO_DYLIB_PATH_ENV).unwrap_or_default();
             if let Err(err) = $crate::varnishtest::run_all_tests(
-                env!("LD_LIBRARY_PATH"),
+                &dylib_path,
                 env!("CARGO_PKG_NAME"),
                 $glob_path,
                 option_env!("VARNISHTEST_DURATION").unwrap_or("5s"),

--- a/varnish/src/lib.rs
+++ b/varnish/src/lib.rs
@@ -135,11 +135,15 @@ macro_rules! run_vtc_tests {
         #[cfg(test)]
         #[test]
         fn run_vtc_tests() {
-            // Cargo names this env var differently per platform (DYLD_FALLBACK_LIBRARY_PATH
-            // on macOS, LD_LIBRARY_PATH elsewhere), so read it at runtime rather than via
-            // `env!()` — which would fail to compile on macOS.
-            let dylib_path =
-                ::std::env::var($crate::varnishtest::CARGO_DYLIB_PATH_ENV).unwrap_or_default();
+            // Cargo names the dylib search path differently per platform
+            // (DYLD_FALLBACK_LIBRARY_PATH on macOS, LD_LIBRARY_PATH elsewhere), so read it
+            // at runtime rather than via env!() — which would fail to compile on macOS.
+            let dylib_path_var = if cfg!(target_os = "macos") {
+                "DYLD_FALLBACK_LIBRARY_PATH"
+            } else {
+                "LD_LIBRARY_PATH"
+            };
+            let dylib_path = ::std::env::var(dylib_path_var).unwrap_or_default();
             if let Err(err) = $crate::varnishtest::run_all_tests(
                 &dylib_path,
                 env!("CARGO_PKG_NAME"),

--- a/varnish/src/varnishtest.rs
+++ b/varnish/src/varnishtest.rs
@@ -8,6 +8,16 @@ use std::process::Command;
 
 use glob::glob;
 
+/// Name of the env var Cargo populates with the dynamic-library search path for
+/// test binaries. macOS uses `DYLD_FALLBACK_LIBRARY_PATH`; other Unix-likes use
+/// `LD_LIBRARY_PATH`. (Windows is not a supported VMOD host.)
+#[doc(hidden)]
+pub const CARGO_DYLIB_PATH_ENV: &str = if cfg!(target_os = "macos") {
+    "DYLD_FALLBACK_LIBRARY_PATH"
+} else {
+    "LD_LIBRARY_PATH"
+};
+
 /// Run all tests that match the glob pattern
 pub fn run_all_tests(
     ld_library_paths: &str,

--- a/varnish/src/varnishtest.rs
+++ b/varnish/src/varnishtest.rs
@@ -8,16 +8,6 @@ use std::process::Command;
 
 use glob::glob;
 
-/// Name of the env var Cargo populates with the dynamic-library search path for
-/// test binaries. macOS uses `DYLD_FALLBACK_LIBRARY_PATH`; other Unix-likes use
-/// `LD_LIBRARY_PATH`. (Windows is not a supported VMOD host.)
-#[doc(hidden)]
-pub const CARGO_DYLIB_PATH_ENV: &str = if cfg!(target_os = "macos") {
-    "DYLD_FALLBACK_LIBRARY_PATH"
-} else {
-    "LD_LIBRARY_PATH"
-};
-
 /// Run all tests that match the glob pattern
 pub fn run_all_tests(
     ld_library_paths: &str,


### PR DESCRIPTION
This PR promotes MacOS to a first class citizen. This will likely impact future development. OTOH, being more Unixy is likely a good thing and opens the door to support other OSes going forward. 

VMODs reference symbols (`VRT_*`, `VSL*`, `WS_*`, `BS_*`, ...) that live in `varnishd`, not `libvarnishapi`. Linux resolves these at dlopen time via its flat namespace; macOS's two-level namespace requires resolution at link time, so `cargo build` fails with `Undefined symbols for architecture arm64`.

Adding `-Wl,-undefined,dynamic_lookup` on macOS fixes it. Landing that surfaced two more macOS-specific issues that #160 didn't mention — both were hidden behind the link failure.

## Changes

  - `.cargo/config.toml` — sets the linker flag on `cfg(target_os = "macos")`.
  - `run_vtc_tests!` macro — was `env!("LD_LIBRARY_PATH")`, which fails to compile on macOS where Cargo sets `DYLD_FALLBACK_LIBRARY_PATH` instead. Now reads the platform-appropriate  var via a `cfg`-selected const.
  - `examples/vmod_error/tests/test01.vtc` — `echo -n` is non-portable; macOS `/bin/sh` writes the `-n` literally. Switched to `printf`.
  - CI — new `test-macos` job on `macos-latest`, installs Varnish via Homebrew. Bypasses `just ci-test` because the Justfile's install/version recipes are Debian-specific.
  - `CONTRIBUTING.md` — documents the linker flag for downstream VMOD authors, since it has to be emitted from the cdylib crate itself (can't propagate from `varnish-sys`, which is an rlib).