### PR TITLE
Generate docs for #[restrict(...)] and defaulted/optional args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Ctx::subroutine() to expose the currently executing VCL subroutine ([#315](https://github.com/varnish-rs/varnish-rs/pull/315))
 - Add Ctx::response_buffer() to write directly into the vcl_synth/vcl_backend_error response body, plus a vmod_synthbuffer example ([#316](https://github.com/varnish-rs/varnish-rs/pull/316))
 
+### Fixed
+
+- Generate docs for `#[restrict(...)]`-decorated vmod functions, and show `(optional)`/`(optional, default: ...)` for optional and defaulted arguments instead of bracket notation ([#317](https://github.com/varnish-rs/varnish-rs/pull/317))
+
 ## [0.7.2](https://github.com/varnish-rs/varnish-rs/compare/varnish-sys-v0.7.1...varnish-sys-v0.7.2) - 2026-08-10
 
 ### Added

--- a/examples/vmod_example/README.md
+++ b/examples/vmod_example/README.md
@@ -44,7 +44,7 @@ set resp.http.Obvious = example.captain_obvious();
 set resp.http.Obvious-Number = example.captain_obvious(42);
 ```
 
-* `[INT opt]`:
+* `INT opt` (optional):
 Optional number to provide as argument
 
 ### Function `STRING example.hello(STRING s)`

--- a/examples/vmod_native_backend/README.md
+++ b/examples/vmod_native_backend/README.md
@@ -29,7 +29,7 @@ Example:
 set req.backend_hint = native_backend.create("${server_addr}:${server_port}");
 ```
 
-* `[STRING addr]`:
+* `STRING addr` (optional):
 Socket address string (e.g., "127.0.0.1:8080")
 
 ## Object `DynamicBackend`

--- a/examples/vmod_restricted_callsites/README.md
+++ b/examples/vmod_restricted_callsites/README.md
@@ -25,16 +25,24 @@ import restricted_callsites from "path/to/librestricted_callsites.so";
 
 ### Function `INT restricted_callsites.client_only()`
 
+**Restricted to:** `client`
+
 Only callable from client-side VCL subs (`vcl_recv`, `vcl_pass`, `vcl_hash`, etc.)
 
 ### Function `INT restricted_callsites.backend_only()`
+
+**Restricted to:** `backend`
 
 Only callable from backend-side VCL subs (`vcl_backend_fetch`, `vcl_backend_response`, etc.)
 
 ### Function `INT restricted_callsites.recv_or_hash()`
 
+**Restricted to:** `vcl_recv`, `vcl_hash`
+
 Only callable from `vcl_recv` and `vcl_hash`
 
 ### Function `INT restricted_callsites.client_or_backend()`
+
+**Restricted to:** `client`, `backend`
 
 Callable from both client and backend contexts

--- a/examples/vmod_synthbuffer/README.md
+++ b/examples/vmod_synthbuffer/README.md
@@ -23,8 +23,12 @@ import synthbuffer from "path/to/libsynthbuffer.so";
 
 ### Function `VOID synthbuffer.push(STRING s)`
 
+**Restricted to:** `vcl_synth`, `vcl_backend_error`
+
 Push `s` onto the response body, unchanged.
 
 ### Function `VOID synthbuffer.push_reverse(STRING s)`
+
+**Restricted to:** `vcl_synth`, `vcl_backend_error`
 
 Push `s` onto the response body, with its bytes in reverse order.

--- a/justfile
+++ b/justfile
@@ -332,7 +332,7 @@ install-varnish version=default_varnish_ver debug='':
              apt-get update -qqq; \
         sudo DEBIAN_FRONTEND=noninteractive \
              DEBCONF_NONINTERACTIVE_SEEN=true \
-             apt-get install -qqq autoconf automake flex libtool python3-sphinx libpcre2-dev libedit-dev libssl-dev
+             apt-get install -qqq autoconf automake bison flex libtool python3-sphinx libpcre2-dev libedit-dev libssl-dev
         git clone --depth=1 --recursive https://github.com/varnish/varnish.git /tmp/varnish-src
         cd /tmp/varnish-src
         ./autogen.des --prefix="$INSTALL_DIR" --mandir="$INSTALL_DIR/man"

--- a/varnish-macros/src/gen_docs.rs
+++ b/varnish-macros/src/gen_docs.rs
@@ -129,7 +129,11 @@ fn write_function(
     if user_args.iter().any(|(arg, _)| !arg.docs.is_empty()) {
         ln!(docs, "");
         for (arg, ty) in &user_args {
-            wrt!(docs, "* `{}`:", bracketed_name(arg, ty));
+            wrt!(docs, "* `{} {}`", ty.ty_info.to_vcc_type(), arg.ident);
+            if matches!(ty.kind, ParamKind::Optional) {
+                wrt!(docs, " (optional)");
+            }
+            wrt!(docs, ":");
             if arg.docs.is_empty() {
                 ln!(docs, "");
             } else {

--- a/varnish-macros/src/gen_docs.rs
+++ b/varnish-macros/src/gen_docs.rs
@@ -122,6 +122,7 @@ fn write_function(
         );
     }
 
+    write_restrict_note(docs, &func.restrict);
     write_docs(docs, &func.docs, prefix);
 
     // List of arguments are printed only if any of them have documentation
@@ -135,6 +136,19 @@ fn write_function(
                 write_docs(docs, &arg.docs, prefix);
             }
         }
+    }
+}
+
+/// Print a note listing the VCL subroutine scopes a `#[restrict(...)]`-decorated
+/// function is limited to, if any.
+fn write_restrict_note(docs: &mut String, restrict: &[String]) {
+    if !restrict.is_empty() {
+        let scopes = restrict
+            .iter()
+            .map(|s| format!("`{s}`"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        ln!(docs, "\n**Restricted to:** {scopes}");
     }
 }
 

--- a/varnish-macros/src/gen_docs.rs
+++ b/varnish-macros/src/gen_docs.rs
@@ -130,7 +130,9 @@ fn write_function(
         ln!(docs, "");
         for (arg, ty) in &user_args {
             wrt!(docs, "* `{} {}`", ty.ty_info.to_vcc_type(), arg.ident);
-            if matches!(ty.kind, ParamKind::Optional) {
+            if !ty.default.is_null() {
+                wrt!(docs, " (optional, default: `{}`)", ty.default);
+            } else if matches!(ty.kind, ParamKind::Optional) {
                 wrt!(docs, " (optional)");
             }
             wrt!(docs, ":");

--- a/varnish-macros/src/snapshots/populated.snap
+++ b/varnish-macros/src/snapshots/populated.snap
@@ -49,9 +49,7 @@ fn vtc_basic() {
     if let Err(err) = ::varnish::varnishtest::run_one_test(
         &dylib_path,
         env!("CARGO_PKG_NAME"),
-        ::std::path::Path::new(
-            "{MANIFEST_DIR}/tests/vtc_fixtures/basic.vtc",
-        ),
+        ::std::path::Path::new("{MANIFEST_DIR}/tests/vtc_fixtures/basic.vtc"),
         option_env!("VARNISHTEST_DURATION").unwrap_or("10s"),
         false,
     ) {
@@ -70,9 +68,7 @@ fn vtc_has_dashes() {
     if let Err(err) = ::varnish::varnishtest::run_one_test(
         &dylib_path,
         env!("CARGO_PKG_NAME"),
-        ::std::path::Path::new(
-            "{MANIFEST_DIR}/tests/vtc_fixtures/has-dashes.vtc",
-        ),
+        ::std::path::Path::new("{MANIFEST_DIR}/tests/vtc_fixtures/has-dashes.vtc"),
         option_env!("VARNISHTEST_DURATION").unwrap_or("10s"),
         false,
     ) {

--- a/varnish-macros/src/snapshots/populated.snap
+++ b/varnish-macros/src/snapshots/populated.snap
@@ -49,7 +49,9 @@ fn vtc_basic() {
     if let Err(err) = ::varnish::varnishtest::run_one_test(
         &dylib_path,
         env!("CARGO_PKG_NAME"),
-        ::std::path::Path::new("{MANIFEST_DIR}/tests/vtc_fixtures/basic.vtc"),
+        ::std::path::Path::new(
+            "{MANIFEST_DIR}/tests/vtc_fixtures/basic.vtc",
+        ),
         option_env!("VARNISHTEST_DURATION").unwrap_or("10s"),
         false,
     ) {
@@ -68,7 +70,9 @@ fn vtc_has_dashes() {
     if let Err(err) = ::varnish::varnishtest::run_one_test(
         &dylib_path,
         env!("CARGO_PKG_NAME"),
-        ::std::path::Path::new("{MANIFEST_DIR}/tests/vtc_fixtures/has-dashes.vtc"),
+        ::std::path::Path::new(
+            "{MANIFEST_DIR}/tests/vtc_fixtures/has-dashes.vtc",
+        ),
         option_env!("VARNISHTEST_DURATION").unwrap_or("10s"),
         false,
     ) {

--- a/varnish-macros/src/snapshots/populated_debug.snap
+++ b/varnish-macros/src/snapshots/populated_debug.snap
@@ -49,9 +49,7 @@ fn vtc_basic() {
     if let Err(err) = ::varnish::varnishtest::run_one_test(
         &dylib_path,
         env!("CARGO_PKG_NAME"),
-        ::std::path::Path::new(
-            "{MANIFEST_DIR}/tests/vtc_fixtures/basic.vtc",
-        ),
+        ::std::path::Path::new("{MANIFEST_DIR}/tests/vtc_fixtures/basic.vtc"),
         option_env!("VARNISHTEST_DURATION").unwrap_or("10s"),
         true,
     ) {
@@ -70,9 +68,7 @@ fn vtc_has_dashes() {
     if let Err(err) = ::varnish::varnishtest::run_one_test(
         &dylib_path,
         env!("CARGO_PKG_NAME"),
-        ::std::path::Path::new(
-            "{MANIFEST_DIR}/tests/vtc_fixtures/has-dashes.vtc",
-        ),
+        ::std::path::Path::new("{MANIFEST_DIR}/tests/vtc_fixtures/has-dashes.vtc"),
         option_env!("VARNISHTEST_DURATION").unwrap_or("10s"),
         true,
     ) {

--- a/varnish-macros/src/snapshots/populated_debug.snap
+++ b/varnish-macros/src/snapshots/populated_debug.snap
@@ -49,7 +49,9 @@ fn vtc_basic() {
     if let Err(err) = ::varnish::varnishtest::run_one_test(
         &dylib_path,
         env!("CARGO_PKG_NAME"),
-        ::std::path::Path::new("{MANIFEST_DIR}/tests/vtc_fixtures/basic.vtc"),
+        ::std::path::Path::new(
+            "{MANIFEST_DIR}/tests/vtc_fixtures/basic.vtc",
+        ),
         option_env!("VARNISHTEST_DURATION").unwrap_or("10s"),
         true,
     ) {
@@ -68,7 +70,9 @@ fn vtc_has_dashes() {
     if let Err(err) = ::varnish::varnishtest::run_one_test(
         &dylib_path,
         env!("CARGO_PKG_NAME"),
-        ::std::path::Path::new("{MANIFEST_DIR}/tests/vtc_fixtures/has-dashes.vtc"),
+        ::std::path::Path::new(
+            "{MANIFEST_DIR}/tests/vtc_fixtures/has-dashes.vtc",
+        ),
         option_env!("VARNISHTEST_DURATION").unwrap_or("10s"),
         true,
     ) {

--- a/varnish/snapshots8.0.0/docs_types@docs.snap
+++ b/varnish/snapshots8.0.0/docs_types@docs.snap
@@ -66,7 +66,7 @@ doctest for `DocStruct` implementation
 
 doctest for `new`
 
-* `[INT cap]`:
+* `INT cap` (optional):
 doc comment for `cap`
 
 ### Method `VOID <object>.function(STRING key)`

--- a/varnish/snapshots8.0.0/function_types@code.snap
+++ b/varnish/snapshots8.0.0/function_types@code.snap
@@ -987,7 +987,7 @@ mod types {
         pub static Vmod_types_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
-            file_id: c"90968e517039f4c73943ba74b5f3c2e8bc329a6a486d4b3d16075f7403c4f6d7"
+            file_id: c"3ea64ebb30f96cdaac904be0def6d390902a5d82d857e00203de9985f3a08d60"
                 .as_ptr(),
             name: c"types".as_ptr(),
             func_name: c"Vmod_vmod_types_Func".as_ptr(),

--- a/varnish/snapshots8.0.0/function_types@docs.snap
+++ b/varnish/snapshots8.0.0/function_types@docs.snap
@@ -36,6 +36,9 @@ import types from "path/to/libtypes.so";
 
 ### Function `VOID types.type_bool_dflt(BOOL _v = 1)`
 
+* `BOOL _v` (optional, default: `1`):
+Flag with a default value.
+
 ### Function `VOID types.opt_bool([BOOL _v])`
 
 ### Function `BOOL types.to_bool()`
@@ -105,6 +108,9 @@ import types from "path/to/libtypes.so";
 ### Function `VOID types.opt_str_req(STRING _v)`
 
 ### Function `VOID types.type_str_dflt(STRING _v = "baz")`
+
+* `STRING _v` (optional, default: `"baz"`):
+String with a default value.
 
 ### Function `VOID types.opt_str_dflt([STRING _v] = "baz")`
 

--- a/varnish/snapshots8.0.0/function_types@json.snap
+++ b/varnish/snapshots8.0.0/function_types@json.snap
@@ -8,7 +8,7 @@ VMOD_JSON_SPEC
     "2.0",
     "types",
     "Vmod_vmod_types_Func",
-    "90968e517039f4c73943ba74b5f3c2e8bc329a6a486d4b3d16075f7403c4f6d7",
+    "3ea64ebb30f96cdaac904be0def6d390902a5d82d857e00203de9985f3a08d60",
     "Varnish (version) (hash)",
     "0",
     "0"

--- a/varnish/snapshots8.0.0/function_types@model.snap
+++ b/varnish/snapshots8.0.0/function_types@model.snap
@@ -130,7 +130,7 @@ VmodInfo {
             args: [
                 ParamTypeInfo {
                     ident: "_v",
-                    docs: "",
+                    docs: "Flag with a default value.",
                     ty: Value(
                         ParamInfo {
                             kind: Regular,
@@ -805,7 +805,7 @@ VmodInfo {
             args: [
                 ParamTypeInfo {
                     ident: "_v",
-                    docs: "",
+                    docs: "String with a default value.",
                     ty: Value(
                         ParamInfo {
                             kind: Regular,

--- a/varnish/snapshots8.0.0/restrict_restrict_scopes@code.snap
+++ b/varnish/snapshots8.0.0/restrict_restrict_scopes@code.snap
@@ -191,7 +191,7 @@ mod restrict_scopes {
         pub static Vmod_restrict_scopes_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
-            file_id: c"914e0ff7ce24091c035bd84a2876f3cb5dcddf49fcecc8d25a9424e194391ee3"
+            file_id: c"776ba51c758eea75219a10903fd4c86c6b8d9d9ac226d6c856ced2dbff5bf420"
                 .as_ptr(),
             name: c"restrict_scopes".as_ptr(),
             func_name: c"Vmod_vmod_restrict_scopes_Func".as_ptr(),
@@ -205,6 +205,7 @@ mod restrict_scopes {
         };
         const JSON: &CStr = c"(moved to @json.snap files)";
     }
+    /// Only callable from client-side VCL subroutines.
     pub fn client_only() -> i64 {
         1
     }

--- a/varnish/snapshots8.0.0/restrict_restrict_scopes@docs.snap
+++ b/varnish/snapshots8.0.0/restrict_restrict_scopes@docs.snap
@@ -22,14 +22,30 @@ import restrict_scopes from "path/to/librestrict_scopes.so";
 
 ### Function `INT restrict_scopes.client_only()`
 
+**Restricted to:** `client`
+
+Only callable from client-side VCL subroutines.
+
 ### Function `INT restrict_scopes.backend_only()`
+
+**Restricted to:** `backend`
 
 ### Function `INT restrict_scopes.housekeeping_only()`
 
+**Restricted to:** `housekeeping`
+
 ### Function `INT restrict_scopes.client_or_backend()`
+
+**Restricted to:** `client`, `backend`
 
 ### Function `INT restrict_scopes.recv_only()`
 
+**Restricted to:** `vcl_recv`
+
 ### Function `INT restrict_scopes.recv_or_hash()`
 
+**Restricted to:** `vcl_recv`, `vcl_hash`
+
 ### Function `INT restrict_scopes.backend_subs()`
+
+**Restricted to:** `vcl_backend_fetch`, `vcl_backend_response`, `vcl_backend_error`

--- a/varnish/snapshots8.0.0/restrict_restrict_scopes@json.snap
+++ b/varnish/snapshots8.0.0/restrict_restrict_scopes@json.snap
@@ -8,7 +8,7 @@ VMOD_JSON_SPEC
     "2.0",
     "restrict_scopes",
     "Vmod_vmod_restrict_scopes_Func",
-    "914e0ff7ce24091c035bd84a2876f3cb5dcddf49fcecc8d25a9424e194391ee3",
+    "776ba51c758eea75219a10903fd4c86c6b8d9d9ac226d6c856ced2dbff5bf420",
     "Varnish (version) (hash)",
     "0",
     "0"

--- a/varnish/snapshots8.0.0/restrict_restrict_scopes@model.snap
+++ b/varnish/snapshots8.0.0/restrict_restrict_scopes@model.snap
@@ -12,7 +12,7 @@ VmodInfo {
             func_type: Function,
             ident: "client_only",
             vcl_name: None,
-            docs: "",
+            docs: "Only callable from client-side VCL subroutines.",
             has_optional_args: false,
             args: [],
             output_ty: ParamType(

--- a/varnish/snapshots9.0.0/docs_types@docs.snap
+++ b/varnish/snapshots9.0.0/docs_types@docs.snap
@@ -66,7 +66,7 @@ doctest for `DocStruct` implementation
 
 doctest for `new`
 
-* `[INT cap]`:
+* `INT cap` (optional):
 doc comment for `cap`
 
 ### Method `VOID <object>.function(STRING key)`

--- a/varnish/snapshots9.0.0/function_types@code.snap
+++ b/varnish/snapshots9.0.0/function_types@code.snap
@@ -987,7 +987,7 @@ mod types {
         pub static Vmod_types_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
-            file_id: c"90968e517039f4c73943ba74b5f3c2e8bc329a6a486d4b3d16075f7403c4f6d7"
+            file_id: c"3ea64ebb30f96cdaac904be0def6d390902a5d82d857e00203de9985f3a08d60"
                 .as_ptr(),
             name: c"types".as_ptr(),
             func_name: c"Vmod_vmod_types_Func".as_ptr(),

--- a/varnish/snapshots9.0.0/function_types@docs.snap
+++ b/varnish/snapshots9.0.0/function_types@docs.snap
@@ -36,6 +36,9 @@ import types from "path/to/libtypes.so";
 
 ### Function `VOID types.type_bool_dflt(BOOL _v = 1)`
 
+* `BOOL _v` (optional, default: `1`):
+Flag with a default value.
+
 ### Function `VOID types.opt_bool([BOOL _v])`
 
 ### Function `BOOL types.to_bool()`
@@ -105,6 +108,9 @@ import types from "path/to/libtypes.so";
 ### Function `VOID types.opt_str_req(STRING _v)`
 
 ### Function `VOID types.type_str_dflt(STRING _v = "baz")`
+
+* `STRING _v` (optional, default: `"baz"`):
+String with a default value.
 
 ### Function `VOID types.opt_str_dflt([STRING _v] = "baz")`
 

--- a/varnish/snapshots9.0.0/function_types@json.snap
+++ b/varnish/snapshots9.0.0/function_types@json.snap
@@ -8,7 +8,7 @@ VMOD_JSON_SPEC
     "2.0",
     "types",
     "Vmod_vmod_types_Func",
-    "90968e517039f4c73943ba74b5f3c2e8bc329a6a486d4b3d16075f7403c4f6d7",
+    "3ea64ebb30f96cdaac904be0def6d390902a5d82d857e00203de9985f3a08d60",
     "Varnish (version) (hash)",
     "0",
     "0"

--- a/varnish/snapshots9.0.0/function_types@model.snap
+++ b/varnish/snapshots9.0.0/function_types@model.snap
@@ -130,7 +130,7 @@ VmodInfo {
             args: [
                 ParamTypeInfo {
                     ident: "_v",
-                    docs: "",
+                    docs: "Flag with a default value.",
                     ty: Value(
                         ParamInfo {
                             kind: Regular,
@@ -805,7 +805,7 @@ VmodInfo {
             args: [
                 ParamTypeInfo {
                     ident: "_v",
-                    docs: "",
+                    docs: "String with a default value.",
                     ty: Value(
                         ParamInfo {
                             kind: Regular,

--- a/varnish/snapshots9.0.0/restrict_restrict_scopes@code.snap
+++ b/varnish/snapshots9.0.0/restrict_restrict_scopes@code.snap
@@ -191,7 +191,7 @@ mod restrict_scopes {
         pub static Vmod_restrict_scopes_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
-            file_id: c"914e0ff7ce24091c035bd84a2876f3cb5dcddf49fcecc8d25a9424e194391ee3"
+            file_id: c"776ba51c758eea75219a10903fd4c86c6b8d9d9ac226d6c856ced2dbff5bf420"
                 .as_ptr(),
             name: c"restrict_scopes".as_ptr(),
             func_name: c"Vmod_vmod_restrict_scopes_Func".as_ptr(),
@@ -205,6 +205,7 @@ mod restrict_scopes {
         };
         const JSON: &CStr = c"(moved to @json.snap files)";
     }
+    /// Only callable from client-side VCL subroutines.
     pub fn client_only() -> i64 {
         1
     }

--- a/varnish/snapshots9.0.0/restrict_restrict_scopes@docs.snap
+++ b/varnish/snapshots9.0.0/restrict_restrict_scopes@docs.snap
@@ -22,14 +22,30 @@ import restrict_scopes from "path/to/librestrict_scopes.so";
 
 ### Function `INT restrict_scopes.client_only()`
 
+**Restricted to:** `client`
+
+Only callable from client-side VCL subroutines.
+
 ### Function `INT restrict_scopes.backend_only()`
+
+**Restricted to:** `backend`
 
 ### Function `INT restrict_scopes.housekeeping_only()`
 
+**Restricted to:** `housekeeping`
+
 ### Function `INT restrict_scopes.client_or_backend()`
+
+**Restricted to:** `client`, `backend`
 
 ### Function `INT restrict_scopes.recv_only()`
 
+**Restricted to:** `vcl_recv`
+
 ### Function `INT restrict_scopes.recv_or_hash()`
 
+**Restricted to:** `vcl_recv`, `vcl_hash`
+
 ### Function `INT restrict_scopes.backend_subs()`
+
+**Restricted to:** `vcl_backend_fetch`, `vcl_backend_response`, `vcl_backend_error`

--- a/varnish/snapshots9.0.0/restrict_restrict_scopes@json.snap
+++ b/varnish/snapshots9.0.0/restrict_restrict_scopes@json.snap
@@ -8,7 +8,7 @@ VMOD_JSON_SPEC
     "2.0",
     "restrict_scopes",
     "Vmod_vmod_restrict_scopes_Func",
-    "914e0ff7ce24091c035bd84a2876f3cb5dcddf49fcecc8d25a9424e194391ee3",
+    "776ba51c758eea75219a10903fd4c86c6b8d9d9ac226d6c856ced2dbff5bf420",
     "Varnish (version) (hash)",
     "0",
     "0"

--- a/varnish/snapshots9.0.0/restrict_restrict_scopes@model.snap
+++ b/varnish/snapshots9.0.0/restrict_restrict_scopes@model.snap
@@ -12,7 +12,7 @@ VmodInfo {
             func_type: Function,
             ident: "client_only",
             vcl_name: None,
-            docs: "",
+            docs: "Only callable from client-side VCL subroutines.",
             has_optional_args: false,
             args: [],
             output_ty: ParamType(

--- a/varnish/snapshotstrunk/docs_types@docs.snap
+++ b/varnish/snapshotstrunk/docs_types@docs.snap
@@ -66,7 +66,7 @@ doctest for `DocStruct` implementation
 
 doctest for `new`
 
-* `[INT cap]`:
+* `INT cap` (optional):
 doc comment for `cap`
 
 ### Method `VOID <object>.function(STRING key)`

--- a/varnish/snapshotstrunk/function_types@code.snap
+++ b/varnish/snapshotstrunk/function_types@code.snap
@@ -987,7 +987,7 @@ mod types {
         pub static Vmod_types_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
-            file_id: c"90968e517039f4c73943ba74b5f3c2e8bc329a6a486d4b3d16075f7403c4f6d7"
+            file_id: c"3ea64ebb30f96cdaac904be0def6d390902a5d82d857e00203de9985f3a08d60"
                 .as_ptr(),
             name: c"types".as_ptr(),
             func_name: c"Vmod_vmod_types_Func".as_ptr(),

--- a/varnish/snapshotstrunk/function_types@docs.snap
+++ b/varnish/snapshotstrunk/function_types@docs.snap
@@ -36,6 +36,9 @@ import types from "path/to/libtypes.so";
 
 ### Function `VOID types.type_bool_dflt(BOOL _v = 1)`
 
+* `BOOL _v` (optional, default: `1`):
+Flag with a default value.
+
 ### Function `VOID types.opt_bool([BOOL _v])`
 
 ### Function `BOOL types.to_bool()`
@@ -105,6 +108,9 @@ import types from "path/to/libtypes.so";
 ### Function `VOID types.opt_str_req(STRING _v)`
 
 ### Function `VOID types.type_str_dflt(STRING _v = "baz")`
+
+* `STRING _v` (optional, default: `"baz"`):
+String with a default value.
 
 ### Function `VOID types.opt_str_dflt([STRING _v] = "baz")`
 

--- a/varnish/snapshotstrunk/function_types@json.snap
+++ b/varnish/snapshotstrunk/function_types@json.snap
@@ -8,7 +8,7 @@ VMOD_JSON_SPEC
     "2.0",
     "types",
     "Vmod_vmod_types_Func",
-    "90968e517039f4c73943ba74b5f3c2e8bc329a6a486d4b3d16075f7403c4f6d7",
+    "3ea64ebb30f96cdaac904be0def6d390902a5d82d857e00203de9985f3a08d60",
     "Varnish (version) (hash)",
     "0",
     "0"

--- a/varnish/snapshotstrunk/function_types@model.snap
+++ b/varnish/snapshotstrunk/function_types@model.snap
@@ -130,7 +130,7 @@ VmodInfo {
             args: [
                 ParamTypeInfo {
                     ident: "_v",
-                    docs: "",
+                    docs: "Flag with a default value.",
                     ty: Value(
                         ParamInfo {
                             kind: Regular,
@@ -805,7 +805,7 @@ VmodInfo {
             args: [
                 ParamTypeInfo {
                     ident: "_v",
-                    docs: "",
+                    docs: "String with a default value.",
                     ty: Value(
                         ParamInfo {
                             kind: Regular,

--- a/varnish/snapshotstrunk/restrict_restrict_scopes@code.snap
+++ b/varnish/snapshotstrunk/restrict_restrict_scopes@code.snap
@@ -191,7 +191,7 @@ mod restrict_scopes {
         pub static Vmod_restrict_scopes_Data: vmod_data = vmod_data {
             vrt_major: 0,
             vrt_minor: 0,
-            file_id: c"914e0ff7ce24091c035bd84a2876f3cb5dcddf49fcecc8d25a9424e194391ee3"
+            file_id: c"776ba51c758eea75219a10903fd4c86c6b8d9d9ac226d6c856ced2dbff5bf420"
                 .as_ptr(),
             name: c"restrict_scopes".as_ptr(),
             func_name: c"Vmod_vmod_restrict_scopes_Func".as_ptr(),
@@ -205,6 +205,7 @@ mod restrict_scopes {
         };
         const JSON: &CStr = c"(moved to @json.snap files)";
     }
+    /// Only callable from client-side VCL subroutines.
     pub fn client_only() -> i64 {
         1
     }

--- a/varnish/snapshotstrunk/restrict_restrict_scopes@docs.snap
+++ b/varnish/snapshotstrunk/restrict_restrict_scopes@docs.snap
@@ -22,14 +22,30 @@ import restrict_scopes from "path/to/librestrict_scopes.so";
 
 ### Function `INT restrict_scopes.client_only()`
 
+**Restricted to:** `client`
+
+Only callable from client-side VCL subroutines.
+
 ### Function `INT restrict_scopes.backend_only()`
+
+**Restricted to:** `backend`
 
 ### Function `INT restrict_scopes.housekeeping_only()`
 
+**Restricted to:** `housekeeping`
+
 ### Function `INT restrict_scopes.client_or_backend()`
+
+**Restricted to:** `client`, `backend`
 
 ### Function `INT restrict_scopes.recv_only()`
 
+**Restricted to:** `vcl_recv`
+
 ### Function `INT restrict_scopes.recv_or_hash()`
 
+**Restricted to:** `vcl_recv`, `vcl_hash`
+
 ### Function `INT restrict_scopes.backend_subs()`
+
+**Restricted to:** `vcl_backend_fetch`, `vcl_backend_response`, `vcl_backend_error`

--- a/varnish/snapshotstrunk/restrict_restrict_scopes@json.snap
+++ b/varnish/snapshotstrunk/restrict_restrict_scopes@json.snap
@@ -8,7 +8,7 @@ VMOD_JSON_SPEC
     "2.0",
     "restrict_scopes",
     "Vmod_vmod_restrict_scopes_Func",
-    "914e0ff7ce24091c035bd84a2876f3cb5dcddf49fcecc8d25a9424e194391ee3",
+    "776ba51c758eea75219a10903fd4c86c6b8d9d9ac226d6c856ced2dbff5bf420",
     "Varnish (version) (hash)",
     "0",
     "0"

--- a/varnish/snapshotstrunk/restrict_restrict_scopes@model.snap
+++ b/varnish/snapshotstrunk/restrict_restrict_scopes@model.snap
@@ -12,7 +12,7 @@ VmodInfo {
             func_type: Function,
             ident: "client_only",
             vcl_name: None,
-            docs: "",
+            docs: "Only callable from client-side VCL subroutines.",
             has_optional_args: false,
             args: [],
             output_ty: ParamType(

--- a/varnish/tests/pass/function.rs
+++ b/varnish/tests/pass/function.rs
@@ -32,7 +32,12 @@ mod types {
 
     // bool
     pub fn type_bool(_v: bool) {}
-    pub fn type_bool_dflt(#[default(true)] _v: bool) {}
+    pub fn type_bool_dflt(
+        /// Flag with a default value.
+        #[default(true)]
+        _v: bool,
+    ) {
+    }
     pub fn opt_bool(_v: Option<bool>) {}
     pub fn to_bool() -> bool {
         false
@@ -105,7 +110,12 @@ mod types {
     pub fn type_str(_v: &str) {}
     pub fn opt_str(_v: Option<&str>) {}
     pub fn opt_str_req(#[required] _v: Option<&str>) {}
-    pub fn type_str_dflt(#[default("baz")] _v: &str) {}
+    pub fn type_str_dflt(
+        /// String with a default value.
+        #[default("baz")]
+        _v: &str,
+    ) {
+    }
     pub fn opt_str_dflt(#[default("baz")] _v: Option<&str>) {}
     pub fn to_str() -> &'static str {
         ""

--- a/varnish/tests/pass/restrict.rs
+++ b/varnish/tests/pass/restrict.rs
@@ -4,6 +4,7 @@ fn main() {}
 
 #[vmod]
 mod restrict_scopes {
+    /// Only callable from client-side VCL subroutines.
     #[restrict(client)]
     pub fn client_only() -> i64 {
         1


### PR DESCRIPTION
## Summary
- `#[restrict(scope, ...)]`-decorated functions now get a `**Restricted to:** \`scope\`, ...` note in the generated docs (`#[vmod(docs = "...")]`) — previously the scope info was silently dropped, only surfacing in the runtime VCL-fail error message.
- Optional-argument bullets in generated docs now read `` `TYPE name` (optional): `` instead of `` `[TYPE name]`: `` — brackets aren't valid VCL call syntax outside the signature line.
- Defaulted-argument bullets now read `` `TYPE name` (optional, default: `val`): `` instead of just `(optional)` / nothing.

## Test plan
- [x] `cargo check -p varnish-macros`
- [x] Added doc comments to `type_bool_dflt`/`type_str_dflt` in `varnish/tests/pass/function.rs`, and to `client_only()` in `varnish/tests/pass/restrict.rs`, to exercise these paths
- [x] Blessed snapshots for Varnish 8.0.0/9.0.0/trunk (`cargo insta accept`)
- [x] Regenerated `examples/vmod_restricted_callsites/README.md`, `examples/vmod_example/README.md`, `examples/vmod_native_backend/README.md` to confirm real-world rendering