### PR TITLE
Fix flaky vmod_echo_backend test01.vtc c8 (write-vs-early-response race)

### DIFF
--- a/examples/vmod_echo_backend/tests/test01.vtc
+++ b/examples/vmod_echo_backend/tests/test01.vtc
@@ -115,8 +115,15 @@ client c7 {
 # req_body_status as BS_ERROR (mirrors vrb_pull), which used to get
 # misattributed as the c5 short-read case (400) instead of surfacing as this
 # writer's own error (503)
+#
+# non_fatal around txreq: Varnish can answer 503 (and tear down the
+# connection) before this client finishes writing all 512KiB, so the
+# client's own write can legitimately fail with EPIPE/"Broken pipe" -
+# that's not a test failure, just this race, so don't let it abort the vtc.
 client c8 {
+    non_fatal
     txreq -method "POST" -hdr "x-fail-after-bytes: 3" -bodylen 524288
+    fatal
     rxresp
     expect resp.status == 503
 } -run


### PR DESCRIPTION
## Summary
- `c8` in `examples/vmod_echo_backend/tests/test01.vtc` POSTs a 512KiB body while the echo backend is set to fail its writer after 3 bytes, expecting Varnish to answer 503.
- On some runners (observed on macOS in [PR #306](https://github.com/varnish-rs/varnish-rs/pull/306)'s CI), Varnish answers and the connection gets torn down before the client finishes writing the body, so the client's own `write()` legitimately gets `EPIPE`/"Broken pipe". varnishtest treated that as fatal and aborted the vtc before ever reaching `rxresp`/`expect resp.status == 503`.
- Fix: bracket the `txreq` with `non_fatal`/`fatal`, the same idiom used elsewhere in varnish-cache's own test suite for this exact peer-may-reset-mid-write race (`c00030.vtc`, `c00046.vtc`).
- Confirmed pre-existing and unrelated to #306's (doc-only) change: the exact same commit (`27bab58`) passed "Test on macOS" cleanly in its own push-triggered CI run.

## Test plan
- [x] `cargo test -p vmod_echo_backend` — 3/3 passing, run 5x locally with no flakes