### PR TITLE
use #[allow(non_snake_case)] 

### DIFF
--- a/varnish-sys/src/lib.rs
+++ b/varnish-sys/src/lib.rs
@@ -3,6 +3,7 @@ extern crate core;
 // FIXME: `improper_ctypes` should be `expected`
 //    but a nightly version is having issues with it
 #[allow(improper_ctypes)]
+#[allow(non_snake_case)]
 #[expect(non_camel_case_types, non_upper_case_globals, unused_qualifications)]
 #[expect(
     clippy::approx_constant,


### PR DESCRIPTION
fix(varnish-sys): use #[allow(non_snake_case)] for platform-dependent bindgen output

On macOS, libc headers define _mbstateL which triggers non_snake_case. On Linux, no such identifier exists. #[expect] can't handle this because the lint's presence depends on the host platform's libc headers, not the source in this crate.

#[allow] is silent on both platforms regardless of whether the lint fires.

Fixes #275