### PR TITLE
fix(backend): deregister director on VCL_EVENT_DISCARD

### DIFF
--- a/examples/vmod_be/README.md
+++ b/examples/vmod_be/README.md
@@ -27,3 +27,13 @@ it only needs two functions:
 - `backend()`, so that we can produce a C pointer for varnish to use
 
 #### Method `BACKEND <object>.backend()`
+
+### Constructor `be.leaky_parrot(STRING to_repeat)`
+
+`leaky_parrot` wraps its [`Backend`] in `ManuallyDrop` so the per-VCL
+fini does NOT drop the Backend. The director must therefore be
+deregistered via the `VCL_EVENT_DISCARD` event handler, not via `Drop`.
+
+This is the test harness for the vcl_KillBackends assertion fix.
+
+#### Method `BACKEND <object>.backend()`

--- a/examples/vmod_be/src/lib.rs
+++ b/examples/vmod_be/src/lib.rs
@@ -1,3 +1,5 @@
+use std::mem::ManuallyDrop;
+
 use varnish::vcl::{Backend, Ctx, VclBackend, VclError, VclResponse};
 
 varnish::run_vtc_tests!("tests/*.vtc");
@@ -7,13 +9,25 @@ struct parrot {
     backend: Backend<ParrotBackend, ResponseBody>,
 }
 
