### PR TITLE
Add Ctx::subroutine() to expose the currently executing VCL subroutine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add Ctx::subroutine() to expose the currently executing VCL subroutine ([#315](https://github.com/varnish-rs/varnish-rs/pull/315))
+
 ## [0.7.2](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.7.1...varnish-sys-v0.7.2) - 2026-08-10
 
 ### Added

--- a/varnish-sys/src/vcl/ctx.rs
+++ b/varnish-sys/src/vcl/ctx.rs
@@ -7,8 +7,9 @@ use std::net::SocketAddr;
 use crate::ffi;
 use crate::ffi::{vrt_ctx, VRT_call, VRT_check_call, VRT_fail, VRT_handled, VRT_CTX_MAGIC};
 use crate::vcl::{
-    sc_to_ptr, subroutine::Subroutine, Acl, HttpHeaders, LogTag, StreamClose, TestWS, VclError,
-    VclResult, Workspace,
+    sc_to_ptr,
+    subroutine::{Id, Subroutine},
+    Acl, HttpHeaders, LogTag, StreamClose, TestWS, VclError, VclResult, Workspace,
 };
 
 /// VCL context
@@ -276,6 +277,16 @@ impl<'a> Ctx<'a> {
     /// in a VCL error.
     pub fn is_handled(&self) -> bool {
         unsafe { VRT_handled(self.raw) != 0 }
+    }
+
+    /// Return the VCL subroutine currently executing in this context.
+    ///
+    /// # Panics
+    /// Panics if `ctx.raw.method` doesn't match any known subroutine.
+    /// Every real `vrt_ctx` must be stamped with exactly one method bit while a subroutine body runs.
+    pub fn subroutine(&self) -> Id {
+        Id::from_bitfield(self.raw.method)
+            .expect("vrt_ctx.method must match a known VCL subroutine")
     }
 
     /// Retrieve the cached request body as a list of byte slices.
@@ -648,6 +659,14 @@ mod tests {
     fn ctx_test() {
         let mut test_ctx = TestCtx::new(100);
         test_ctx.ctx();
+    }
+
+    #[test]
+    fn subroutine_returns_current_method() {
+        let mut test_ctx = TestCtx::new(100);
+        test_ctx.vrt_ctx.method = Id::Recv.to_bitfield();
+        let ctx = test_ctx.ctx();
+        assert_eq!(ctx.subroutine(), Id::Recv);
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds `Ctx::subroutine()`, returning the `subroutine::Id` of the VCL subroutine currently executing in this context.
- Reuses the existing `Id::from_bitfield` lookup against `ctx.raw.method` (the bitmask Varnish itself uses to track the running subroutine), so callers don't need to poke at the raw C field directly.
- This is a building block for a follow-up PR (`Ctx::response_buffer()`), stacked on top of this one.

## Test plan
- [x] `cargo test -p varnish-sys --lib vcl::ctx`
- [x] `cargo clippy -p varnish-sys --all-targets -- -D warnings`