### PR TITLE
Update CHANGELOG.md with user-facing additions since 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Ctx::req_body/req_body_state for reading bereq's/req's body ([#305](https://github.com/varnish-rs/varnish-rs/pull/305))
 - Add probe support to NativeBackendBuilder ([#310](https://github.com/varnish-rs/varnish-rs/pull/310))
 
+### Fixed
+
+- Fix build against syn 3 / darling 0.24 / prettyplease 0.3 ([#313](https://github.com/varnish-rs/varnish-rs/pull/313))
+
 ## [0.7.1](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.7.0...varnish-sys-v0.7.1)
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add Ctx::req_body/req_body_state for reading bereq's/req's body ([#305](https://github.com/varnish-rs/varnish-rs/pull/305))
+- Add probe support to NativeBackendBuilder ([#310](https://github.com/varnish-rs/varnish-rs/pull/310))
+
 ## [0.7.1](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.7.0...varnish-sys-v0.7.1)
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.2](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.7.1...varnish-sys-v0.7.2) - 2026-08-10
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["varnish", "varnish-macros", "varnish-sys", "varnish/tests/vmod_test"
 
 [workspace.package]
 # These fields are used by multiple crates, so it's defined here.
-version = "0.7.1"
+version = "0.7.2"
 repository = "https://github.com/varnish-rs/varnish-rs"
 edition = "2021"
 rust-version = "1.90.0"
@@ -17,9 +17,9 @@ readme = "README.md"
 
 [workspace.dependencies]
 # These versions should match the package.version above, and will be updated by release-plz.
-varnish = { path = "./varnish", version = "0.7.1" }
-varnish-macros = { path = "./varnish-macros", version = "0.7.1" }
-varnish-sys = { path = "./varnish-sys", version = "0.7.1" }
+varnish = { path = "./varnish", version = "0.7.2" }
+varnish-macros = { path = "./varnish-macros", version = "0.7.2" }
+varnish-sys = { path = "./varnish-sys", version = "0.7.2" }
 #
 # These dependencies are used by one or more crates, and easier to maintain in one place.
 bindgen_helpers = "0.6.1"


### PR DESCRIPTION
## Summary
- Add Unreleased section to CHANGELOG.md covering user-facing additions merged since 0.7.1: req_body/req_body_state (#305) and NativeBackendBuilder probe support (#310)

🤖 Generated with [Claude Code](https://claude.com/claude-code)