### PR TITLE
Add probe support to NativeBackendBuilder

### DIFF
--- a/examples/vmod_native_backend/README.md
+++ b/examples/vmod_native_backend/README.md
@@ -31,3 +31,16 @@ set req.backend_hint = native_backend.create("${server_addr}:${server_port}");
 
 * `[STRING addr]`:
 Socket address string (e.g., "127.0.0.1:8080")
+
+## Object `DynamicBackend`
+
+### Constructor `native_backend.new(STRING addr, [PROBE probe])`
+
+Create a backend with an optional probe attached from a socket address.
+
+This function demonstrates creating native backends at initalization.
+The backend is for the VCL lifetime and can be reused..
+
+### Method `BACKEND <object>.backend()`
+
+Retrieve the configured native backend.

--- a/examples/vmod_native_backend/src/lib.rs
+++ b/examples/vmod_native_backend/src/lib.rs
@@ -1,11 +1,67 @@
+use varnish::vcl::BackendRef;
+
 varnish::run_vtc_tests!("tests/*.vtc");
+
+pub struct DynamicBackend {
+    /// A native backend created alongside this `DynamicBackend`.
+    backend: BackendRef,
+}
 
 #[varnish::vmod(docs = "README.md")]
 mod native_backend {
+    use super::DynamicBackend;
     use std::net::SocketAddr;
+    use std::ptr::null;
+    use varnish::ffi;
     use varnish::vcl::Ctx;
+    use varnish::vcl::IntoVCL;
     use varnish::vcl::NativeBackendBuilder;
+    use varnish::vcl::Probe;
     use varnish::vcl::{BackendRef, NativeBackend};
+
+    impl DynamicBackend {
+        /// Create a backend with an optional probe attached from a socket address.
+        ///
+        /// This function demonstrates creating native backends at initalization.
+        /// The backend is for the VCL lifetime and can be reused..
+        pub fn new(
+            ctx: &mut Ctx,
+            #[vcl_name] vcl_name: &str,
+            addr: &str,
+            probe: Option<Probe>,
+        ) -> Result<Self, &'static str> {
+            let Ok(sock_addr) = addr.parse() else {
+                return Err("failed to parse addr");
+            };
+
+            // Create backend name from address
+            let name = format!("{vcl_name}_{sock_addr}");
+            let Ok(name_cstr) = std::ffi::CString::new(name) else {
+                return Err("failed to create native name");
+            };
+
+            let native_backend_probe = match probe {
+                None => ffi::VCL_PROBE(null()),
+                Some(probe) => probe.into_vcl(&mut ctx.ws).expect("no workspace left"),
+            };
+
+            let Ok(native_backend) = NativeBackendBuilder::new_ip(&name_cstr, sock_addr)
+                .probe(&native_backend_probe)
+                .build(ctx)
+            else {
+                return Err("failed to build native backend");
+            };
+
+            let backend = native_backend.as_ref().clone();
+
+            Ok(Self { backend })
+        }
+
+        /// Retrieve the configured native backend.
+        pub fn backend(&self) -> BackendRef {
+            self.backend.clone()
+        }
+    }
 
     /// Create a dynamic backend from a socket address.
     ///

--- a/examples/vmod_native_backend/src/lib.rs
+++ b/examples/vmod_native_backend/src/lib.rs
@@ -1,10 +1,10 @@
-use varnish::vcl::BackendRef;
+use varnish::vcl::NativeBackend;
 
 varnish::run_vtc_tests!("tests/*.vtc");
 
 pub struct DynamicBackend {
     /// A native backend created alongside this `DynamicBackend`.
-    backend: BackendRef,
+    backend: NativeBackend,
 }
 
 #[varnish::vmod(docs = "README.md")]
@@ -52,16 +52,14 @@ mod native_backend {
                 return Err("failed to create native backend");
             };
 
-            let native_backend_ref = native_backend.as_ref();
-
             Ok(Self {
-                backend: native_backend_ref.clone(),
+                backend: native_backend,
             })
         }
 
         /// Retrieve the configured native backend.
         pub fn backend(&self) -> BackendRef {
-            self.backend.clone()
+            self.backend.as_ref().clone()
         }
     }
 

--- a/examples/vmod_native_backend/src/lib.rs
+++ b/examples/vmod_native_backend/src/lib.rs
@@ -49,12 +49,14 @@ mod native_backend {
                 .probe(&native_backend_probe)
                 .build(ctx)
             else {
-                return Err("failed to build native backend");
+                return Err("failed to create native backend");
             };
 
-            let backend = native_backend.as_ref().clone();
+            let native_backend_ref = native_backend.as_ref();
 
-            Ok(Self { backend })
+            Ok(Self {
+                backend: native_backend_ref.clone(),
+            })
         }
 
         /// Retrieve the configured native backend.