+/// A `parrot` variant whose [`Backend`] is wrapped in `ManuallyDrop` so the
+/// per-VCL fini cannot drop it. This deliberately reproduces the production
+/// pattern (e.g. ghost storing backends inside `Arc`s that outlive the fini
+/// callback) that triggers the `vcl_KillBackends()` assertion when the
+/// director's `VCL_EVENT_DISCARD` handler is not wired to `VRT_DelDirector`.
+#[allow(non_camel_case_types)]
+struct leaky_parrot {
+    backend: ManuallyDrop<Backend<ParrotBackend, ResponseBody>>,
+}
+
 /// a simple STRING dictionary in your VCL
 #[varnish::vmod(docs = "README.md")]
 mod be {
     use varnish::ffi::VCL_BACKEND;
     use varnish::vcl::{Backend, Ctx, VclError};
 
-    use super::{parrot, ParrotBackend};
+    use std::mem::ManuallyDrop;
+
+    use super::{leaky_parrot, parrot, ParrotBackend};
 
     /// parrot is our VCL object, which just holds a rust Backend,
     /// it only needs two functions:
@@ -42,6 +56,37 @@ mod be {
             )?;
 
             Ok(parrot { backend })
+        }
+
+        pub unsafe fn backend(&self) -> VCL_BACKEND {
+            self.backend.as_ref().vcl_ptr()
+        }
+    }
+
+    /// `leaky_parrot` wraps its [`Backend`] in `ManuallyDrop` so the per-VCL
+    /// fini does NOT drop the Backend. The director must therefore be
+    /// deregistered via the `VCL_EVENT_DISCARD` event handler, not via `Drop`.
+    ///
+    /// This is the test harness for the vcl_KillBackends assertion fix.
+    impl leaky_parrot {
+        pub fn new(
+            ctx: &mut Ctx,
+            #[vcl_name] name: &str,
+            to_repeat: &str,
+        ) -> Result<Self, VclError> {
+            let backend = Backend::new(
+                ctx,
+                "leaky_parrot",
+                name,
+                ParrotBackend {
+                    data: Vec::from(to_repeat),
+                },
+                false,
+            )?;
+
+            Ok(leaky_parrot {
+                backend: ManuallyDrop::new(backend),
+            })
         }
 
         pub unsafe fn backend(&self) -> VCL_BACKEND {

--- a/examples/vmod_be/tests/test02.vtc
+++ b/examples/vmod_be/tests/test02.vtc
@@ -1,0 +1,62 @@
+varnishtest "Backend deregisters on VCL discard when Drop doesn't run"
+
+# Regression test for the panic
+#   "Assert error in vcl_KillBackends(), cache/cache_vcl.c line 704:"
+#   "Condition(VTAILQ_EMPTY(&vdire->directors)) not true."
+#
+# Custom backends added via `Backend::new` / `Director::new` get registered with
+# `VRT_AddDirector` but were only deregistered from Backend::drop / Director::drop.
+# When the per-VCL VMOD object that owns the Backend is destroyed inside VCL_EVENT_DISCARD
+# (the normal teardown path), Drop runs in time and everything works. But when the
+# Backend lives behind an `Arc` (or any reference that outlives the per-VCL fini)
+# — the way ghost stores backends in a shared `BackendPool` — Backend::drop never
+# runs in time, the director stays on `vdire->directors`, and `vcl_KillBackends`'s
+# trailing `assert(VTAILQ_EMPTY(&vdire->directors))` panics the child.
+#
+# To reproduce that deterministically without dragging in extra dependencies,
+# `leaky_parrot` parks its Backend in a process-wide `OnceLock<Mutex<Vec<…>>>`,
+# so the per-VCL fini cannot drop it. The only way the director gets removed
+# from the list is the `wrap_event` callback acting on VCL_EVENT_DISCARD.
+
+server s1 {} -start
+
+varnish v1 -vcl+backend {
+    import be from "${vmod}";
+
+    sub vcl_init {
+        new leaky = be.leaky_parrot("doesn't matter");
+    }
+
+    sub vcl_recv {
+        set req.backend_hint = leaky.backend();
+        return (pass);
+    }
+} -start
+
+# Sanity check that the backend wires up.
+client c1 {
+    txreq
+    rxresp
+    expect resp.body == "doesn't matter"
+} -run
+
+# Swap to a different VCL and discard the first. The discard triggers
+# vcl_KillBackends → VCL_EVENT_DISCARD on the leaky_parrot director, which
+# must call VRT_DelDirector synchronously or the assertion at
+# cache_vcl.c:704 fires.
+varnish v1 -cliok {vcl.inline plain "vcl 4.1; backend default none;"}
+varnish v1 -cliok "vcl.use plain"
+varnish v1 -cliok "vcl.discard vcl1"
+
+# Force VCL_Poll on the next CLI command, which actually runs vcl_KillBackends.
+varnish v1 -cliok "backend.list"
+
+# Confirm the worker is still alive: if discard had panicked, the child would
+# be down and the next request would not get a clean 503.
+client c2 {
+    txreq
+    rxresp
+    expect resp.status == 503
+} -run
+
+varnish v1 -expect MAIN.client_req >= 2

--- a/varnish-sys/src/vcl/backend/backend_main.rs
+++ b/varnish-sys/src/vcl/backend/backend_main.rs
@@ -5,6 +5,7 @@ use std::net::{SocketAddr, TcpStream};
 use std::os::unix::io::FromRawFd;
 use std::ptr;
 use std::ptr::{null, null_mut};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::SystemTime;
 
 use crate::ffi::{VclEvent, VfpStatus, VCL_BACKEND, VCL_BOOL, VCL_IP, VCL_TIME};
@@ -45,6 +46,25 @@ pub struct NativeVclResponseShim;
 
 impl VclResponse for NativeVclResponseShim {}
 
+/// Storage for the user's [`VclBackend`] implementation, paired with a flag
+/// tracking whether the director has been deregistered from VCL.
+///
+/// Lives behind a `Box` so its address is stable for the C side: a raw pointer
+/// to a `BackendShim<S>` is what we hand to `VRT_AddDirector` as the director's
+/// `priv_`. Because the struct is `#[repr(C)]` with `inner` as the first field,
+/// the same pointer can be read back as `*const S` (this is what
+/// [`get_backend`] relies on).
+///
+/// The `deregistered` flag is set when `VCL_EVENT_DISCARD` synchronously calls
+/// `VRT_DelDirector` from [`wrap_event`]; [`Backend::drop`] checks it to avoid
+/// a double-`VRT_DelDirector`.
+#[repr(C)]
+#[derive(Debug)]
+pub(super) struct BackendShim<S> {
+    pub(super) inner: S,
+    pub(super) deregistered: AtomicBool,
+}
+
 /// Fat wrapper around [`VCL_BACKEND`].
 ///
 /// It will handle almost all the necessary boilerplate needed to create a custom backend. Most importantly,
@@ -59,7 +79,7 @@ impl VclResponse for NativeVclResponseShim {}
 pub struct Backend<S: VclBackend<T>, T: VclResponse> {
     #[expect(dead_code)]
     methods: Box<ffi::vdi_methods>,
-    inner: Box<S>,
+    inner: Box<BackendShim<S>>,
     #[expect(dead_code)]
     ctype: CString,
     phantom: PhantomData<T>,
@@ -72,7 +92,7 @@ impl<S: VclBackend<T>, T: VclResponse> Backend<S, T> {
     /// Access the inner type wrapped by [Backend]. Note that it isn't `mut` as other threads are
     /// likely to have access to it too.
     pub fn get_inner(&self) -> &S {
-        &self.inner
+        &self.inner.inner
     }
 
     /// Create a new builder, wrapping the `inner` structure (that implements [`VclBackend`]),
@@ -85,7 +105,10 @@ impl<S: VclBackend<T>, T: VclResponse> Backend<S, T> {
         be: S,
         has_probe: bool,
     ) -> VclResult<Self> {
-        let mut inner = Box::new(be);
+        let mut inner = Box::new(BackendShim {
+            inner: be,
+            deregistered: AtomicBool::new(false),
+        });
         let ctype: CString = CString::new(backend_type).map_err(|e| e.to_string())?;
         let cname: CString = CString::new(backend_id).map_err(|e| e.to_string())?;
         let methods = Box::new(ffi::vdi_methods {
@@ -104,11 +127,15 @@ impl<S: VclBackend<T>, T: VclResponse> Backend<S, T> {
             release: None,
         });
 
+        // The C side stores a raw pointer to the BackendShim as the director's priv_.
+        // Because BackendShim is #[repr(C)] with `inner: S` first, the same pointer
+        // can be read back as either &BackendShim<S> (by wrap_event) or &S (by
+        // get_backend / the other wrap_* callbacks).
         let bep = unsafe {
             ffi::VRT_AddDirector(
                 ctx.raw,
                 &raw const *methods,
-                ptr::from_mut::<S>(&mut *inner).cast::<c_void>(),
+                ptr::from_mut::<BackendShim<S>>(&mut *inner).cast::<c_void>(),
                 c"%.*s".as_ptr(),
                 cname.as_bytes().len(),
                 cname.as_ptr().cast::<c_char>(),
@@ -252,11 +279,16 @@ impl VclResponse for () {
 
 impl<S: VclBackend<T>, T: VclResponse> Drop for Backend<S, T> {
     fn drop(&mut self) {
+        // For VclBackend-backed directors, wrap_event already calls VRT_DelDirector when
+        // VCL_EVENT_DISCARD fires (the normal teardown path: the per-VCL VMOD object that
+        // owns us is dropped *after* vcl_KillBackends has run). Only fall through to
+        // VRT_DelDirector here if that didn't happen — e.g. the Backend was dropped before
+        // the VCL was discarded.
         unsafe {
             let mut bep = self.backend_ref.vcl_ptr();
             if self.native_configuration.is_some() {
                 ffi::VRT_delete_backend(null(), &raw mut bep);
-            } else {
+            } else if !self.inner.deregistered.swap(true, Ordering::AcqRel) {
                 ffi::VRT_DelDirector(&raw mut bep);
             }
         };
@@ -590,7 +622,10 @@ impl<'a> NativeBackendBuilder<'a> {
 
         Ok(Backend {
             methods,
-            inner: Box::new(NativeVclBackendShim),
+            inner: Box::new(BackendShim {
+                inner: NativeVclBackendShim,
+                deregistered: AtomicBool::new(false),
+            }),
             ctype: CString::new("native").expect("\"native\" is a valid C string"),
             phantom: PhantomData,
             backend_ref,
@@ -648,8 +683,26 @@ unsafe extern "C" fn vfp_pull<T: VclResponse>(
 }
 
 unsafe extern "C" fn wrap_event<S: VclBackend<T>, T: VclResponse>(be: VCL_BACKEND, ev: VclEvent) {
-    let backend: &S = get_backend(validate_director(be));
-    backend.event(ev);
+    let dir = validate_director(be);
+    let shim = dir
+        .priv_
+        .cast::<BackendShim<S>>()
+        .as_ref()
+        .expect("backend priv_ pointer is null");
+    shim.inner.event(ev);
+
+    // Varnish (and especially vinyld) requires that on VCL_EVENT_DISCARD the director
+    // is removed from `vdire->directors` synchronously inside the event callback. The
+    // canonical built-in backend handler (`vbe_dir_event`) does this via `VRT_DelDirector`;
+    // we must do the same, otherwise `vcl_KillBackends`'s
+    // `assert(VTAILQ_EMPTY(&vdire->directors))` at cache_vcl.c:704 trips and the child
+    // panics. Drop will see the `deregistered` flag and skip its own `VRT_DelDirector`.
+    if matches!(ev, VclEvent::Discard)
+        && !shim.deregistered.swap(true, Ordering::AcqRel)
+    {
+        let mut bep = be;
+        ffi::VRT_DelDirector(&raw mut bep);
+    }
 }
 
 unsafe extern "C" fn wrap_list<S: VclBackend<T>, T: VclResponse>(

--- a/varnish-sys/src/vcl/backend/backend_main.rs
+++ b/varnish-sys/src/vcl/backend/backend_main.rs
@@ -697,9 +697,7 @@ unsafe extern "C" fn wrap_event<S: VclBackend<T>, T: VclResponse>(be: VCL_BACKEN
     // we must do the same, otherwise `vcl_KillBackends`'s
     // `assert(VTAILQ_EMPTY(&vdire->directors))` at cache_vcl.c:704 trips and the child
     // panics. Drop will see the `deregistered` flag and skip its own `VRT_DelDirector`.
-    if matches!(ev, VclEvent::Discard)
-        && !shim.deregistered.swap(true, Ordering::AcqRel)
-    {
+    if matches!(ev, VclEvent::Discard) && !shim.deregistered.swap(true, Ordering::AcqRel) {
         let mut bep = be;
         ffi::VRT_DelDirector(&raw mut bep);
     }

--- a/varnish-sys/src/vcl/backend/director.rs
+++ b/varnish-sys/src/vcl/backend/director.rs
@@ -251,9 +251,7 @@ unsafe extern "C" fn wrap_director_event<D: VclDirector>(director: VCL_BACKEND, 
     // `vcl_KillBackends` asserts that VCL_EVENT_DISCARD synchronously removes the
     // director from `vdire->directors`, which only happens if we call
     // VRT_DelDirector here.
-    if matches!(ev, VclEvent::Discard)
-        && !shim.deregistered.swap(true, Ordering::AcqRel)
-    {
+    if matches!(ev, VclEvent::Discard) && !shim.deregistered.swap(true, Ordering::AcqRel) {
         let mut bep = director;
         ffi::VRT_DelDirector(&raw mut bep);
     }

--- a/varnish-sys/src/vcl/backend/director.rs
+++ b/varnish-sys/src/vcl/backend/director.rs
@@ -1,11 +1,13 @@
 use std::ffi::{c_char, c_void, CString};
 use std::ptr;
 use std::ptr::null;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::ffi::{VclEvent, VCL_BACKEND, VCL_BOOL, VCL_TIME};
 use crate::vcl::{Buffer, Ctx, VclResult};
 use crate::{ffi, validate_director};
 
+use super::backend_main::BackendShim;
 use super::{BackendRef, ProbeResult};
 
 /// Trait for wrapping a C `struct director`
@@ -77,7 +79,7 @@ pub trait VclDirector {
 pub struct Director<D: VclDirector> {
     #[expect(dead_code)]
     methods: Box<ffi::vdi_methods>,
-    inner: Box<D>,
+    inner: Box<BackendShim<D>>,
     #[expect(dead_code)]
     ctype: CString,
     backend_ref: BackendRef,
@@ -89,7 +91,10 @@ impl<D: VclDirector> Director<D> {
     /// This registers the director with Varnish and sets up the appropriate callbacks.
     /// The director will be automatically unregistered when dropped.
     pub fn new(ctx: &mut Ctx, director_type: &str, vcl_name: &str, inner: D) -> VclResult<Self> {
-        let mut inner = Box::new(inner);
+        let mut inner = Box::new(BackendShim {
+            inner,
+            deregistered: AtomicBool::new(false),
+        });
         let ctype = CString::new(director_type).map_err(|e| e.to_string())?;
         let cname = CString::new(vcl_name).map_err(|e| e.to_string())?;
         let methods = Box::new(ffi::vdi_methods {
@@ -108,11 +113,13 @@ impl<D: VclDirector> Director<D> {
             list: Some(wrap_director_list::<D>),
         });
 
+        // priv_ points to BackendShim<D>; #[repr(C)] with inner first means
+        // casting it back to *const D in the other wrap_* callbacks remains valid.
         let bep = unsafe {
             ffi::VRT_AddDirector(
                 ctx.raw,
                 &raw const *methods,
-                ptr::from_mut::<D>(&mut *inner).cast::<c_void>(),
+                ptr::from_mut::<BackendShim<D>>(&mut *inner).cast::<c_void>(),
                 c"%.*s".as_ptr(),
                 cname.as_bytes().len(),
                 cname.as_ptr().cast::<c_char>(),
@@ -140,12 +147,12 @@ impl<D: VclDirector> Director<D> {
 
     /// Access the bep director implementation
     pub fn get_inner(&self) -> &D {
-        &self.inner
+        &self.inner.inner
     }
 
     /// Access the bep director implementation mutably
     pub fn get_inner_mut(&mut self) -> &mut D {
-        &mut self.inner
+        &mut self.inner.inner
     }
 
     /// Resolve this director to a backend using `VRT_DirectorResolve`
@@ -164,9 +171,15 @@ impl<D: VclDirector> Director<D> {
 
 impl<D: VclDirector> Drop for Director<D> {
     fn drop(&mut self) {
+        // wrap_director_event already calls VRT_DelDirector when VCL_EVENT_DISCARD
+        // fires on the normal teardown path (per-VCL VMOD object dropped after
+        // vcl_KillBackends). Only fall through here if that didn't happen — e.g. the
+        // Director was dropped while the VCL is still warm.
         unsafe {
-            let mut bep = self.backend_ref.vcl_ptr();
-            ffi::VRT_DelDirector(&raw mut bep);
+            if !self.inner.deregistered.swap(true, Ordering::AcqRel) {
+                let mut bep = self.backend_ref.vcl_ptr();
+                ffi::VRT_DelDirector(&raw mut bep);
+            }
         }
     }
 }
@@ -231,6 +244,17 @@ unsafe extern "C" fn wrap_director_list<D: VclDirector>(
 
 unsafe extern "C" fn wrap_director_event<D: VclDirector>(director: VCL_BACKEND, ev: VclEvent) {
     let dir = validate_director(director);
-    let dir_impl: &D = &*dir.priv_.cast::<D>();
-    dir_impl.event(ev);
+    let shim: &BackendShim<D> = &*dir.priv_.cast::<BackendShim<D>>();
+    shim.inner.event(ev);
+
+    // See wrap_event in backend_main.rs for the rationale: vinyld's
+    // `vcl_KillBackends` asserts that VCL_EVENT_DISCARD synchronously removes the
+    // director from `vdire->directors`, which only happens if we call
+    // VRT_DelDirector here.
+    if matches!(ev, VclEvent::Discard)
+        && !shim.deregistered.swap(true, Ordering::AcqRel)
+    {
+        let mut bep = director;
+        ffi::VRT_DelDirector(&raw mut bep);
+    }
 }


### PR DESCRIPTION
Custom backends/directors registered via `VRT_AddDirector` were only removed from `vdire->directors` in `Backend::drop` / `Director::drop`. When the per-VCL VMOD object that owns the Backend outlives the fini (e.g. parked behind an `Arc` in a shared pool), Drop does not run before `vcl_KillBackends`, and its trailing
`assert(VTAILQ_EMPTY(&vdire->directors))` at cache_vcl.c:704 panics the child.

Match the built-in `vbe_dir_event` behaviour: call `VRT_DelDirector` synchronously from the `VCL_EVENT_DISCARD` handler. A `deregistered` flag on the new `BackendShim<S>` wrapper guards against a second `VRT_DelDirector` from Drop. The shim is `#[repr(C)]` with the user type first so existing `priv_` casts in the other `wrap_*` callbacks remain valid.

Includes a `leaky_parrot` test object that wraps its Backend in `ManuallyDrop` to deterministically reproduce the assertion without the discard handler fix.