### PR TITLE
Document that Ctx::req_body never feeds Write an empty buffer

### DIFF
--- a/varnish-sys/src/vcl/ctx.rs
+++ b/varnish-sys/src/vcl/ctx.rs
@@ -104,6 +104,11 @@ struct BodyWriterState<'w, W: Write> {
 /// Monomorphized per `W`. `ObjIterate`/`VRB_Iterate` call this synchronously
 /// and sequentially, so at most one `&mut` derived from `priv_` is ever live,
 /// and it never outlives that call. Used by [`Ctx::req_body`].
+///
+/// The `ptr.is_null() || len <= 0` guard below means `W::write_all` (and thus
+/// a caller's own `Write` impl) is never invoked with an empty buffer through
+/// this path — callers of [`Ctx::req_body`] can rely on that when implementing
+/// `W`.
 unsafe extern "C" fn write_body_iterate<W: Write>(
     priv_: *mut c_void,
     _flush: c_uint,
@@ -405,6 +410,9 @@ impl<'a> Ctx<'a> {
     /// ```
     ///
     /// To consume the body without keeping it, pass [`std::io::sink()`] as `writer`.
+    ///
+    /// `writer` is only ever fed non-empty chunks — a custom `Write` impl
+    /// doesn't need to handle a zero-length `buf` in its `write`.
     ///
     /// Returns `Ok(false)` without touching `writer` if there is no body at all.
     /// Returns `Ok(true)` once the full body has been copied into `writer`.


### PR DESCRIPTION
## Summary
- Small doc-only follow-up to #305 (`Ctx::req_body`/`req_body_state`).
- Downstream review on a `req_body` consumer ([vmod-reqwest PR #36](https://github.com/varnish-rs/vmod-reqwest/pull/36)) flagged that a custom `Write` impl might need to guard against a zero-length `buf`. It doesn't: `write_body_iterate`'s `ptr.is_null() || len <= 0` guard already filters that out before ever calling into the writer. Documenting the guarantee on both `write_body_iterate` and the public `req_body` doc comment so future implementors don't have to go read the trampoline to find out.

## Test plan
- [x] `cargo check -p varnish-sys`