--- a/examples/vmod_native_backend/tests/test04.vtc
+++ b/examples/vmod_native_backend/tests/test04.vtc
@@ -1,0 +1,41 @@
+varnishtest "Test dynamic backend health probe (intentionally sick)"
+
+server s1 {
+    rxreq
+    txresp
+} -start
+
+varnish v1 -vcl {
+    import native_backend from "${vmod}";
+
+    backend default none;
+
+    probe p1 {
+        .initial = 0;
+        .threshold = 64;
+        .url = "/";
+        .expected_response = 599;
+    }
+
+    sub vcl_init {
+        new be1 = native_backend.new("${s1_addr}:${s1_port}", probe=p1);
+    }
+
+    sub vcl_recv {
+        set req.backend_hint = be1.backend();
+        return(pass);
+    }
+} -start
+
+
+client c1 {
+    txreq -url "/probe"
+    rxresp
+    expect resp.status == 503
+} -run
+
+logexpect l1 -v v1 -d 1 -g raw {
+    expect * 0 Backend_health "^be1_${s1_addr}:${s1_port} Still sick"
+} -start
+
+logexpect l1 -wait

--- a/varnish-sys/src/vcl/backend/backend_main.rs
+++ b/varnish-sys/src/vcl/backend/backend_main.rs
@@ -10,8 +10,8 @@ use std::ptr::{null, null_mut};
 use std::time::SystemTime;
 
 use crate::ffi::{
-    vrt_ctx, vsa_suckaddr_len, VclEvent, VfpStatus, VCL_BACKEND, VCL_BOOL, VCL_IP, VCL_TIME,
-    VCL_VCL, VRT_CTX_MAGIC,
+    vrt_ctx, vsa_suckaddr_len, VclEvent, VfpStatus, VCL_BACKEND, VCL_BOOL, VCL_IP, VCL_PROBE,
+    VCL_TIME, VCL_VCL, VRT_CTX_MAGIC,
 };
 #[cfg(varnishsys_90_sslflags)]
 use crate::ffi::{BSSL_F_ENABLE, BSSL_F_NOVERIFY, BSSL_F_VERIFY_HOST};
@@ -368,6 +368,7 @@ pub struct NativeBackendBuilder<'a> {
     backend_wait_limit: Option<u32>,
     #[cfg(varnishsys_90_sslflags)]
     sslflags: c_uint,
+    probe: Option<&'a VCL_PROBE>,
 }
 
 /// Macro to generate builder setter methods
@@ -399,6 +400,7 @@ impl<'a> NativeBackendBuilder<'a> {
             backend_wait_limit: None,
             #[cfg(varnishsys_90_sslflags)]
             sslflags: 0,
+            probe: None,
         }
     }
 
@@ -418,6 +420,7 @@ impl<'a> NativeBackendBuilder<'a> {
             backend_wait_limit: None,
             #[cfg(varnishsys_90_sslflags)]
             sslflags: 0,
+            probe: None,
         }
     }
 
@@ -478,6 +481,8 @@ impl<'a> NativeBackendBuilder<'a> {
         "Set the Host header to use sending a request that doesn't have a
         `Host` header. "
     );
+
+    builder_setter!(probe, &'a VCL_PROBE, "Set the probe for health checks.");
 
     /// Use the `PROXY` protocol v1 to connect to the backend.
     #[must_use]
@@ -603,7 +608,10 @@ impl<'a> NativeBackendBuilder<'a> {
             max_connections: self.max_connections.unwrap_or(0),
             proxy_header: self.proxy_header.unwrap_or(0),
             backend_wait_limit: self.backend_wait_limit.unwrap_or(0),
-            probe: ffi::VCL_PROBE(null()),
+            probe: match self.probe {
+                None => VCL_PROBE(null()),
+                Some(p) => p.to_owned(),
+            },
         });
 
         let bep = ffi::VRT_new_backend(


### PR DESCRIPTION
# Summary

Fixes #308.

VMOD authors can now set probes for native backends created with NativeBackendBuilder:

```rust
let native_backend_probe = match probe {
   None => ffi::VCL_PROBE(null()),
   Some(p) => p.into_vcl(&mut ctx.ws).expect("workspace for probe"),
};

let native_backend = NativeBackendBuilder::new_ip(&name, sock_addr)
   .probe(native_backend_probe)
   .build(ctx)
   .ok()?;
```

(mostly taken from `examples/vmod_native_backend`). 

Rationale for VCL_PROBE: The rest of the parameters are low-level parameters (such as CStr), so this change follows that pattern as well. Also, there is no real way with the current setup to convert a higher level `Probe` to `VCL_PROBE` without a workspace (using `IntoVCL`).

---

# Open questions

- [x] What kind of tests should be added?
- [x] Is the interface actually good or is there a better choice? (Especially around `ffi::VCL_PROBE` conversion for VMOD authors) -> I would like to bring the higher level `Probe` types here instead of a raw `VCL_PROBE`