### PR TITLE
Add new Acl type

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ There are two types of tests in this project:
 
 ## Debugging Macro-Generated Code
 
-The simplest way to observe generated code is to examine `varnish/sanshots/*@code.snap` files. They contain code generated from the `varnish/test/pass/*.rs` files. Additionally, the model file describes intermediate parse result of the test file, json files shows the data given to the Varnish vmod compiler, and docs contain the generated documentation.
+The simplest way to observe generated code is to examine `varnish/snapshots*/*@code.snap` files. They contain code generated from the `varnish/test/pass/*.rs` files. Additionally, the model file describes intermediate parse result of the test file, json files shows the data given to the Varnish vmod compiler, and docs contain the generated documentation.
 
 For a more in-depth look, use `cargo expand` command.  You will need to run `cargo install cargo-expand` to install it first. You can copy/paste the expanded code into the same file, removing some boilerplate before and after the expanded code, and then run `cargo check` to see the errors.  Note that some expansions cannot be compiled - e.g. anything expanded from `format!` or `panic!` - so you may need compare the generated code with the original, and keep all the original parts for anything unrelated to the generated code.
 

--- a/varnish-macros/src/generator.rs
+++ b/varnish-macros/src/generator.rs
@@ -201,6 +201,7 @@ impl Generator {
 
         // WARNING: This list must match the list in varnish-macros/src/lib.rs
         let mut use_ffi_items = quote![
+            VCL_ACL,
             VCL_BACKEND,
             VCL_BLOB,
             VCL_BOOL,

--- a/varnish-macros/src/model.rs
+++ b/varnish-macros/src/model.rs
@@ -235,7 +235,8 @@ impl ParamTy {
     /// User MUST use some types with `Option`
     pub fn must_be_optional(self) -> bool {
         match self {
-            Self::Bool
+            Self::Acl
+            | Self::Bool
             | Self::Blob
             | Self::CStr
             | Self::Duration
@@ -245,11 +246,7 @@ impl ParamTy {
             | Self::Str
             | Self::Sub
             | Self::VclType(_) => false,
-            Self::Acl
-            | Self::BackendRef
-            | Self::Probe
-            | Self::ProbeCow
-            | Self::SocketAddr => true,
+            Self::BackendRef | Self::Probe | Self::ProbeCow | Self::SocketAddr => true,
         }
     }
 

--- a/varnish-macros/src/model.rs
+++ b/varnish-macros/src/model.rs
@@ -176,6 +176,7 @@ pub struct ParamInfo {
 /// Represents the common function argument types. These could also be returned.
 #[derive(Debug, Clone, Copy)]
 pub enum ParamTy {
+    Acl,
     Bool,
     BackendRef,
     Blob,
@@ -195,6 +196,7 @@ pub enum ParamTy {
 impl ParamTy {
     pub fn to_vcc_type(self) -> &'static str {
         match self {
+            Self::Acl => "ACL",
             Self::Bool => "BOOL",
             Self::BackendRef => "BACKEND",
             Self::Blob => "BLOB",
@@ -214,6 +216,7 @@ impl ParamTy {
         // ATTENTION: Each VCL_* type here must also be listed in the `use varnish::...`
         //            statement in the `varnish-macros/src/generator.rs` file.
         match self {
+            Self::Acl => "VCL_ACL",
             Self::Bool => "VCL_BOOL",
             Self::BackendRef => "VCL_BACKEND",
             Self::Blob => "VCL_BLOB",
@@ -232,7 +235,8 @@ impl ParamTy {
     /// User MUST use some types with `Option`
     pub fn must_be_optional(self) -> bool {
         match self {
-            Self::Bool
+            Self::Acl
+            | Self::Bool
             | Self::Blob
             | Self::CStr
             | Self::Duration
@@ -250,7 +254,8 @@ impl ParamTy {
     /// e.g. if `&CStr` contains invalid UTF-8 characters and cannot be converted to `&str`.
     pub fn use_try_from(self) -> bool {
         match self {
-            Self::Bool
+            Self::Acl
+            | Self::Bool
             | Self::BackendRef
             | Self::Blob
             | Self::CStr

--- a/varnish-macros/src/model.rs
+++ b/varnish-macros/src/model.rs
@@ -227,6 +227,7 @@ impl ParamTy {
             Self::Probe | Self::ProbeCow => "VCL_PROBE",
             Self::SocketAddr => "VCL_IP",
             Self::Str | Self::CStr => "VCL_STRING",
+            Self::Sub => "VCL_SUB",
             Self::VclType(ty) => ty,
         }
     }

--- a/varnish-macros/src/model.rs
+++ b/varnish-macros/src/model.rs
@@ -227,7 +227,6 @@ impl ParamTy {
             Self::Probe | Self::ProbeCow => "VCL_PROBE",
             Self::SocketAddr => "VCL_IP",
             Self::Str | Self::CStr => "VCL_STRING",
-            Self::Sub => "VCL_SUB",
             Self::VclType(ty) => ty,
         }
     }
@@ -235,8 +234,7 @@ impl ParamTy {
     /// User MUST use some types with `Option`
     pub fn must_be_optional(self) -> bool {
         match self {
-            Self::Acl
-            | Self::Bool
+            Self::Bool
             | Self::Blob
             | Self::CStr
             | Self::Duration
@@ -246,7 +244,11 @@ impl ParamTy {
             | Self::Str
             | Self::Sub
             | Self::VclType(_) => false,
-            Self::BackendRef | Self::Probe | Self::ProbeCow | Self::SocketAddr => true,
+            Self::Acl
+            | Self::BackendRef
+            | Self::Probe
+            | Self::ProbeCow
+            | Self::SocketAddr => true,
         }
     }
 

--- a/varnish-macros/src/parser_args.rs
+++ b/varnish-macros/src/parser_args.rs
@@ -357,7 +357,9 @@ impl ParamTy {
     /// Tries parsing regular VCL types as `i64`, `bool`, `Duration`, `&str`, ...
     pub fn try_parse(ty: &Type) -> Option<Self> {
         if let Some(ident) = as_simple_ty(ty) {
-            if ident == "bool" {
+            if ident == "Acl" {
+                return Some(Self::Acl);
+            } else if ident == "bool" {
                 return Some(Self::Bool);
             } else if ident == "BackendRef" {
                 return Some(Self::BackendRef);

--- a/varnish-macros/src/parser_args.rs
+++ b/varnish-macros/src/parser_args.rs
@@ -375,6 +375,8 @@ impl ParamTy {
                 return Some(Self::Probe);
             } else if ident == "SocketAddr" {
                 return Some(Self::SocketAddr);
+            } else if ident == "VCL_ACL" {
+                return Some(Self::VclType("VCL_ACL"));
             } else if ident == "VCL_BACKEND" {
                 return Some(Self::VclType("VCL_BACKEND"));
             } else if ident == "VCL_BLOB" {

--- a/varnish-macros/src/snapshots/populated.snap
+++ b/varnish-macros/src/snapshots/populated.snap
@@ -49,9 +49,7 @@ fn vtc_basic() {
     if let Err(err) = ::varnish::varnishtest::run_one_test(
         &dylib_path,
         env!("CARGO_PKG_NAME"),
-        ::std::path::Path::new(
-            "{MANIFEST_DIR}/tests/vtc_fixtures/basic.vtc",
-        ),
+        ::std::path::Path::new("{MANIFEST_DIR}/tests/vtc_fixtures/basic.vtc"),
         option_env!("VARNISHTEST_DURATION").unwrap_or("10s"),
         false,
     ) {
@@ -70,9 +68,7 @@ fn vtc_has_dashes() {
     if let Err(err) = ::varnish::varnishtest::run_one_test(
         &dylib_path,
         env!("CARGO_PKG_NAME"),
-        ::std::path::Path::new(
-            "{MANIFEST_DIR}/tests/vtc_fixtures/has-dashes.vtc",
-        ),
+        ::std::path::Path::new("{MANIFEST_DIR}/tests/vtc_fixtures/has-dashes.vtc"),
         option_env!("VARNISHTEST_DURATION").unwrap_or("10s"),
         false,
     ) {

--- a/varnish-macros/src/snapshots/populated.snap
+++ b/varnish-macros/src/snapshots/populated.snap
@@ -49,7 +49,9 @@ fn vtc_basic() {
     if let Err(err) = ::varnish::varnishtest::run_one_test(
         &dylib_path,
         env!("CARGO_PKG_NAME"),
-        ::std::path::Path::new("{MANIFEST_DIR}/tests/vtc_fixtures/basic.vtc"),
+        ::std::path::Path::new(
+            "{MANIFEST_DIR}/tests/vtc_fixtures/basic.vtc",
+        ),
         option_env!("VARNISHTEST_DURATION").unwrap_or("10s"),
         false,
     ) {
@@ -68,7 +70,9 @@ fn vtc_has_dashes() {
     if let Err(err) = ::varnish::varnishtest::run_one_test(
         &dylib_path,
         env!("CARGO_PKG_NAME"),
-        ::std::path::Path::new("{MANIFEST_DIR}/tests/vtc_fixtures/has-dashes.vtc"),
+        ::std::path::Path::new(
+            "{MANIFEST_DIR}/tests/vtc_fixtures/has-dashes.vtc",
+        ),
         option_env!("VARNISHTEST_DURATION").unwrap_or("10s"),
         false,
     ) {

--- a/varnish-macros/src/snapshots/populated_debug.snap
+++ b/varnish-macros/src/snapshots/populated_debug.snap
@@ -49,9 +49,7 @@ fn vtc_basic() {
     if let Err(err) = ::varnish::varnishtest::run_one_test(
         &dylib_path,
         env!("CARGO_PKG_NAME"),
-        ::std::path::Path::new(
-            "{MANIFEST_DIR}/tests/vtc_fixtures/basic.vtc",
-        ),
+        ::std::path::Path::new("{MANIFEST_DIR}/tests/vtc_fixtures/basic.vtc"),
         option_env!("VARNISHTEST_DURATION").unwrap_or("10s"),
         true,
     ) {
@@ -70,9 +68,7 @@ fn vtc_has_dashes() {
     if let Err(err) = ::varnish::varnishtest::run_one_test(
         &dylib_path,
         env!("CARGO_PKG_NAME"),
-        ::std::path::Path::new(
-            "{MANIFEST_DIR}/tests/vtc_fixtures/has-dashes.vtc",
-        ),
+        ::std::path::Path::new("{MANIFEST_DIR}/tests/vtc_fixtures/has-dashes.vtc"),
         option_env!("VARNISHTEST_DURATION").unwrap_or("10s"),
         true,
     ) {

--- a/varnish-macros/src/snapshots/populated_debug.snap
+++ b/varnish-macros/src/snapshots/populated_debug.snap
@@ -49,7 +49,9 @@ fn vtc_basic() {
     if let Err(err) = ::varnish::varnishtest::run_one_test(
         &dylib_path,
         env!("CARGO_PKG_NAME"),
-        ::std::path::Path::new("{MANIFEST_DIR}/tests/vtc_fixtures/basic.vtc"),
+        ::std::path::Path::new(
+            "{MANIFEST_DIR}/tests/vtc_fixtures/basic.vtc",
+        ),
         option_env!("VARNISHTEST_DURATION").unwrap_or("10s"),
         true,
     ) {
@@ -68,7 +70,9 @@ fn vtc_has_dashes() {
     if let Err(err) = ::varnish::varnishtest::run_one_test(
         &dylib_path,
         env!("CARGO_PKG_NAME"),
-        ::std::path::Path::new("{MANIFEST_DIR}/tests/vtc_fixtures/has-dashes.vtc"),
+        ::std::path::Path::new(
+            "{MANIFEST_DIR}/tests/vtc_fixtures/has-dashes.vtc",
+        ),
         option_env!("VARNISHTEST_DURATION").unwrap_or("10s"),
         true,
     ) {

--- a/varnish-sys/c_code/wrapper.h
+++ b/varnish-sys/c_code/wrapper.h
@@ -17,3 +17,13 @@
 #include "vcl.h"
 
 struct vfp_entry *VFP_Push(struct vfp_ctx *, const struct vfp *);
+
+/** from vcc_interface.h */
+typedef int acl_match_f(VRT_CTX, const VCL_IP);
+
+struct vrt_acl {
+    unsigned        magic;
+#define VRT_ACL_MAGIC   0x78329d96
+    acl_match_f     *match;
+    const char    *name;
+};

--- a/varnish-sys/c_code/wrapper.h
+++ b/varnish-sys/c_code/wrapper.h
@@ -17,13 +17,3 @@
 #include "vcl.h"
 
 struct vfp_entry *VFP_Push(struct vfp_ctx *, const struct vfp *);
-
-/** from vcc_interface.h */
-typedef int acl_match_f(VRT_CTX, const VCL_IP);
-
-struct vrt_acl {
-    unsigned        magic;
-#define VRT_ACL_MAGIC   0x78329d96
-    acl_match_f     *match;
-    const char    *name;
-};

--- a/varnish-sys/src/vcl/acl.rs
+++ b/varnish-sys/src/vcl/acl.rs
@@ -1,0 +1,35 @@
+use std::net::SocketAddr;
+
+use crate::ffi;
+
+#[derive(Debug, Clone)]
+pub struct Acl {
+    pub raw: ffi::VCL_ACL,
+}
+
+impl Acl {
+    /// Test if the given address matches the ACL. If `addr` is `None`, a negative match is returned.
+    pub fn matches(&self, ctx: &crate::vcl::Ctx, addr: Option<SocketAddr>) -> bool {
+        assert!(!self.raw.0.is_null());
+
+        match addr {
+            Some(ip) => unsafe {
+                let mut sa_buf = vec![0u8; ffi::vsa_suckaddr_len];
+                crate::vcl::convert::write_ip_to_buf(ip, &mut sa_buf);
+                ffi::VRT_acl_match(ctx.raw, self.raw, ffi::VCL_IP(sa_buf.as_ptr().cast())) == 1
+            },
+            None => false,
+        }
+    }
+
+    /// Retun the `C` pointer to the underlying ACL.
+    pub unsafe fn vcl_ptr(&self) -> ffi::VCL_ACL {
+        self.raw
+    }
+}
+
+impl From<ffi::VCL_ACL> for Acl {
+    fn from(p: ffi::VCL_ACL) -> Self {
+        Acl { raw: p }
+    }
+}

--- a/varnish-sys/src/vcl/acl.rs
+++ b/varnish-sys/src/vcl/acl.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::{ffi::CStr, net::SocketAddr};
 
 use crate::ffi;
 
@@ -22,24 +22,19 @@ impl Acl {
         }
     }
 
+    /// Return the VCL name of the underlying ACL.
+    pub fn name(&self) -> &CStr {
+        assert!(!self.raw.0.is_null());
+
+        unsafe {
+            let acl = *self.raw.0;
+            assert_eq!(acl.magic, ffi::VRT_ACL_MAGIC);
+            CStr::from_ptr(acl.name)
+        }
+    }
+
     /// Retun the `C` pointer to the underlying ACL.
     pub unsafe fn vcl_ptr(&self) -> ffi::VCL_ACL {
         self.raw
-    }
-}
-
-impl From<ffi::VCL_ACL> for Acl {
-    fn from(value: ffi::VCL_ACL) -> Self {
-        Acl { raw: value }
-    }
-}
-
-impl From<ffi::VCL_ACL> for Option<Acl> {
-    fn from(value: ffi::VCL_ACL) -> Self {
-        if value.0.is_null() {
-            return None;
-        }
-
-        Some(Acl { raw: value })
     }
 }

--- a/varnish-sys/src/vcl/acl.rs
+++ b/varnish-sys/src/vcl/acl.rs
@@ -27,19 +27,3 @@ impl Acl {
         self.raw
     }
 }
-
-impl From<ffi::VCL_ACL> for Acl {
-    fn from(value: ffi::VCL_ACL) -> Self {
-        Acl { raw: value }
-    }
-}
-
-impl From<ffi::VCL_ACL> for Option<Acl> {
-    fn from(value: ffi::VCL_ACL) -> Self {
-        if value.0.is_null() {
-            return None;
-        }
-
-        Some(Acl { raw: value })
-    }
-}

--- a/varnish-sys/src/vcl/acl.rs
+++ b/varnish-sys/src/vcl/acl.rs
@@ -29,7 +29,17 @@ impl Acl {
 }
 
 impl From<ffi::VCL_ACL> for Acl {
-    fn from(p: ffi::VCL_ACL) -> Self {
-        Acl { raw: p }
+    fn from(value: ffi::VCL_ACL) -> Self {
+        Acl { raw: value }
+    }
+}
+
+impl From<ffi::VCL_ACL> for Option<Acl> {
+    fn from(value: ffi::VCL_ACL) -> Self {
+        if value.0.is_null() {
+            return None;
+        }
+
+        Some(Acl { raw: value })
     }
 }

--- a/varnish-sys/src/vcl/acl.rs
+++ b/varnish-sys/src/vcl/acl.rs
@@ -1,5 +1,3 @@
-use std::net::SocketAddr;
-
 use crate::ffi;
 
 #[derive(Debug, Clone)]
@@ -8,17 +6,6 @@ pub struct Acl {
 }
 
 impl Acl {
-    /// Test if the given address matches the ACL.
-    pub fn matches(&self, ctx: &crate::vcl::Ctx, addr: SocketAddr) -> bool {
-        assert!(!self.raw.0.is_null());
-
-        unsafe {
-            let mut sa_buf = vec![0u8; ffi::vsa_suckaddr_len];
-            crate::vcl::convert::write_ip_to_buf(addr, &mut sa_buf);
-            ffi::VRT_acl_match(ctx.raw, self.raw, ffi::VCL_IP(sa_buf.as_ptr().cast())) == 1
-        }
-    }
-
     /// Retun the `C` pointer to the underlying ACL.
     pub unsafe fn vcl_ptr(&self) -> ffi::VCL_ACL {
         self.raw

--- a/varnish-sys/src/vcl/acl.rs
+++ b/varnish-sys/src/vcl/acl.rs
@@ -8,17 +8,14 @@ pub struct Acl {
 }
 
 impl Acl {
-    /// Test if the given address matches the ACL. If `addr` is `None`, a negative match is returned.
-    pub fn matches(&self, ctx: &crate::vcl::Ctx, addr: Option<SocketAddr>) -> bool {
+    /// Test if the given address matches the ACL.
+    pub fn matches(&self, ctx: &crate::vcl::Ctx, addr: SocketAddr) -> bool {
         assert!(!self.raw.0.is_null());
 
-        match addr {
-            Some(ip) => unsafe {
-                let mut sa_buf = vec![0u8; ffi::vsa_suckaddr_len];
-                crate::vcl::convert::write_ip_to_buf(ip, &mut sa_buf);
-                ffi::VRT_acl_match(ctx.raw, self.raw, ffi::VCL_IP(sa_buf.as_ptr().cast())) == 1
-            },
-            None => false,
+        unsafe {
+            let mut sa_buf = vec![0u8; ffi::vsa_suckaddr_len];
+            crate::vcl::convert::write_ip_to_buf(addr, &mut sa_buf);
+            ffi::VRT_acl_match(ctx.raw, self.raw, ffi::VCL_IP(sa_buf.as_ptr().cast())) == 1
         }
     }
 

--- a/varnish-sys/src/vcl/acl.rs
+++ b/varnish-sys/src/vcl/acl.rs
@@ -1,4 +1,4 @@
-use std::{ffi::CStr, net::SocketAddr};
+use std::net::SocketAddr;
 
 use crate::ffi;
 
@@ -22,19 +22,24 @@ impl Acl {
         }
     }
 
-    /// Return the VCL name of the underlying ACL.
-    pub fn name(&self) -> &CStr {
-        assert!(!self.raw.0.is_null());
-
-        unsafe {
-            let acl = *self.raw.0;
-            assert_eq!(acl.magic, ffi::VRT_ACL_MAGIC);
-            CStr::from_ptr(acl.name)
-        }
-    }
-
     /// Retun the `C` pointer to the underlying ACL.
     pub unsafe fn vcl_ptr(&self) -> ffi::VCL_ACL {
         self.raw
+    }
+}
+
+impl From<ffi::VCL_ACL> for Acl {
+    fn from(value: ffi::VCL_ACL) -> Self {
+        Acl { raw: value }
+    }
+}
+
+impl From<ffi::VCL_ACL> for Option<Acl> {
+    fn from(value: ffi::VCL_ACL) -> Self {
+        if value.0.is_null() {
+            return None;
+        }
+
+        Some(Acl { raw: value })
     }
 }

--- a/varnish-sys/src/vcl/convert.rs
+++ b/varnish-sys/src/vcl/convert.rs
@@ -58,9 +58,10 @@ use crate::ffi::{
     VCL_HEADER, VCL_HTTP, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL, VCL_REGEX, VCL_STEVEDORE,
     VCL_STRANDS, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VCL,
 };
+
 use crate::vcl::{
-    from_vcl_probe, into_vcl_probe, Acl, subroutine::Subroutine, BackendRef, CowProbe, Probe, VclError,
-    Workspace,
+    from_vcl_probe, into_vcl_probe, subroutine::Subroutine, Acl, BackendRef, CowProbe, Probe,
+    VclError, Workspace,
 };
 
 /// Convert a Rust type into a VCL one

--- a/varnish-sys/src/vcl/convert.rs
+++ b/varnish-sys/src/vcl/convert.rs
@@ -118,33 +118,24 @@ macro_rules! from_vcl_to_opt_rust {
 }
 
 // VCL_ACL
+
+// this is deceiving: VCL_ACL must never be null, but we may need to return a NULL to the C layer if
+// the vmod returns Return<Acl, _>
+default_null_ptr!(VCL_ACL);
+
+from_vcl_to_opt_rust!(VCL_ACL, Acl);
 impl From<VCL_ACL> for Acl {
     fn from(value: VCL_ACL) -> Acl {
+        assert!(!value.0.is_null());
         Acl { raw: value }
-    }
-}
-
-impl From<VCL_ACL> for Option<Acl> {
-    fn from(value: VCL_ACL) -> Option<Acl> {
-        if value.0.is_null() {
-            return None;
-        }
-
-        Some(Acl { raw: value })
     }
 }
 
 impl IntoVCL<VCL_ACL> for Acl {
     fn into_vcl(self, _: &mut Workspace) -> Result<VCL_ACL, VclError> {
-        unsafe { Ok(self.vcl_ptr()) }
-    }
-}
-
-impl IntoVCL<VCL_ACL> for Option<Acl> {
-    fn into_vcl(self, _: &mut Workspace) -> Result<VCL_ACL, VclError> {
-        match self {
-            Some(acl) => unsafe { Ok(acl.vcl_ptr()) },
-            None => Err(VclError::Str("acl is null")),
+        unsafe {
+            assert!(!self.vcl_ptr().0.is_null());
+            Ok(self.vcl_ptr())
         }
     }
 }

--- a/varnish-sys/src/vcl/convert.rs
+++ b/varnish-sys/src/vcl/convert.rs
@@ -60,7 +60,7 @@ use crate::ffi::{
 };
 
 use crate::vcl::{
-    from_vcl_probe, into_vcl_probe, subroutine::Subroutine, BackendRef, CowProbe, Probe, VclError,
+    from_vcl_probe, into_vcl_probe, acl, subroutine::Subroutine, BackendRef, CowProbe, Probe, VclError,
     Workspace,
 };
 
@@ -118,7 +118,21 @@ macro_rules! from_vcl_to_opt_rust {
 }
 
 // VCL_ACL
-default_null_ptr!(VCL_ACL);
+impl From<VCL_ACL> for Acl {
+    fn from(value: VCL_ACL) -> Acl {
+        Acl { raw: value }
+    }
+}
+
+impl From<VCL_ACL> for Option<Acl> {
+    fn from(value: VCL_ACL) -> Option<Acl> {
+        if value.0.is_null() {
+            return None;
+        }
+
+        Some(Acl { raw: value })
+    }
+}
 
 // VCL_BLOB
 default_null_ptr!(VCL_BLOB);

--- a/varnish-sys/src/vcl/convert.rs
+++ b/varnish-sys/src/vcl/convert.rs
@@ -134,6 +134,21 @@ impl From<VCL_ACL> for Option<Acl> {
     }
 }
 
+impl IntoVCL<VCL_ACL> for Acl {
+    fn into_vcl(self, _: &mut Workspace) -> Result<VCL_ACL, VclError> {
+        unsafe { Ok(self.vcl_ptr()) }
+    }
+}
+
+impl IntoVCL<VCL_ACL> for Option<Acl> {
+    fn into_vcl(self, _: &mut Workspace) -> Result<VCL_ACL, VclError> {
+        match self {
+            Some(acl) => unsafe { Ok(acl.vcl_ptr()) },
+            None => Err(VclError::Str("acl is null")),
+        }
+    }
+}
+
 // VCL_BLOB
 default_null_ptr!(VCL_BLOB);
 impl From<VCL_BLOB> for &[u8] {

--- a/varnish-sys/src/vcl/convert.rs
+++ b/varnish-sys/src/vcl/convert.rs
@@ -58,9 +58,8 @@ use crate::ffi::{
     VCL_HEADER, VCL_HTTP, VCL_INT, VCL_IP, VCL_PROBE, VCL_REAL, VCL_REGEX, VCL_STEVEDORE,
     VCL_STRANDS, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VCL,
 };
-
 use crate::vcl::{
-    from_vcl_probe, into_vcl_probe, acl, subroutine::Subroutine, BackendRef, CowProbe, Probe, VclError,
+    from_vcl_probe, into_vcl_probe, Acl, subroutine::Subroutine, BackendRef, CowProbe, Probe, VclError,
     Workspace,
 };
 

--- a/varnish-sys/src/vcl/ctx.rs
+++ b/varnish-sys/src/vcl/ctx.rs
@@ -5,7 +5,7 @@ use std::net::SocketAddr;
 
 use crate::ffi;
 use crate::ffi::{vrt_ctx, VRT_call, VRT_check_call, VRT_fail, VRT_handled, VRT_CTX_MAGIC};
-use crate::vcl::{Acl, subroutine::Subroutine, HttpHeaders, LogTag, TestWS, VclError, Workspace};
+use crate::vcl::{subroutine::Subroutine, Acl, HttpHeaders, LogTag, TestWS, VclError, Workspace};
 
 /// VCL context
 ///
@@ -96,8 +96,14 @@ impl<'a> Ctx<'a> {
     }
 
     /// Match an ACL against a provided address.
-    pub fn acl_match(&self, acl: Acl, addr: SocketAddr) -> bool {
-        acl.matches(self, addr)
+    pub fn acl_match(&self, acl: &Acl, addr: SocketAddr) -> bool {
+        assert!(!acl.raw.0.is_null());
+
+        unsafe {
+            let mut sa_buf = vec![0u8; ffi::vsa_suckaddr_len];
+            crate::vcl::convert::write_ip_to_buf(addr, &mut sa_buf);
+            ffi::VRT_acl_match(self.raw, acl.raw, ffi::VCL_IP(sa_buf.as_ptr().cast())) == 1
+        }
     }
 
     /// Return the name of the listener socket that received the current request.

--- a/varnish-sys/src/vcl/ctx.rs
+++ b/varnish-sys/src/vcl/ctx.rs
@@ -1,10 +1,11 @@
 //! Expose the Varnish context [`vrt_ctx`] as a Rust object
 //!
 use std::ffi::{c_int, c_uint, c_void, CStr};
+use std::net::SocketAddr;
 
 use crate::ffi;
 use crate::ffi::{vrt_ctx, VRT_call, VRT_check_call, VRT_fail, VRT_handled, VRT_CTX_MAGIC};
-use crate::vcl::{subroutine::Subroutine, HttpHeaders, LogTag, TestWS, VclError, Workspace};
+use crate::vcl::{Acl, subroutine::Subroutine, HttpHeaders, LogTag, TestWS, VclError, Workspace};
 
 /// VCL context
 ///
@@ -92,6 +93,11 @@ impl<'a> Ctx<'a> {
                 ffi::VSLbt(vsl, tag, msg);
             }
         }
+    }
+
+    /// Match an ACL against a provided address.
+    pub fn acl_match(&self, acl: Acl, addr: Option<SocketAddr>) -> bool {
+        acl.matches(self, addr)
     }
 
     /// Return the name of the listener socket that received the current request.

--- a/varnish-sys/src/vcl/ctx.rs
+++ b/varnish-sys/src/vcl/ctx.rs
@@ -96,7 +96,7 @@ impl<'a> Ctx<'a> {
     }
 
     /// Match an ACL against a provided address.
-    pub fn acl_match(&self, acl: Acl, addr: Option<SocketAddr>) -> bool {
+    pub fn acl_match(&self, acl: Acl, addr: SocketAddr) -> bool {
         acl.matches(self, addr)
     }
 

--- a/varnish-sys/src/vcl/mod.rs
+++ b/varnish-sys/src/vcl/mod.rs
@@ -1,3 +1,37 @@
+//! This module provides the types used by vmod code.
+//!
+//! # Backends and directors
+//!
+//! As a C construct, [`crate::ffi::VCL_BACKEND`] can be a bit confusing to create and manipulate, notably as it
+//! involves a bunch of structures with different lifetimes and quite a lot of casting. This
+//! module hopes to alleviate those issues by handling the most of them and by offering a more
+//! idiomatic interface centered around vmod objects.
+//!
+//! Here's what's in the toolbox:
+//! - [`Backend`]: an "actual" backend that can be used by Varnish to create an HTTP response. It
+//!   relies on two traits:
+//!   - [`VclBackend`] reports health, and generates the response headers
+//!   - [`VclResponse`] for the response body writer, structs implementing that trait are
+//!     returned by [`VclBackend::get_response`]
+//! - [`NativeBackend`]: a specialization of [`Backend`], relying on the native Varnish
+//!   implementation providing IP and UDS backends
+//! - [`NativeBackendBuilder`]: a builder to easily create a [`NativeBackend`]
+//! - [`Director`]: a routing object doesn't create responses, but insead pick a [`Backend`]
+//!   or [`Director`] object based on the HTTP request, based on the [`VclDirector`].
+//! - [`BackendRef`]: a refcounted wrapper around [`Backend`] and [`Director`], this is the primary
+//!   type used for arguments and returns of vmod functions.
+//!
+//!   **Important:** all these types wraps refcounted C structures that Varnish will try to free
+//!   when a VCL goes cold, which means you can't hold onto them forever. It's not as scary as it
+//!   sounds, and you can approach this two different ways.
+//!
+//!   Use a vmod object that will own them. The object will automatically be dropped at the end of
+//!   the VCL lifetime, as will all its fields, and all the types above will automatically decrease
+//!   their refcount to the underlying C structure when this happens.
+//!
+//!   Otherwise, your vmod can implement the event function and drop the structs on a cold event.
+
+mod acl;
 mod backend;
 mod convert;
 mod ctx;
@@ -11,6 +45,7 @@ mod vsb;
 mod ws;
 mod ws_str_buffer;
 
+pub use acl::*;
 pub use backend::*;
 pub use convert::*;
 pub use ctx::*;

--- a/varnish-sys/src/vcl/mod.rs
+++ b/varnish-sys/src/vcl/mod.rs
@@ -1,36 +1,3 @@
-//! This module provides the types used by vmod code.
-//!
-//! # Backends and directors
-//!
-//! As a C construct, [`crate::ffi::VCL_BACKEND`] can be a bit confusing to create and manipulate, notably as it
-//! involves a bunch of structures with different lifetimes and quite a lot of casting. This
-//! module hopes to alleviate those issues by handling the most of them and by offering a more
-//! idiomatic interface centered around vmod objects.
-//!
-//! Here's what's in the toolbox:
-//! - [`Backend`]: an "actual" backend that can be used by Varnish to create an HTTP response. It
-//!   relies on two traits:
-//!   - [`VclBackend`] reports health, and generates the response headers
-//!   - [`VclResponse`] for the response body writer, structs implementing that trait are
-//!     returned by [`VclBackend::get_response`]
-//! - [`NativeBackend`]: a specialization of [`Backend`], relying on the native Varnish
-//!   implementation providing IP and UDS backends
-//! - [`NativeBackendBuilder`]: a builder to easily create a [`NativeBackend`]
-//! - [`Director`]: a routing object doesn't create responses, but insead pick a [`Backend`]
-//!   or [`Director`] object based on the HTTP request, based on the [`VclDirector`].
-//! - [`BackendRef`]: a refcounted wrapper around [`Backend`] and [`Director`], this is the primary
-//!   type used for arguments and returns of vmod functions.
-//!
-//!   **Important:** all these types wraps refcounted C structures that Varnish will try to free
-//!   when a VCL goes cold, which means you can't hold onto them forever. It's not as scary as it
-//!   sounds, and you can approach this two different ways.
-//!
-//!   Use a vmod object that will own them. The object will automatically be dropped at the end of
-//!   the VCL lifetime, as will all its fields, and all the types above will automatically decrease
-//!   their refcount to the underlying C structure when this happens.
-//!
-//!   Otherwise, your vmod can implement the event function and drop the structs on a cold event.
-
 mod acl;
 mod backend;
 mod convert;

--- a/varnish/snapshots8.0.0/args_args@code.snap
+++ b/varnish/snapshots8.0.0/args_args@code.snap
@@ -9,10 +9,10 @@ mod args {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots8.0.0/docs_types@code.snap
+++ b/varnish/snapshots8.0.0/docs_types@code.snap
@@ -18,10 +18,10 @@ mod types {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots8.0.0/event1_event@code.snap
+++ b/varnish/snapshots8.0.0/event1_event@code.snap
@@ -9,10 +9,10 @@ mod event {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots8.0.0/event2_event2@code.snap
+++ b/varnish/snapshots8.0.0/event2_event2@code.snap
@@ -9,10 +9,10 @@ mod event2 {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots8.0.0/event3_event3@code.snap
+++ b/varnish/snapshots8.0.0/event3_event3@code.snap
@@ -9,10 +9,10 @@ mod event3 {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots8.0.0/event4_event4@code.snap
+++ b/varnish/snapshots8.0.0/event4_event4@code.snap
@@ -9,10 +9,10 @@ mod event4 {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots8.0.0/function_types@code.snap
+++ b/varnish/snapshots8.0.0/function_types@code.snap
@@ -9,10 +9,10 @@ mod types {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;
@@ -184,6 +184,45 @@ mod types {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
                 Ok(super::to_res_cstr_err()?.into_vcl(&mut __ctx.ws)?)
+            };
+            __call_user_func()
+                .unwrap_or_else(|err| {
+                    __ctx.fail(err);
+                    Default::default()
+                })
+        }
+        unsafe extern "C" fn vmod_c_type_acl(__ctx: *mut vrt_ctx, _v: VCL_ACL) {
+            super::type_acl(_v.into())
+        }
+        #[repr(C)]
+        struct arg_vmod_types_arg_acl {
+            valid__v: c_char,
+            _v: VCL_ACL,
+        }
+        unsafe extern "C" fn vmod_c_arg_acl(
+            __ctx: *mut vrt_ctx,
+            __args: *const arg_vmod_types_arg_acl,
+        ) {
+            let __args = __args
+                .as_ref()
+                .expect("optional args pointer must not be null");
+            super::arg_acl(if __args.valid__v != 0 { __args._v.into() } else { None })
+        }
+        unsafe extern "C" fn vmod_c_return_acl(__ctx: *mut vrt_ctx) -> VCL_ACL {
+            let mut __ctx = Ctx::from_ptr(__ctx);
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                Ok(super::return_acl().into_vcl(&mut __ctx.ws)?)
+            };
+            __call_user_func()
+                .unwrap_or_else(|err| {
+                    __ctx.fail(err);
+                    Default::default()
+                })
+        }
+        unsafe extern "C" fn vmod_c_to_res_acl(__ctx: *mut vrt_ctx) -> VCL_ACL {
+            let mut __ctx = Ctx::from_ptr(__ctx);
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                Ok(super::to_res_acl()?.into_vcl(&mut __ctx.ws)?)
             };
             __call_user_func()
                 .unwrap_or_else(|err| {
@@ -715,6 +754,21 @@ mod types {
             vmod_c_to_res_cstr_err: Option<
                 unsafe extern "C" fn(__ctx: *mut vrt_ctx) -> VCL_STRING,
             >,
+            vmod_c_type_acl: Option<
+                unsafe extern "C" fn(__ctx: *mut vrt_ctx, _v: VCL_ACL),
+            >,
+            vmod_c_arg_acl: Option<
+                unsafe extern "C" fn(
+                    __ctx: *mut vrt_ctx,
+                    __args: *const arg_vmod_types_arg_acl,
+                ),
+            >,
+            vmod_c_return_acl: Option<
+                unsafe extern "C" fn(__ctx: *mut vrt_ctx) -> VCL_ACL,
+            >,
+            vmod_c_to_res_acl: Option<
+                unsafe extern "C" fn(__ctx: *mut vrt_ctx) -> VCL_ACL,
+            >,
             vmod_c_type_duration: Option<
                 unsafe extern "C" fn(__ctx: *mut vrt_ctx, _v: VCL_DURATION),
             >,
@@ -881,6 +935,10 @@ mod types {
             vmod_c_to_cstr: Some(vmod_c_to_cstr),
             vmod_c_to_res_cstr: Some(vmod_c_to_res_cstr),
             vmod_c_to_res_cstr_err: Some(vmod_c_to_res_cstr_err),
+            vmod_c_type_acl: Some(vmod_c_type_acl),
+            vmod_c_arg_acl: Some(vmod_c_arg_acl),
+            vmod_c_return_acl: Some(vmod_c_return_acl),
+            vmod_c_to_res_acl: Some(vmod_c_to_res_acl),
             vmod_c_type_duration: Some(vmod_c_type_duration),
             vmod_c_opt_duration: Some(vmod_c_opt_duration),
             vmod_c_to_duration: Some(vmod_c_to_duration),
@@ -929,7 +987,7 @@ mod types {
         pub static Vmod_types_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
-            file_id: c"c13df0540d7786fdca53f5d15d1111b8c80ab3d4de7401fb217f0fb2188d6a9c"
+            file_id: c"90968e517039f4c73943ba74b5f3c2e8bc329a6a486d4b3d16075f7403c4f6d7"
                 .as_ptr(),
             name: c"types".as_ptr(),
             func_name: c"Vmod_vmod_types_Func".as_ptr(),
@@ -948,7 +1006,7 @@ mod types {
     use std::net::SocketAddr;
     use std::time::Duration;
     use varnish::ffi::VCL_STRING;
-    use varnish::vcl::{CowProbe, Probe, Workspace};
+    use varnish::vcl::{Acl, CowProbe, Probe, Workspace};
     use varnish_sys::vcl::VclError;
     pub fn to_void() {}
     pub fn to_res_void_err() -> Result<(), VclError> {
@@ -986,6 +1044,14 @@ mod types {
     }
     pub fn to_res_cstr_err() -> Result<&'static CStr, &'static CStr> {
         Ok(c"")
+    }
+    pub fn type_acl(_v: Acl) {}
+    pub fn arg_acl(_v: Option<Acl>) {}
+    pub fn return_acl() -> Acl {
+        unimplemented!()
+    }
+    pub fn to_res_acl() -> Result<Acl, &'static str> {
+        Err("")
     }
     pub fn type_duration(_v: Duration) {}
     pub fn opt_duration(_v: Option<Duration>) {}

--- a/varnish/snapshots8.0.0/function_types@docs.snap
+++ b/varnish/snapshots8.0.0/function_types@docs.snap
@@ -62,6 +62,14 @@ import types from "path/to/libtypes.so";
 
 ### Function `STRING types.to_res_cstr_err()`
 
+### Function `VOID types.type_acl(ACL _v)`
+
+### Function `VOID types.arg_acl([ACL _v])`
+
+### Function `ACL types.return_acl()`
+
+### Function `ACL types.to_res_acl()`
+
 ### Function `VOID types.type_duration(DURATION _v)`
 
 ### Function `VOID types.opt_duration([DURATION _v])`

--- a/varnish/snapshots8.0.0/function_types@json.snap
+++ b/varnish/snapshots8.0.0/function_types@json.snap
@@ -8,7 +8,7 @@ VMOD_JSON_SPEC
     "2.0",
     "types",
     "Vmod_vmod_types_Func",
-    "c13df0540d7786fdca53f5d15d1111b8c80ab3d4de7401fb217f0fb2188d6a9c",
+    "90968e517039f4c73943ba74b5f3c2e8bc329a6a486d4b3d16075f7403c4f6d7",
     "Varnish (version) (hash)",
     "0",
     "0"
@@ -129,6 +129,29 @@ typedef VCL_STRING td_vmod_types_to_res_cstr(
 );
 
 typedef VCL_STRING td_vmod_types_to_res_cstr_err(
+    VRT_CTX
+);
+
+typedef VCL_VOID td_vmod_types_type_acl(
+    VRT_CTX,
+    VCL_ACL
+);
+
+struct arg_vmod_types_arg_acl {
+  char valid__v;
+  VCL_ACL _v;
+};
+
+typedef VCL_VOID td_vmod_types_arg_acl(
+    VRT_CTX,
+    struct arg_vmod_types_arg_acl *
+);
+
+typedef VCL_ACL td_vmod_types_return_acl(
+    VRT_CTX
+);
+
+typedef VCL_ACL td_vmod_types_to_res_acl(
     VRT_CTX
 );
 
@@ -389,6 +412,10 @@ struct Vmod_vmod_types_Func {
   td_vmod_types_to_cstr *f_to_cstr;
   td_vmod_types_to_res_cstr *f_to_res_cstr;
   td_vmod_types_to_res_cstr_err *f_to_res_cstr_err;
+  td_vmod_types_type_acl *f_type_acl;
+  td_vmod_types_arg_acl *f_arg_acl;
+  td_vmod_types_return_acl *f_return_acl;
+  td_vmod_types_to_res_acl *f_to_res_acl;
   td_vmod_types_type_duration *f_type_duration;
   td_vmod_types_opt_duration *f_opt_duration;
   td_vmod_types_to_duration *f_to_duration;
@@ -739,6 +766,63 @@ static struct Vmod_vmod_types_Func Vmod_vmod_types_Func;"
         "STRING"
       ],
       "Vmod_vmod_types_Func.f_to_res_cstr_err",
+      ""
+    ]
+  ],
+  [
+    "$FUNC",
+    "type_acl",
+    [
+      [
+        "VOID"
+      ],
+      "Vmod_vmod_types_Func.f_type_acl",
+      "",
+      [
+        "ACL",
+        "_v",
+        "_v"
+      ]
+    ]
+  ],
+  [
+    "$FUNC",
+    "arg_acl",
+    [
+      [
+        "VOID"
+      ],
+      "Vmod_vmod_types_Func.f_arg_acl",
+      "struct arg_vmod_types_arg_acl",
+      [
+        "ACL",
+        "_v",
+        "_v",
+        null,
+        null,
+        true
+      ]
+    ]
+  ],
+  [
+    "$FUNC",
+    "return_acl",
+    [
+      [
+        "ACL"
+      ],
+      "Vmod_vmod_types_Func.f_return_acl",
+      ""
+    ]
+  ],
+  [
+    "$FUNC",
+    "to_res_acl",
+    [
+      [
+        "ACL"
+      ],
+      "Vmod_vmod_types_Func.f_to_res_acl",
       ""
     ]
   ],

--- a/varnish/snapshots8.0.0/function_types@model.snap
+++ b/varnish/snapshots8.0.0/function_types@model.snap
@@ -395,6 +395,78 @@ VmodInfo {
         },
         FuncInfo {
             func_type: Function,
+            ident: "type_acl",
+            vcl_name: None,
+            docs: "",
+            has_optional_args: false,
+            args: [
+                ParamTypeInfo {
+                    ident: "_v",
+                    docs: "",
+                    ty: Value(
+                        ParamInfo {
+                            kind: Regular,
+                            default: Null,
+                            ty_info: Acl,
+                        },
+                    ),
+                },
+            ],
+            output_ty: Default,
+            out_result: false,
+            restrict: [],
+        },
+        FuncInfo {
+            func_type: Function,
+            ident: "arg_acl",
+            vcl_name: None,
+            docs: "",
+            has_optional_args: true,
+            args: [
+                ParamTypeInfo {
+                    ident: "_v",
+                    docs: "",
+                    ty: Value(
+                        ParamInfo {
+                            kind: Optional,
+                            default: Null,
+                            ty_info: Acl,
+                        },
+                    ),
+                },
+            ],
+            output_ty: Default,
+            out_result: false,
+            restrict: [],
+        },
+        FuncInfo {
+            func_type: Function,
+            ident: "return_acl",
+            vcl_name: None,
+            docs: "",
+            has_optional_args: false,
+            args: [],
+            output_ty: ParamType(
+                Acl,
+            ),
+            out_result: false,
+            restrict: [],
+        },
+        FuncInfo {
+            func_type: Function,
+            ident: "to_res_acl",
+            vcl_name: None,
+            docs: "",
+            has_optional_args: false,
+            args: [],
+            output_ty: ParamType(
+                Acl,
+            ),
+            out_result: true,
+            restrict: [],
+        },
+        FuncInfo {
+            func_type: Function,
             ident: "type_duration",
             vcl_name: None,
             docs: "",

--- a/varnish/snapshots8.0.0/object2_obj2@code.snap
+++ b/varnish/snapshots8.0.0/object2_obj2@code.snap
@@ -9,10 +9,10 @@ mod obj2 {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots8.0.0/object_multi_constructor_multi_constructor@code.snap
+++ b/varnish/snapshots8.0.0/object_multi_constructor_multi_constructor@code.snap
@@ -9,10 +9,10 @@ mod multi_constructor {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots8.0.0/object_non_new_constructor_non_new_constructor@code.snap
+++ b/varnish/snapshots8.0.0/object_non_new_constructor_non_new_constructor@code.snap
@@ -9,10 +9,10 @@ mod non_new_constructor {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots8.0.0/object_obj@code.snap
+++ b/varnish/snapshots8.0.0/object_obj@code.snap
@@ -9,10 +9,10 @@ mod obj {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots8.0.0/restrict_restrict_scopes@code.snap
+++ b/varnish/snapshots8.0.0/restrict_restrict_scopes@code.snap
@@ -9,10 +9,10 @@ mod restrict_scopes {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots8.0.0/return_returns@code.snap
+++ b/varnish/snapshots8.0.0/return_returns@code.snap
@@ -9,10 +9,10 @@ mod returns {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots8.0.0/shared1_task@code.snap
+++ b/varnish/snapshots8.0.0/shared1_task@code.snap
@@ -9,10 +9,10 @@ mod task {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots8.0.0/shared2_tuple@code.snap
+++ b/varnish/snapshots8.0.0/shared2_tuple@code.snap
@@ -9,10 +9,10 @@ mod tuple {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots8.0.0/shared3_tuple@code.snap
+++ b/varnish/snapshots8.0.0/shared3_tuple@code.snap
@@ -9,10 +9,10 @@ mod tuple {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots8.0.0/shared4_refcell_task@code.snap
+++ b/varnish/snapshots8.0.0/shared4_refcell_task@code.snap
@@ -9,10 +9,10 @@ mod refcell_task {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots8.0.0/shared5_refcell_task_map@code.snap
+++ b/varnish/snapshots8.0.0/shared5_refcell_task_map@code.snap
@@ -9,10 +9,10 @@ mod refcell_task_map {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots8.0.0/vcl_args_vcl_args@code.snap
+++ b/varnish/snapshots8.0.0/vcl_args_vcl_args@code.snap
@@ -9,10 +9,10 @@ mod vcl_args {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots8.0.0/vcl_rename_vcl_rename@code.snap
+++ b/varnish/snapshots8.0.0/vcl_rename_vcl_rename@code.snap
@@ -9,10 +9,10 @@ mod vcl_rename {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots8.0.0/vcl_returns_vcl_returns@code.snap
+++ b/varnish/snapshots8.0.0/vcl_returns_vcl_returns@code.snap
@@ -9,10 +9,10 @@ mod vcl_returns {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots9.0.0/args_args@code.snap
+++ b/varnish/snapshots9.0.0/args_args@code.snap
@@ -9,10 +9,10 @@ mod args {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots9.0.0/docs_types@code.snap
+++ b/varnish/snapshots9.0.0/docs_types@code.snap
@@ -18,10 +18,10 @@ mod types {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots9.0.0/event1_event@code.snap
+++ b/varnish/snapshots9.0.0/event1_event@code.snap
@@ -9,10 +9,10 @@ mod event {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots9.0.0/event2_event2@code.snap
+++ b/varnish/snapshots9.0.0/event2_event2@code.snap
@@ -9,10 +9,10 @@ mod event2 {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots9.0.0/event3_event3@code.snap
+++ b/varnish/snapshots9.0.0/event3_event3@code.snap
@@ -9,10 +9,10 @@ mod event3 {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots9.0.0/event4_event4@code.snap
+++ b/varnish/snapshots9.0.0/event4_event4@code.snap
@@ -9,10 +9,10 @@ mod event4 {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots9.0.0/function_types@code.snap
+++ b/varnish/snapshots9.0.0/function_types@code.snap
@@ -9,21 +9,10 @@ mod types {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-<<<<<<< HEAD
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-=======
             VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
-<<<<<<< HEAD
-            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
->>>>>>> 4e0c943 (Update snapshots for new Acl type)
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
-=======
             VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
             VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
             VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
->>>>>>> ca08975 (Remove tests for Option<Option<Acl>>)
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;
@@ -202,22 +191,33 @@ mod types {
                     Default::default()
                 })
         }
+        unsafe extern "C" fn vmod_c_type_acl(__ctx: *mut vrt_ctx, _v: VCL_ACL) {
+            super::type_acl(_v.into())
+        }
         #[repr(C)]
-        struct arg_vmod_types_opt_acl {
+        struct arg_vmod_types_arg_acl {
             valid__v: c_char,
             _v: VCL_ACL,
         }
-        unsafe extern "C" fn vmod_c_opt_acl(
+        unsafe extern "C" fn vmod_c_arg_acl(
             __ctx: *mut vrt_ctx,
-            __args: *const arg_vmod_types_opt_acl,
+            __args: *const arg_vmod_types_arg_acl,
         ) {
             let __args = __args
                 .as_ref()
                 .expect("optional args pointer must not be null");
-            super::opt_acl(if __args.valid__v != 0 { __args._v.into() } else { None })
+            super::arg_acl(if __args.valid__v != 0 { __args._v.into() } else { None })
         }
-        unsafe extern "C" fn vmod_c_opt_req_acl(__ctx: *mut vrt_ctx, _v: VCL_ACL) {
-            super::opt_req_acl(_v.into())
+        unsafe extern "C" fn vmod_c_return_acl(__ctx: *mut vrt_ctx) -> VCL_ACL {
+            let mut __ctx = Ctx::from_ptr(__ctx);
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                Ok(super::return_acl().into_vcl(&mut __ctx.ws)?)
+            };
+            __call_user_func()
+                .unwrap_or_else(|err| {
+                    __ctx.fail(err);
+                    Default::default()
+                })
         }
         unsafe extern "C" fn vmod_c_to_res_acl(__ctx: *mut vrt_ctx) -> VCL_ACL {
             let mut __ctx = Ctx::from_ptr(__ctx);
@@ -754,14 +754,17 @@ mod types {
             vmod_c_to_res_cstr_err: Option<
                 unsafe extern "C" fn(__ctx: *mut vrt_ctx) -> VCL_STRING,
             >,
-            vmod_c_opt_acl: Option<
+            vmod_c_type_acl: Option<
+                unsafe extern "C" fn(__ctx: *mut vrt_ctx, _v: VCL_ACL),
+            >,
+            vmod_c_arg_acl: Option<
                 unsafe extern "C" fn(
                     __ctx: *mut vrt_ctx,
-                    __args: *const arg_vmod_types_opt_acl,
+                    __args: *const arg_vmod_types_arg_acl,
                 ),
             >,
-            vmod_c_opt_req_acl: Option<
-                unsafe extern "C" fn(__ctx: *mut vrt_ctx, _v: VCL_ACL),
+            vmod_c_return_acl: Option<
+                unsafe extern "C" fn(__ctx: *mut vrt_ctx) -> VCL_ACL,
             >,
             vmod_c_to_res_acl: Option<
                 unsafe extern "C" fn(__ctx: *mut vrt_ctx) -> VCL_ACL,
@@ -932,8 +935,9 @@ mod types {
             vmod_c_to_cstr: Some(vmod_c_to_cstr),
             vmod_c_to_res_cstr: Some(vmod_c_to_res_cstr),
             vmod_c_to_res_cstr_err: Some(vmod_c_to_res_cstr_err),
-            vmod_c_opt_acl: Some(vmod_c_opt_acl),
-            vmod_c_opt_req_acl: Some(vmod_c_opt_req_acl),
+            vmod_c_type_acl: Some(vmod_c_type_acl),
+            vmod_c_arg_acl: Some(vmod_c_arg_acl),
+            vmod_c_return_acl: Some(vmod_c_return_acl),
             vmod_c_to_res_acl: Some(vmod_c_to_res_acl),
             vmod_c_type_duration: Some(vmod_c_type_duration),
             vmod_c_opt_duration: Some(vmod_c_opt_duration),
@@ -983,15 +987,7 @@ mod types {
         pub static Vmod_types_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
-<<<<<<< HEAD
-<<<<<<< HEAD
-            file_id: c"c13df0540d7786fdca53f5d15d1111b8c80ab3d4de7401fb217f0fb2188d6a9c"
-=======
-            file_id: c"bf16dadd071d5848b6db9a3adf94d4b5e98d040f188bc7d5e9db15106b5f5029"
->>>>>>> 4e0c943 (Update snapshots for new Acl type)
-=======
-            file_id: c"6a07d4e6b45387996d6ddf4316f787c14c6ec62d8d17fc10c182b3dcf2cc172c"
->>>>>>> ca08975 (Remove tests for Option<Option<Acl>>)
+            file_id: c"90968e517039f4c73943ba74b5f3c2e8bc329a6a486d4b3d16075f7403c4f6d7"
                 .as_ptr(),
             name: c"types".as_ptr(),
             func_name: c"Vmod_vmod_types_Func".as_ptr(),
@@ -1049,9 +1045,12 @@ mod types {
     pub fn to_res_cstr_err() -> Result<&'static CStr, &'static CStr> {
         Ok(c"")
     }
-    pub fn opt_acl(_v: Option<Acl>) {}
-    pub fn opt_req_acl(_v: Option<Acl>) {}
-    pub fn to_res_acl() -> Result<Option<Acl>, &'static str> {
+    pub fn type_acl(_v: Acl) {}
+    pub fn arg_acl(_v: Option<Acl>) {}
+    pub fn return_acl() -> Acl {
+        unimplemented!()
+    }
+    pub fn to_res_acl() -> Result<Acl, &'static str> {
         Err("")
     }
     pub fn type_duration(_v: Duration) {}

--- a/varnish/snapshots9.0.0/function_types@code.snap
+++ b/varnish/snapshots9.0.0/function_types@code.snap
@@ -9,8 +9,13 @@ mod types {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
+<<<<<<< HEAD
             VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
             VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
+=======
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
+>>>>>>> 4e0c943 (Update snapshots for new Acl type)
             VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
             vmod_priv_methods,
         };
@@ -184,6 +189,34 @@ mod types {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
                 Ok(super::to_res_cstr_err()?.into_vcl(&mut __ctx.ws)?)
+            };
+            __call_user_func()
+                .unwrap_or_else(|err| {
+                    __ctx.fail(err);
+                    Default::default()
+                })
+        }
+        #[repr(C)]
+        struct arg_vmod_types_opt_acl {
+            valid__v: c_char,
+            _v: VCL_ACL,
+        }
+        unsafe extern "C" fn vmod_c_opt_acl(
+            __ctx: *mut vrt_ctx,
+            __args: *const arg_vmod_types_opt_acl,
+        ) {
+            let __args = __args
+                .as_ref()
+                .expect("optional args pointer must not be null");
+            super::opt_acl(if __args.valid__v != 0 { __args._v.into() } else { None })
+        }
+        unsafe extern "C" fn vmod_c_opt_req_acl(__ctx: *mut vrt_ctx, _v: VCL_ACL) {
+            super::opt_req_acl(_v.into())
+        }
+        unsafe extern "C" fn vmod_c_to_res_acl(__ctx: *mut vrt_ctx) -> VCL_ACL {
+            let mut __ctx = Ctx::from_ptr(__ctx);
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                Ok(super::to_res_acl()?.into_vcl(&mut __ctx.ws)?)
             };
             __call_user_func()
                 .unwrap_or_else(|err| {
@@ -715,6 +748,18 @@ mod types {
             vmod_c_to_res_cstr_err: Option<
                 unsafe extern "C" fn(__ctx: *mut vrt_ctx) -> VCL_STRING,
             >,
+            vmod_c_opt_acl: Option<
+                unsafe extern "C" fn(
+                    __ctx: *mut vrt_ctx,
+                    __args: *const arg_vmod_types_opt_acl,
+                ),
+            >,
+            vmod_c_opt_req_acl: Option<
+                unsafe extern "C" fn(__ctx: *mut vrt_ctx, _v: VCL_ACL),
+            >,
+            vmod_c_to_res_acl: Option<
+                unsafe extern "C" fn(__ctx: *mut vrt_ctx) -> VCL_ACL,
+            >,
             vmod_c_type_duration: Option<
                 unsafe extern "C" fn(__ctx: *mut vrt_ctx, _v: VCL_DURATION),
             >,
@@ -881,6 +926,9 @@ mod types {
             vmod_c_to_cstr: Some(vmod_c_to_cstr),
             vmod_c_to_res_cstr: Some(vmod_c_to_res_cstr),
             vmod_c_to_res_cstr_err: Some(vmod_c_to_res_cstr_err),
+            vmod_c_opt_acl: Some(vmod_c_opt_acl),
+            vmod_c_opt_req_acl: Some(vmod_c_opt_req_acl),
+            vmod_c_to_res_acl: Some(vmod_c_to_res_acl),
             vmod_c_type_duration: Some(vmod_c_type_duration),
             vmod_c_opt_duration: Some(vmod_c_opt_duration),
             vmod_c_to_duration: Some(vmod_c_to_duration),
@@ -929,7 +977,11 @@ mod types {
         pub static Vmod_types_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
+<<<<<<< HEAD
             file_id: c"c13df0540d7786fdca53f5d15d1111b8c80ab3d4de7401fb217f0fb2188d6a9c"
+=======
+            file_id: c"bf16dadd071d5848b6db9a3adf94d4b5e98d040f188bc7d5e9db15106b5f5029"
+>>>>>>> 4e0c943 (Update snapshots for new Acl type)
                 .as_ptr(),
             name: c"types".as_ptr(),
             func_name: c"Vmod_vmod_types_Func".as_ptr(),
@@ -948,7 +1000,7 @@ mod types {
     use std::net::SocketAddr;
     use std::time::Duration;
     use varnish::ffi::VCL_STRING;
-    use varnish::vcl::{CowProbe, Probe, Workspace};
+    use varnish::vcl::{Acl, CowProbe, Probe, Workspace};
     use varnish_sys::vcl::VclError;
     pub fn to_void() {}
     pub fn to_res_void_err() -> Result<(), VclError> {
@@ -986,6 +1038,11 @@ mod types {
     }
     pub fn to_res_cstr_err() -> Result<&'static CStr, &'static CStr> {
         Ok(c"")
+    }
+    pub fn opt_acl(_v: Option<Acl>) {}
+    pub fn opt_req_acl(_v: Option<Acl>) {}
+    pub fn to_res_acl() -> Result<Option<Acl>, &'static str> {
+        Err("")
     }
     pub fn type_duration(_v: Duration) {}
     pub fn opt_duration(_v: Option<Duration>) {}

--- a/varnish/snapshots9.0.0/function_types@code.snap
+++ b/varnish/snapshots9.0.0/function_types@code.snap
@@ -14,10 +14,16 @@ mod types {
             VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
 =======
             VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+<<<<<<< HEAD
             VCL_PROBE, VCL_REAL, VCL_STRING, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
 >>>>>>> 4e0c943 (Update snapshots for new Acl type)
             VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
             vmod_priv_methods,
+=======
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
+>>>>>>> ca08975 (Remove tests for Option<Option<Acl>>)
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;
@@ -978,10 +984,14 @@ mod types {
             vrt_major: 0,
             vrt_minor: 0,
 <<<<<<< HEAD
+<<<<<<< HEAD
             file_id: c"c13df0540d7786fdca53f5d15d1111b8c80ab3d4de7401fb217f0fb2188d6a9c"
 =======
             file_id: c"bf16dadd071d5848b6db9a3adf94d4b5e98d040f188bc7d5e9db15106b5f5029"
 >>>>>>> 4e0c943 (Update snapshots for new Acl type)
+=======
+            file_id: c"6a07d4e6b45387996d6ddf4316f787c14c6ec62d8d17fc10c182b3dcf2cc172c"
+>>>>>>> ca08975 (Remove tests for Option<Option<Acl>>)
                 .as_ptr(),
             name: c"types".as_ptr(),
             func_name: c"Vmod_vmod_types_Func".as_ptr(),

--- a/varnish/snapshots9.0.0/function_types@docs.snap
+++ b/varnish/snapshots9.0.0/function_types@docs.snap
@@ -62,6 +62,12 @@ import types from "path/to/libtypes.so";
 
 ### Function `STRING types.to_res_cstr_err()`
 
+### Function `VOID types.opt_acl([ACL _v])`
+
+### Function `VOID types.opt_req_acl(ACL _v)`
+
+### Function `ACL types.to_res_acl()`
+
 ### Function `VOID types.type_duration(DURATION _v)`
 
 ### Function `VOID types.opt_duration([DURATION _v])`

--- a/varnish/snapshots9.0.0/function_types@docs.snap
+++ b/varnish/snapshots9.0.0/function_types@docs.snap
@@ -62,9 +62,11 @@ import types from "path/to/libtypes.so";
 
 ### Function `STRING types.to_res_cstr_err()`
 
-### Function `VOID types.opt_acl([ACL _v])`
+### Function `VOID types.type_acl(ACL _v)`
 
-### Function `VOID types.opt_req_acl(ACL _v)`
+### Function `VOID types.arg_acl([ACL _v])`
+
+### Function `ACL types.return_acl()`
 
 ### Function `ACL types.to_res_acl()`
 

--- a/varnish/snapshots9.0.0/function_types@error.snap
+++ b/varnish/snapshots9.0.0/function_types@error.snap
@@ -1,0 +1,4 @@
+---
+source: varnish-macros/src/tests.rs
+---
+:: core :: compile_error ! { "unsupported argument type" }

--- a/varnish/snapshots9.0.0/function_types@error.snap
+++ b/varnish/snapshots9.0.0/function_types@error.snap
@@ -1,4 +1,0 @@
----
-source: varnish-macros/src/tests.rs
----
-:: core :: compile_error ! { "unsupported argument type" }

--- a/varnish/snapshots9.0.0/function_types@json.snap
+++ b/varnish/snapshots9.0.0/function_types@json.snap
@@ -9,10 +9,14 @@ VMOD_JSON_SPEC
     "types",
     "Vmod_vmod_types_Func",
 <<<<<<< HEAD
+<<<<<<< HEAD
     "c13df0540d7786fdca53f5d15d1111b8c80ab3d4de7401fb217f0fb2188d6a9c",
 =======
     "bf16dadd071d5848b6db9a3adf94d4b5e98d040f188bc7d5e9db15106b5f5029",
 >>>>>>> 4e0c943 (Update snapshots for new Acl type)
+=======
+    "6a07d4e6b45387996d6ddf4316f787c14c6ec62d8d17fc10c182b3dcf2cc172c",
+>>>>>>> ca08975 (Remove tests for Option<Option<Acl>>)
     "Varnish (version) (hash)",
     "0",
     "0"

--- a/varnish/snapshots9.0.0/function_types@json.snap
+++ b/varnish/snapshots9.0.0/function_types@json.snap
@@ -8,15 +8,7 @@ VMOD_JSON_SPEC
     "2.0",
     "types",
     "Vmod_vmod_types_Func",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "c13df0540d7786fdca53f5d15d1111b8c80ab3d4de7401fb217f0fb2188d6a9c",
-=======
-    "bf16dadd071d5848b6db9a3adf94d4b5e98d040f188bc7d5e9db15106b5f5029",
->>>>>>> 4e0c943 (Update snapshots for new Acl type)
-=======
-    "6a07d4e6b45387996d6ddf4316f787c14c6ec62d8d17fc10c182b3dcf2cc172c",
->>>>>>> ca08975 (Remove tests for Option<Option<Acl>>)
+    "90968e517039f4c73943ba74b5f3c2e8bc329a6a486d4b3d16075f7403c4f6d7",
     "Varnish (version) (hash)",
     "0",
     "0"
@@ -140,19 +132,23 @@ typedef VCL_STRING td_vmod_types_to_res_cstr_err(
     VRT_CTX
 );
 
-struct arg_vmod_types_opt_acl {
+typedef VCL_VOID td_vmod_types_type_acl(
+    VRT_CTX,
+    VCL_ACL
+);
+
+struct arg_vmod_types_arg_acl {
   char valid__v;
   VCL_ACL _v;
 };
 
-typedef VCL_VOID td_vmod_types_opt_acl(
+typedef VCL_VOID td_vmod_types_arg_acl(
     VRT_CTX,
-    struct arg_vmod_types_opt_acl *
+    struct arg_vmod_types_arg_acl *
 );
 
-typedef VCL_VOID td_vmod_types_opt_req_acl(
-    VRT_CTX,
-    VCL_ACL
+typedef VCL_ACL td_vmod_types_return_acl(
+    VRT_CTX
 );
 
 typedef VCL_ACL td_vmod_types_to_res_acl(
@@ -416,8 +412,9 @@ struct Vmod_vmod_types_Func {
   td_vmod_types_to_cstr *f_to_cstr;
   td_vmod_types_to_res_cstr *f_to_res_cstr;
   td_vmod_types_to_res_cstr_err *f_to_res_cstr_err;
-  td_vmod_types_opt_acl *f_opt_acl;
-  td_vmod_types_opt_req_acl *f_opt_req_acl;
+  td_vmod_types_type_acl *f_type_acl;
+  td_vmod_types_arg_acl *f_arg_acl;
+  td_vmod_types_return_acl *f_return_acl;
   td_vmod_types_to_res_acl *f_to_res_acl;
   td_vmod_types_type_duration *f_type_duration;
   td_vmod_types_opt_duration *f_opt_duration;
@@ -774,13 +771,29 @@ static struct Vmod_vmod_types_Func Vmod_vmod_types_Func;"
   ],
   [
     "$FUNC",
-    "opt_acl",
+    "type_acl",
     [
       [
         "VOID"
       ],
-      "Vmod_vmod_types_Func.f_opt_acl",
-      "struct arg_vmod_types_opt_acl",
+      "Vmod_vmod_types_Func.f_type_acl",
+      "",
+      [
+        "ACL",
+        "_v",
+        "_v"
+      ]
+    ]
+  ],
+  [
+    "$FUNC",
+    "arg_acl",
+    [
+      [
+        "VOID"
+      ],
+      "Vmod_vmod_types_Func.f_arg_acl",
+      "struct arg_vmod_types_arg_acl",
       [
         "ACL",
         "_v",
@@ -793,18 +806,13 @@ static struct Vmod_vmod_types_Func Vmod_vmod_types_Func;"
   ],
   [
     "$FUNC",
-    "opt_req_acl",
+    "return_acl",
     [
       [
-        "VOID"
+        "ACL"
       ],
-      "Vmod_vmod_types_Func.f_opt_req_acl",
-      "",
-      [
-        "ACL",
-        "_v",
-        "_v"
-      ]
+      "Vmod_vmod_types_Func.f_return_acl",
+      ""
     ]
   ],
   [

--- a/varnish/snapshots9.0.0/function_types@json.snap
+++ b/varnish/snapshots9.0.0/function_types@json.snap
@@ -8,7 +8,11 @@ VMOD_JSON_SPEC
     "2.0",
     "types",
     "Vmod_vmod_types_Func",
+<<<<<<< HEAD
     "c13df0540d7786fdca53f5d15d1111b8c80ab3d4de7401fb217f0fb2188d6a9c",
+=======
+    "bf16dadd071d5848b6db9a3adf94d4b5e98d040f188bc7d5e9db15106b5f5029",
+>>>>>>> 4e0c943 (Update snapshots for new Acl type)
     "Varnish (version) (hash)",
     "0",
     "0"
@@ -129,6 +133,25 @@ typedef VCL_STRING td_vmod_types_to_res_cstr(
 );
 
 typedef VCL_STRING td_vmod_types_to_res_cstr_err(
+    VRT_CTX
+);
+
+struct arg_vmod_types_opt_acl {
+  char valid__v;
+  VCL_ACL _v;
+};
+
+typedef VCL_VOID td_vmod_types_opt_acl(
+    VRT_CTX,
+    struct arg_vmod_types_opt_acl *
+);
+
+typedef VCL_VOID td_vmod_types_opt_req_acl(
+    VRT_CTX,
+    VCL_ACL
+);
+
+typedef VCL_ACL td_vmod_types_to_res_acl(
     VRT_CTX
 );
 
@@ -389,6 +412,9 @@ struct Vmod_vmod_types_Func {
   td_vmod_types_to_cstr *f_to_cstr;
   td_vmod_types_to_res_cstr *f_to_res_cstr;
   td_vmod_types_to_res_cstr_err *f_to_res_cstr_err;
+  td_vmod_types_opt_acl *f_opt_acl;
+  td_vmod_types_opt_req_acl *f_opt_req_acl;
+  td_vmod_types_to_res_acl *f_to_res_acl;
   td_vmod_types_type_duration *f_type_duration;
   td_vmod_types_opt_duration *f_opt_duration;
   td_vmod_types_to_duration *f_to_duration;
@@ -739,6 +765,52 @@ static struct Vmod_vmod_types_Func Vmod_vmod_types_Func;"
         "STRING"
       ],
       "Vmod_vmod_types_Func.f_to_res_cstr_err",
+      ""
+    ]
+  ],
+  [
+    "$FUNC",
+    "opt_acl",
+    [
+      [
+        "VOID"
+      ],
+      "Vmod_vmod_types_Func.f_opt_acl",
+      "struct arg_vmod_types_opt_acl",
+      [
+        "ACL",
+        "_v",
+        "_v",
+        null,
+        null,
+        true
+      ]
+    ]
+  ],
+  [
+    "$FUNC",
+    "opt_req_acl",
+    [
+      [
+        "VOID"
+      ],
+      "Vmod_vmod_types_Func.f_opt_req_acl",
+      "",
+      [
+        "ACL",
+        "_v",
+        "_v"
+      ]
+    ]
+  ],
+  [
+    "$FUNC",
+    "to_res_acl",
+    [
+      [
+        "ACL"
+      ],
+      "Vmod_vmod_types_Func.f_to_res_acl",
       ""
     ]
   ],

--- a/varnish/snapshots9.0.0/function_types@model.snap
+++ b/varnish/snapshots9.0.0/function_types@model.snap
@@ -395,7 +395,30 @@ VmodInfo {
         },
         FuncInfo {
             func_type: Function,
-            ident: "opt_acl",
+            ident: "type_acl",
+            vcl_name: None,
+            docs: "",
+            has_optional_args: false,
+            args: [
+                ParamTypeInfo {
+                    ident: "_v",
+                    docs: "",
+                    ty: Value(
+                        ParamInfo {
+                            kind: Regular,
+                            default: Null,
+                            ty_info: Acl,
+                        },
+                    ),
+                },
+            ],
+            output_ty: Default,
+            out_result: false,
+            restrict: [],
+        },
+        FuncInfo {
+            func_type: Function,
+            ident: "arg_acl",
             vcl_name: None,
             docs: "",
             has_optional_args: true,
@@ -418,24 +441,14 @@ VmodInfo {
         },
         FuncInfo {
             func_type: Function,
-            ident: "opt_req_acl",
+            ident: "return_acl",
             vcl_name: None,
             docs: "",
             has_optional_args: false,
-            args: [
-                ParamTypeInfo {
-                    ident: "_v",
-                    docs: "",
-                    ty: Value(
-                        ParamInfo {
-                            kind: Required,
-                            default: Null,
-                            ty_info: Acl,
-                        },
-                    ),
-                },
-            ],
-            output_ty: Default,
+            args: [],
+            output_ty: ParamType(
+                Acl,
+            ),
             out_result: false,
             restrict: [],
         },

--- a/varnish/snapshots9.0.0/function_types@model.snap
+++ b/varnish/snapshots9.0.0/function_types@model.snap
@@ -395,6 +395,62 @@ VmodInfo {
         },
         FuncInfo {
             func_type: Function,
+            ident: "opt_acl",
+            docs: "",
+            has_optional_args: true,
+            args: [
+                ParamTypeInfo {
+                    ident: "_v",
+                    docs: "",
+                    ty: Value(
+                        ParamInfo {
+                            kind: Optional,
+                            default: Null,
+                            ty_info: Acl,
+                        },
+                    ),
+                },
+            ],
+            output_ty: Default,
+            out_result: false,
+            restrict: [],
+        },
+        FuncInfo {
+            func_type: Function,
+            ident: "opt_req_acl",
+            docs: "",
+            has_optional_args: false,
+            args: [
+                ParamTypeInfo {
+                    ident: "_v",
+                    docs: "",
+                    ty: Value(
+                        ParamInfo {
+                            kind: Required,
+                            default: Null,
+                            ty_info: Acl,
+                        },
+                    ),
+                },
+            ],
+            output_ty: Default,
+            out_result: false,
+            restrict: [],
+        },
+        FuncInfo {
+            func_type: Function,
+            ident: "to_res_acl",
+            docs: "",
+            has_optional_args: false,
+            args: [],
+            output_ty: ParamType(
+                Acl,
+            ),
+            out_result: true,
+            restrict: [],
+        },
+        FuncInfo {
+            func_type: Function,
             ident: "type_duration",
             vcl_name: None,
             docs: "",

--- a/varnish/snapshots9.0.0/function_types@model.snap
+++ b/varnish/snapshots9.0.0/function_types@model.snap
@@ -396,6 +396,7 @@ VmodInfo {
         FuncInfo {
             func_type: Function,
             ident: "opt_acl",
+            vcl_name: None,
             docs: "",
             has_optional_args: true,
             args: [
@@ -418,6 +419,7 @@ VmodInfo {
         FuncInfo {
             func_type: Function,
             ident: "opt_req_acl",
+            vcl_name: None,
             docs: "",
             has_optional_args: false,
             args: [
@@ -440,6 +442,7 @@ VmodInfo {
         FuncInfo {
             func_type: Function,
             ident: "to_res_acl",
+            vcl_name: None,
             docs: "",
             has_optional_args: false,
             args: [],

--- a/varnish/snapshots9.0.0/object2_obj2@code.snap
+++ b/varnish/snapshots9.0.0/object2_obj2@code.snap
@@ -9,10 +9,10 @@ mod obj2 {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots9.0.0/object_multi_constructor_multi_constructor@code.snap
+++ b/varnish/snapshots9.0.0/object_multi_constructor_multi_constructor@code.snap
@@ -9,10 +9,10 @@ mod multi_constructor {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots9.0.0/object_non_new_constructor_non_new_constructor@code.snap
+++ b/varnish/snapshots9.0.0/object_non_new_constructor_non_new_constructor@code.snap
@@ -9,10 +9,10 @@ mod non_new_constructor {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots9.0.0/object_obj@code.snap
+++ b/varnish/snapshots9.0.0/object_obj@code.snap
@@ -9,10 +9,10 @@ mod obj {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots9.0.0/restrict_restrict_scopes@code.snap
+++ b/varnish/snapshots9.0.0/restrict_restrict_scopes@code.snap
@@ -9,10 +9,10 @@ mod restrict_scopes {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots9.0.0/return_returns@code.snap
+++ b/varnish/snapshots9.0.0/return_returns@code.snap
@@ -9,10 +9,10 @@ mod returns {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots9.0.0/shared1_task@code.snap
+++ b/varnish/snapshots9.0.0/shared1_task@code.snap
@@ -9,10 +9,10 @@ mod task {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots9.0.0/shared2_tuple@code.snap
+++ b/varnish/snapshots9.0.0/shared2_tuple@code.snap
@@ -9,10 +9,10 @@ mod tuple {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots9.0.0/shared3_tuple@code.snap
+++ b/varnish/snapshots9.0.0/shared3_tuple@code.snap
@@ -9,10 +9,10 @@ mod tuple {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots9.0.0/shared4_refcell_task@code.snap
+++ b/varnish/snapshots9.0.0/shared4_refcell_task@code.snap
@@ -9,10 +9,10 @@ mod refcell_task {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots9.0.0/shared5_refcell_task_map@code.snap
+++ b/varnish/snapshots9.0.0/shared5_refcell_task_map@code.snap
@@ -9,10 +9,10 @@ mod refcell_task_map {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots9.0.0/vcl_args_vcl_args@code.snap
+++ b/varnish/snapshots9.0.0/vcl_args_vcl_args@code.snap
@@ -9,10 +9,10 @@ mod vcl_args {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots9.0.0/vcl_rename_vcl_rename@code.snap
+++ b/varnish/snapshots9.0.0/vcl_rename_vcl_rename@code.snap
@@ -9,10 +9,10 @@ mod vcl_rename {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshots9.0.0/vcl_returns_vcl_returns@code.snap
+++ b/varnish/snapshots9.0.0/vcl_returns_vcl_returns@code.snap
@@ -9,10 +9,10 @@ mod vcl_returns {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshotstrunk/args_args@code.snap
+++ b/varnish/snapshotstrunk/args_args@code.snap
@@ -9,10 +9,10 @@ mod args {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshotstrunk/docs_types@code.snap
+++ b/varnish/snapshotstrunk/docs_types@code.snap
@@ -18,10 +18,10 @@ mod types {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshotstrunk/event1_event@code.snap
+++ b/varnish/snapshotstrunk/event1_event@code.snap
@@ -9,10 +9,10 @@ mod event {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshotstrunk/event2_event2@code.snap
+++ b/varnish/snapshotstrunk/event2_event2@code.snap
@@ -9,10 +9,10 @@ mod event2 {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshotstrunk/event3_event3@code.snap
+++ b/varnish/snapshotstrunk/event3_event3@code.snap
@@ -9,10 +9,10 @@ mod event3 {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshotstrunk/event4_event4@code.snap
+++ b/varnish/snapshotstrunk/event4_event4@code.snap
@@ -9,10 +9,10 @@ mod event4 {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshotstrunk/function_types@code.snap
+++ b/varnish/snapshotstrunk/function_types@code.snap
@@ -9,10 +9,10 @@ mod types {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;
@@ -184,6 +184,45 @@ mod types {
             let mut __ctx = Ctx::from_ptr(__ctx);
             let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
                 Ok(super::to_res_cstr_err()?.into_vcl(&mut __ctx.ws)?)
+            };
+            __call_user_func()
+                .unwrap_or_else(|err| {
+                    __ctx.fail(err);
+                    Default::default()
+                })
+        }
+        unsafe extern "C" fn vmod_c_type_acl(__ctx: *mut vrt_ctx, _v: VCL_ACL) {
+            super::type_acl(_v.into())
+        }
+        #[repr(C)]
+        struct arg_vmod_types_arg_acl {
+            valid__v: c_char,
+            _v: VCL_ACL,
+        }
+        unsafe extern "C" fn vmod_c_arg_acl(
+            __ctx: *mut vrt_ctx,
+            __args: *const arg_vmod_types_arg_acl,
+        ) {
+            let __args = __args
+                .as_ref()
+                .expect("optional args pointer must not be null");
+            super::arg_acl(if __args.valid__v != 0 { __args._v.into() } else { None })
+        }
+        unsafe extern "C" fn vmod_c_return_acl(__ctx: *mut vrt_ctx) -> VCL_ACL {
+            let mut __ctx = Ctx::from_ptr(__ctx);
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                Ok(super::return_acl().into_vcl(&mut __ctx.ws)?)
+            };
+            __call_user_func()
+                .unwrap_or_else(|err| {
+                    __ctx.fail(err);
+                    Default::default()
+                })
+        }
+        unsafe extern "C" fn vmod_c_to_res_acl(__ctx: *mut vrt_ctx) -> VCL_ACL {
+            let mut __ctx = Ctx::from_ptr(__ctx);
+            let mut __call_user_func = || -> Result<_, ::varnish::vcl::VclError> {
+                Ok(super::to_res_acl()?.into_vcl(&mut __ctx.ws)?)
             };
             __call_user_func()
                 .unwrap_or_else(|err| {
@@ -715,6 +754,21 @@ mod types {
             vmod_c_to_res_cstr_err: Option<
                 unsafe extern "C" fn(__ctx: *mut vrt_ctx) -> VCL_STRING,
             >,
+            vmod_c_type_acl: Option<
+                unsafe extern "C" fn(__ctx: *mut vrt_ctx, _v: VCL_ACL),
+            >,
+            vmod_c_arg_acl: Option<
+                unsafe extern "C" fn(
+                    __ctx: *mut vrt_ctx,
+                    __args: *const arg_vmod_types_arg_acl,
+                ),
+            >,
+            vmod_c_return_acl: Option<
+                unsafe extern "C" fn(__ctx: *mut vrt_ctx) -> VCL_ACL,
+            >,
+            vmod_c_to_res_acl: Option<
+                unsafe extern "C" fn(__ctx: *mut vrt_ctx) -> VCL_ACL,
+            >,
             vmod_c_type_duration: Option<
                 unsafe extern "C" fn(__ctx: *mut vrt_ctx, _v: VCL_DURATION),
             >,
@@ -881,6 +935,10 @@ mod types {
             vmod_c_to_cstr: Some(vmod_c_to_cstr),
             vmod_c_to_res_cstr: Some(vmod_c_to_res_cstr),
             vmod_c_to_res_cstr_err: Some(vmod_c_to_res_cstr_err),
+            vmod_c_type_acl: Some(vmod_c_type_acl),
+            vmod_c_arg_acl: Some(vmod_c_arg_acl),
+            vmod_c_return_acl: Some(vmod_c_return_acl),
+            vmod_c_to_res_acl: Some(vmod_c_to_res_acl),
             vmod_c_type_duration: Some(vmod_c_type_duration),
             vmod_c_opt_duration: Some(vmod_c_opt_duration),
             vmod_c_to_duration: Some(vmod_c_to_duration),
@@ -929,7 +987,7 @@ mod types {
         pub static Vmod_types_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
-            file_id: c"c13df0540d7786fdca53f5d15d1111b8c80ab3d4de7401fb217f0fb2188d6a9c"
+            file_id: c"90968e517039f4c73943ba74b5f3c2e8bc329a6a486d4b3d16075f7403c4f6d7"
                 .as_ptr(),
             name: c"types".as_ptr(),
             func_name: c"Vmod_vmod_types_Func".as_ptr(),
@@ -948,7 +1006,7 @@ mod types {
     use std::net::SocketAddr;
     use std::time::Duration;
     use varnish::ffi::VCL_STRING;
-    use varnish::vcl::{CowProbe, Probe, Workspace};
+    use varnish::vcl::{Acl, CowProbe, Probe, Workspace};
     use varnish_sys::vcl::VclError;
     pub fn to_void() {}
     pub fn to_res_void_err() -> Result<(), VclError> {
@@ -986,6 +1044,14 @@ mod types {
     }
     pub fn to_res_cstr_err() -> Result<&'static CStr, &'static CStr> {
         Ok(c"")
+    }
+    pub fn type_acl(_v: Acl) {}
+    pub fn arg_acl(_v: Option<Acl>) {}
+    pub fn return_acl() -> Acl {
+        unimplemented!()
+    }
+    pub fn to_res_acl() -> Result<Acl, &'static str> {
+        Err("")
     }
     pub fn type_duration(_v: Duration) {}
     pub fn opt_duration(_v: Option<Duration>) {}

--- a/varnish/snapshotstrunk/function_types@docs.snap
+++ b/varnish/snapshotstrunk/function_types@docs.snap
@@ -62,6 +62,14 @@ import types from "path/to/libtypes.so";
 
 ### Function `STRING types.to_res_cstr_err()`
 
+### Function `VOID types.type_acl(ACL _v)`
+
+### Function `VOID types.arg_acl([ACL _v])`
+
+### Function `ACL types.return_acl()`
+
+### Function `ACL types.to_res_acl()`
+
 ### Function `VOID types.type_duration(DURATION _v)`
 
 ### Function `VOID types.opt_duration([DURATION _v])`

--- a/varnish/snapshotstrunk/function_types@json.snap
+++ b/varnish/snapshotstrunk/function_types@json.snap
@@ -8,7 +8,7 @@ VMOD_JSON_SPEC
     "2.0",
     "types",
     "Vmod_vmod_types_Func",
-    "c13df0540d7786fdca53f5d15d1111b8c80ab3d4de7401fb217f0fb2188d6a9c",
+    "90968e517039f4c73943ba74b5f3c2e8bc329a6a486d4b3d16075f7403c4f6d7",
     "Varnish (version) (hash)",
     "0",
     "0"
@@ -129,6 +129,29 @@ typedef VCL_STRING td_vmod_types_to_res_cstr(
 );
 
 typedef VCL_STRING td_vmod_types_to_res_cstr_err(
+    VRT_CTX
+);
+
+typedef VCL_VOID td_vmod_types_type_acl(
+    VRT_CTX,
+    VCL_ACL
+);
+
+struct arg_vmod_types_arg_acl {
+  char valid__v;
+  VCL_ACL _v;
+};
+
+typedef VCL_VOID td_vmod_types_arg_acl(
+    VRT_CTX,
+    struct arg_vmod_types_arg_acl *
+);
+
+typedef VCL_ACL td_vmod_types_return_acl(
+    VRT_CTX
+);
+
+typedef VCL_ACL td_vmod_types_to_res_acl(
     VRT_CTX
 );
 
@@ -389,6 +412,10 @@ struct Vmod_vmod_types_Func {
   td_vmod_types_to_cstr *f_to_cstr;
   td_vmod_types_to_res_cstr *f_to_res_cstr;
   td_vmod_types_to_res_cstr_err *f_to_res_cstr_err;
+  td_vmod_types_type_acl *f_type_acl;
+  td_vmod_types_arg_acl *f_arg_acl;
+  td_vmod_types_return_acl *f_return_acl;
+  td_vmod_types_to_res_acl *f_to_res_acl;
   td_vmod_types_type_duration *f_type_duration;
   td_vmod_types_opt_duration *f_opt_duration;
   td_vmod_types_to_duration *f_to_duration;
@@ -739,6 +766,63 @@ static struct Vmod_vmod_types_Func Vmod_vmod_types_Func;"
         "STRING"
       ],
       "Vmod_vmod_types_Func.f_to_res_cstr_err",
+      ""
+    ]
+  ],
+  [
+    "$FUNC",
+    "type_acl",
+    [
+      [
+        "VOID"
+      ],
+      "Vmod_vmod_types_Func.f_type_acl",
+      "",
+      [
+        "ACL",
+        "_v",
+        "_v"
+      ]
+    ]
+  ],
+  [
+    "$FUNC",
+    "arg_acl",
+    [
+      [
+        "VOID"
+      ],
+      "Vmod_vmod_types_Func.f_arg_acl",
+      "struct arg_vmod_types_arg_acl",
+      [
+        "ACL",
+        "_v",
+        "_v",
+        null,
+        null,
+        true
+      ]
+    ]
+  ],
+  [
+    "$FUNC",
+    "return_acl",
+    [
+      [
+        "ACL"
+      ],
+      "Vmod_vmod_types_Func.f_return_acl",
+      ""
+    ]
+  ],
+  [
+    "$FUNC",
+    "to_res_acl",
+    [
+      [
+        "ACL"
+      ],
+      "Vmod_vmod_types_Func.f_to_res_acl",
       ""
     ]
   ],

--- a/varnish/snapshotstrunk/function_types@model.snap
+++ b/varnish/snapshotstrunk/function_types@model.snap
@@ -395,6 +395,78 @@ VmodInfo {
         },
         FuncInfo {
             func_type: Function,
+            ident: "type_acl",
+            vcl_name: None,
+            docs: "",
+            has_optional_args: false,
+            args: [
+                ParamTypeInfo {
+                    ident: "_v",
+                    docs: "",
+                    ty: Value(
+                        ParamInfo {
+                            kind: Regular,
+                            default: Null,
+                            ty_info: Acl,
+                        },
+                    ),
+                },
+            ],
+            output_ty: Default,
+            out_result: false,
+            restrict: [],
+        },
+        FuncInfo {
+            func_type: Function,
+            ident: "arg_acl",
+            vcl_name: None,
+            docs: "",
+            has_optional_args: true,
+            args: [
+                ParamTypeInfo {
+                    ident: "_v",
+                    docs: "",
+                    ty: Value(
+                        ParamInfo {
+                            kind: Optional,
+                            default: Null,
+                            ty_info: Acl,
+                        },
+                    ),
+                },
+            ],
+            output_ty: Default,
+            out_result: false,
+            restrict: [],
+        },
+        FuncInfo {
+            func_type: Function,
+            ident: "return_acl",
+            vcl_name: None,
+            docs: "",
+            has_optional_args: false,
+            args: [],
+            output_ty: ParamType(
+                Acl,
+            ),
+            out_result: false,
+            restrict: [],
+        },
+        FuncInfo {
+            func_type: Function,
+            ident: "to_res_acl",
+            vcl_name: None,
+            docs: "",
+            has_optional_args: false,
+            args: [],
+            output_ty: ParamType(
+                Acl,
+            ),
+            out_result: true,
+            restrict: [],
+        },
+        FuncInfo {
+            func_type: Function,
             ident: "type_duration",
             vcl_name: None,
             docs: "",

--- a/varnish/snapshotstrunk/object2_obj2@code.snap
+++ b/varnish/snapshotstrunk/object2_obj2@code.snap
@@ -9,10 +9,10 @@ mod obj2 {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshotstrunk/object_multi_constructor_multi_constructor@code.snap
+++ b/varnish/snapshotstrunk/object_multi_constructor_multi_constructor@code.snap
@@ -9,10 +9,10 @@ mod multi_constructor {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshotstrunk/object_non_new_constructor_non_new_constructor@code.snap
+++ b/varnish/snapshotstrunk/object_non_new_constructor_non_new_constructor@code.snap
@@ -9,10 +9,10 @@ mod non_new_constructor {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshotstrunk/object_obj@code.snap
+++ b/varnish/snapshotstrunk/object_obj@code.snap
@@ -9,10 +9,10 @@ mod obj {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshotstrunk/restrict_restrict_scopes@code.snap
+++ b/varnish/snapshotstrunk/restrict_restrict_scopes@code.snap
@@ -9,10 +9,10 @@ mod restrict_scopes {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshotstrunk/return_returns@code.snap
+++ b/varnish/snapshotstrunk/return_returns@code.snap
@@ -9,10 +9,10 @@ mod returns {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshotstrunk/shared1_task@code.snap
+++ b/varnish/snapshotstrunk/shared1_task@code.snap
@@ -9,10 +9,10 @@ mod task {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshotstrunk/shared2_tuple@code.snap
+++ b/varnish/snapshotstrunk/shared2_tuple@code.snap
@@ -9,10 +9,10 @@ mod tuple {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshotstrunk/shared3_tuple@code.snap
+++ b/varnish/snapshotstrunk/shared3_tuple@code.snap
@@ -9,10 +9,10 @@ mod tuple {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshotstrunk/shared4_refcell_task@code.snap
+++ b/varnish/snapshotstrunk/shared4_refcell_task@code.snap
@@ -9,10 +9,10 @@ mod refcell_task {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshotstrunk/shared5_refcell_task_map@code.snap
+++ b/varnish/snapshotstrunk/shared5_refcell_task_map@code.snap
@@ -9,10 +9,10 @@ mod refcell_task_map {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshotstrunk/vcl_args_vcl_args@code.snap
+++ b/varnish/snapshotstrunk/vcl_args_vcl_args@code.snap
@@ -9,10 +9,10 @@ mod vcl_args {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshotstrunk/vcl_rename_vcl_rename@code.snap
+++ b/varnish/snapshotstrunk/vcl_rename_vcl_rename@code.snap
@@ -9,10 +9,10 @@ mod vcl_rename {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/snapshotstrunk/vcl_returns_vcl_returns@code.snap
+++ b/varnish/snapshotstrunk/vcl_returns_vcl_returns@code.snap
@@ -9,10 +9,10 @@ mod vcl_returns {
         use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
         use std::ptr::null;
         use varnish::ffi::{
-            VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_PROBE,
-            VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID, VMOD_ABI_Version,
-            VclEvent, vmod_data, vmod_priv, vrt_ctx, VMOD_PRIV_METHODS_MAGIC,
-            vmod_priv_methods,
+            VCL_ACL, VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP,
+            VCL_PROBE, VCL_REAL, VCL_STRING, VCL_SUB, VCL_TIME, VCL_VOID,
+            VMOD_ABI_Version, VclEvent, vmod_data, vmod_priv, vrt_ctx,
+            VMOD_PRIV_METHODS_MAGIC, vmod_priv_methods,
         };
         use varnish::vcl::{Ctx, IntoVCL, PerVclState, Workspace};
         use super::*;

--- a/varnish/src/lib.rs
+++ b/varnish/src/lib.rs
@@ -467,8 +467,8 @@ pub use varnish_sys::report_details_json;
 pub mod ffi {
     // This list must match the `use_ffi_items` in generator.rs
     pub use varnish_sys::ffi::{
-        vmod_data, vmod_priv, vmod_priv_methods, vrt_ctx, VMOD_ABI_Version, VclEvent, VCL_BACKEND,
-        VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_MET_BACKEND_ERROR,
+        vmod_data, vmod_priv, vmod_priv_methods, vrt_ctx, VMOD_ABI_Version, VclEvent, VCL_ACL,
+        VCL_BACKEND, VCL_BLOB, VCL_BOOL, VCL_DURATION, VCL_INT, VCL_IP, VCL_MET_BACKEND_ERROR,
         VCL_MET_BACKEND_FETCH, VCL_MET_BACKEND_REFRESH, VCL_MET_BACKEND_RESPONSE, VCL_MET_DELIVER,
         VCL_MET_FINI, VCL_MET_HASH, VCL_MET_HIT, VCL_MET_INIT, VCL_MET_MISS, VCL_MET_PASS,
         VCL_MET_PIPE, VCL_MET_PURGE, VCL_MET_RECV, VCL_MET_SYNTH, VCL_MET_TASK_B, VCL_MET_TASK_C,

--- a/varnish/tests/fail/error_acl.rs
+++ b/varnish/tests/fail/error_acl.rs
@@ -1,0 +1,17 @@
+use varnish::vmod;
+
+fn main() {}
+
+#[vmod]
+mod acl {
+    use varnish::vcl::Acl;
+
+    pub fn return_opt_opt_acl(_v: Option<Option<Acl>>) {}
+    pub fn return_opt_acl() -> Option<Acl> {
+        todo!()
+    }
+
+    pub fn return_res_opt_acl() -> Result<Option<Acl>, &'static str> {
+        todo!()
+    }
+}

--- a/varnish/tests/fail/error_acl.stderr
+++ b/varnish/tests/fail/error_acl.stderr
@@ -1,0 +1,5 @@
+error: unsupported argument type
+ --> tests/fail/error_acl.rs:9:31
+  |
+9 |     pub fn return_opt_opt_acl(_v: Option<Option<Acl>>) {}
+  |                               ^^

--- a/varnish/tests/pass/function.rs
+++ b/varnish/tests/pass/function.rs
@@ -60,9 +60,12 @@ mod types {
     }
 
     // Acl
-    pub fn opt_acl(_v: Option<Acl>) {}
-    pub fn opt_req_acl(#[required] _v: Option<Acl>) {}
-    pub fn to_res_acl() -> Result<Option<Acl>, &'static str> {
+    pub fn type_acl(_v: Acl) {}
+    pub fn arg_acl(_v: Option<Acl>) {}
+    pub fn return_acl() -> Acl {
+        unimplemented!()
+    }
+    pub fn to_res_acl() -> Result<Acl, &'static str> {
         Err("")
     }
 

--- a/varnish/tests/pass/function.rs
+++ b/varnish/tests/pass/function.rs
@@ -61,7 +61,6 @@ mod types {
 
     // Acl
     pub fn opt_acl(_v: Option<Acl>) {}
-    pub fn opt_opt_acl(_v: Option<Option<Acl>>) {}
     pub fn opt_req_acl(#[required] _v: Option<Acl>) {}
     pub fn to_res_acl() -> Result<Option<Acl>, &'static str> {
         Err("")

--- a/varnish/tests/pass/function.rs
+++ b/varnish/tests/pass/function.rs
@@ -61,7 +61,11 @@ mod types {
 
     // Acl
     pub fn opt_acl(_v: Option<Acl>) {}
-    pub fn type_acl_req(#[required] _v: Option<Acl>) {}
+    pub fn opt_opt_acl(_v: Option<Option<Acl>>) {}
+    pub fn opt_req_acl(#[required] _v: Option<Acl>) {}
+    pub fn to_res_acl() -> Result<Option<Acl>, &'static str> {
+        Err("")
+    }
 
     // Duration
     pub fn type_duration(_v: Duration) {}

--- a/varnish/tests/pass/function.rs
+++ b/varnish/tests/pass/function.rs
@@ -11,7 +11,7 @@ mod types {
     use std::net::SocketAddr;
     use std::time::Duration;
     use varnish::ffi::VCL_STRING;
-    use varnish::vcl::{CowProbe, Probe, Workspace};
+    use varnish::vcl::{Acl, CowProbe, Probe, Workspace};
     use varnish_sys::vcl::VclError;
 
     // void
@@ -58,6 +58,10 @@ mod types {
     pub fn to_res_cstr_err() -> Result<&'static CStr, &'static CStr> {
         Ok(c"")
     }
+
+    // Acl
+    pub fn opt_acl(_v: Option<Acl>) {}
+    pub fn type_acl_req(#[required] _v: Option<Acl>) {}
 
     // Duration
     pub fn type_duration(_v: Duration) {}


### PR DESCRIPTION
# Summary

Adds support for `VCL_ACL` and matching ACLs against IP addresses. This is primarily a wrapper around `VRT_acl_match` and the introduction of a new `Acl` parameter type for VMODs. 

# Design

## Rust wrapper 

First, a new simple wrapper around `VCL_ACL` is introduced to hold a reference to the `ffi::VCL_ACL` (rust pseudocode). Here is a sketch of the interface

```rust
struct Acl {
  raw: ffi::VCL_ACL
}

impl Acl {
  // NOTE: match is a keyword 
  fn matches(self, Ctx, SockAddr /* aka VCL_IP */) -> bool {
    unsafe  { ffi::VRT_acl_match(ctx.raw,  self.raw, addr); }
  }
}
```

## VMOD interface

Then, the `Acl` type is added to `varnish-macros` and supported as a function parameter:

```rust
#[varnish::vmod(docs = "README.md")]
mod firewall {
  pub fn is_allowed(ctx: &mut Ctx, allowlist: Acl, addr: Option<SocketAddr>) -> bool {
    return allowlist.matches(ctx, addr)
  }
}
```

As an alternative, the ACL matching could be exposed on `Ctx` like this:

```rust
#[varnish::vmod(docs = "README.md")]
mod firewall {
  pub fn is_allowed(ctx: &mut Ctx, allowlist: Acl, addr: Option<SocketAddr>) -> bool {
    return ctx.acl_match(acl, addr)
  }
}
```

## Checklist 

(sourced from review)

- [x] Add `Acl::vcl_ptr()` instead of `return self.raw`
- [x] Implement `<VCL_ACL> for Option<Acl>` in `convert.rs`
- [x] Add `Acl::name(&self) -> &CStr` -> discontinued, since it requires vendoring vcc_interface.h
- [x] Add tests in `varnish/tests/pass/function.rs`
- [x] Add `Ctx::acl_match()` as the primary interface for users
